### PR TITLE
feat: Playback 엔티티 및 관련 Enum 추가

### DIFF
--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -1,0 +1,56 @@
+package com.fivefy.domain.playback.entity;
+
+import com.fivefy.domain.playback.enums.PlaybackStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "playbacks")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Playback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long trackId;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 255)
+    private String sessionId;
+
+    @Column(length = 100)
+    private String deviceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PlaybackStatus status;
+
+    @Column(nullable = false)
+    private Integer playedDuration;
+
+    @Column(nullable = false)
+    private LocalDateTime playedAt;
+
+    public static Playback create(Long trackId, Long userId, String sessionId, String deviceId) {
+        Playback playback = new Playback();
+        playback.trackId = trackId;
+        playback.userId = userId;
+        playback.sessionId = sessionId;
+        playback.deviceId = deviceId;
+
+        playback.status = PlaybackStatus.START;
+        playback.playedDuration = 0;
+        playback.playedAt = LocalDateTime.now();
+
+        return playback;
+    }
+}

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -36,13 +36,15 @@ public class Playback {
     private PlaybackStatus status;
 
     @Column(nullable = false)
-    private int playedDuration;
+    private Integer playedDuration;
 
     @Column(nullable = false)
     private LocalDateTime playedAt;
 
     public static Playback create(Long trackId, Long userId, String sessionId, String deviceId) {
-        validateNonNull(trackId, userId, sessionId);
+        validateNotNull(trackId, "trackId");
+        validateNotNull(userId, "userId");
+        validateNotNull(sessionId, "sessionId");
 
         Playback playback = new Playback();
         playback.trackId = trackId;
@@ -57,15 +59,7 @@ public class Playback {
         return playback;
     }
 
-    private static void validateNonNull(Long trackId, Long userId, String sessionId) {
-        if (trackId == null) {
-            throw new IllegalArgumentException("trackId는 필수입니다");
-        }
-        if (userId == null) {
-            throw new IllegalArgumentException("userId는 필수입니다");
-        }
-        if (sessionId == null) {
-            throw new IllegalArgumentException("sessionId는 필수입니다");
-        }
+    private static void validateNotNull(Object value, String fieldName) {
+        Objects.requireNonNull(value, fieldName + "는 필수입니다. (validationNotNull)");
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -35,7 +35,7 @@ public class Playback {
     private PlaybackStatus status;
 
     @Column(nullable = false)
-    private Integer playedDuration;
+    private int playedDuration;
 
     @Column(nullable = false)
     private LocalDateTime playedAt;

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -41,6 +42,8 @@ public class Playback {
     private LocalDateTime playedAt;
 
     public static Playback create(Long trackId, Long userId, String sessionId, String deviceId) {
+        validateNonNull(trackId, userId, sessionId);
+
         Playback playback = new Playback();
         playback.trackId = trackId;
         playback.userId = userId;
@@ -52,5 +55,17 @@ public class Playback {
         playback.playedAt = LocalDateTime.now();
 
         return playback;
+    }
+
+    private static void validateNonNull(Long trackId, Long userId, String sessionId) {
+        if (trackId == null) {
+            throw new IllegalArgumentException("trackId는 필수입니다");
+        }
+        if (userId == null) {
+            throw new IllegalArgumentException("userId는 필수입니다");
+        }
+        if (sessionId == null) {
+            throw new IllegalArgumentException("sessionId는 필수입니다");
+        }
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.playback.entity;
 
+import com.fivefy.common.util.ValidationUtils;
 import com.fivefy.domain.playback.enums.PlaybackStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -7,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @Getter
 @Entity
@@ -42,9 +42,9 @@ public class Playback {
     private LocalDateTime playedAt;
 
     public static Playback create(Long trackId, Long userId, String sessionId, String deviceId) {
-        validateNotNull(trackId, "trackId");
-        validateNotNull(userId, "userId");
-        validateNotNull(sessionId, "sessionId");
+        ValidationUtils.validateNonNull(trackId, "trackId");
+        ValidationUtils.validateNonNull(userId, "userId");
+        ValidationUtils.validateNonNull(sessionId, "sessionId");
 
         Playback playback = new Playback();
         playback.trackId = trackId;
@@ -57,9 +57,5 @@ public class Playback {
         playback.playedAt = LocalDateTime.now();
 
         return playback;
-    }
-
-    private static void validateNotNull(Object value, String fieldName) {
-        Objects.requireNonNull(value, fieldName + "는 필수입니다. (validationNotNull)");
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/enums/PlaybackStatus.java
+++ b/src/main/java/com/fivefy/domain/playback/enums/PlaybackStatus.java
@@ -1,0 +1,10 @@
+package com.fivefy.domain.playback.enums;
+
+public enum PlaybackStatus {
+
+    START,    // 재생
+    PAUSE,    // 일시 정지
+    COMPLETE, // 완료
+    STOP,     // 중단
+    SKIP      // 건너뛰기
+}


### PR DESCRIPTION
## 개요

> Playback 엔티티와 그에 관련된 Enum (PlaybackStatus) 추가

## 변경 사항

- Playback 엔티티 생성 및 정적 메서드 create 추가
- PlaybackStatus Enum 추가 (START, PAUSE, COMPLETE, STOP, SKIP)

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 재생 상태 추적 기능 추가: 트랙·사용자·세션·디바이스 정보를 바탕으로 재생 활동을 기록하고 모니터링할 수 있습니다. 지원 상태: START, PAUSE, COMPLETE, STOP, SKIP.
  * 재생 기록 생성 시 초기값 자동 설정: 새 기록은 생성 시 상태가 START로 설정되고 재생 지속시간은 0으로 초기화되며, 생성 시각이 함께 저장되어 분석·통계에 즉시 활용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->