### PR TITLE
feat: 아티스트 및 아티스트 신청 도메인 엔티티 추가

### DIFF
--- a/src/main/java/com/fivefy/domain/artist/entity/Artist.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/Artist.java
@@ -1,0 +1,62 @@
+package com.fivefy.domain.artist.entity;
+
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.domain.artist.enums.ArtistStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "artists")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Artist extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "owner_user_id", nullable = false)
+    private Long ownerUserId;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "bio", columnDefinition = "TEXT")
+    private String bio;
+
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ArtistStatus status;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public static Artist create(
+            Long ownerUserId,
+            String name,
+            String bio,
+            String profileImageUrl
+    ) {
+        Artist artist = new Artist();
+
+        artist.ownerUserId = ownerUserId;
+        artist.name = name;
+        artist.bio = bio;
+        artist.profileImageUrl = profileImageUrl;
+        artist.status = ArtistStatus.ACTIVE;
+
+        return artist;
+    }
+}

--- a/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
@@ -1,0 +1,68 @@
+package com.fivefy.domain.artist.entity;
+
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.domain.artist.enums.ApplicationStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "artist_applications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArtistApplication extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requester_user_id", nullable = false)
+    private Long requesterUserId;
+
+    @Column(name = "requested_name", nullable = false, length = 100)
+    private String requestedName;
+
+    @Column(name = "bio", columnDefinition = "TEXT")
+    private String bio;
+
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ApplicationStatus status;
+
+    @Column(name = "reviewed_by_admin_id")
+    private Long reviewedByAdminId;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    @Column(name = "rejection_reason", length = 255)
+    private String rejectionReason;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static ArtistApplication create(
+            Long requesterUserId,
+            String requestedName,
+            String bio,
+            String profileImageUrl
+    ) {
+        ArtistApplication application = new ArtistApplication();
+
+        application.requesterUserId = requesterUserId;
+        application.requestedName = requestedName;
+        application.bio = bio;
+        application.profileImageUrl = profileImageUrl;
+        application.status = ApplicationStatus.PENDING;
+
+        return application;
+    }
+}

--- a/src/main/java/com/fivefy/domain/artist/enums/ApplicationStatus.java
+++ b/src/main/java/com/fivefy/domain/artist/enums/ApplicationStatus.java
@@ -1,0 +1,7 @@
+package com.fivefy.domain.artist.enums;
+
+public enum ApplicationStatus {
+    PENDING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/fivefy/domain/artist/enums/ArtistStatus.java
+++ b/src/main/java/com/fivefy/domain/artist/enums/ArtistStatus.java
@@ -1,0 +1,6 @@
+package com.fivefy.domain.artist.enums;
+
+public enum ArtistStatus {
+    ACTIVE,
+    SUSPENDED
+}


### PR DESCRIPTION
## 개요
아티스트 도메인 모델링 및 등록 신청 흐름을 분리하여 설계
아티스트 생성은 직접 생성이 아닌 신청 → 승인 → 생성 구조로 제한되도록 도메인 규칙을 반영

## 변경 사항
+ Artist 엔티티 추가
  + 대표 아티스트 단일 소유 정책 (ownerUserId 기반)
  + 상태 관리 필드 추가 (ACTIVE, SUSPENDED)
+ ArtistApplication 엔티티 추가
  + 아티스트 등록 신청 흐름 분리
  + 신청 상태 관리 (PENDING, APPROVED, REJECTED)
+ 아티스트 생성 프로세스 설계
  + 신청 승인 시에만 Artist 생성 가능하도록 구조 정의

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 아티스트 프로필 기능이 추가되었습니다. 아티스트는 이제 프로필 정보, 소개글, 프로필 이미지 등을 관리할 수 있습니다.
* 아티스트 신청 및 승인 프로세스가 구현되었습니다. 사용자가 아티스트로 등록할 수 있으며, 관리자가 이를 검토하고 승인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->