### PR TITLE
feat: 음악 콘텐츠(앨범/트랙) 발매 요청 흐름 및 도메인 설계

### DIFF
--- a/src/main/java/com/fivefy/common/enums/ApplicationStatus.java
+++ b/src/main/java/com/fivefy/common/enums/ApplicationStatus.java
@@ -1,4 +1,4 @@
-package com.fivefy.domain.artist.enums;
+package com.fivefy.common.enums;
 
 public enum ApplicationStatus {
     PENDING,

--- a/src/main/java/com/fivefy/domain/album/entity/Album.java
+++ b/src/main/java/com/fivefy/domain/album/entity/Album.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -66,6 +67,10 @@ public class Album extends BaseEntity {
             LocalDateTime releaseAt,
             LocalDateTime scheduledPublishAt
     ) {
+        validateNonNull(artistId, "artistId");
+        validateNonNull(title, "title");
+        validateNonNull(releaseAt, "releaseAt");
+
         Album album = new Album();
 
         album.artistId = artistId;

--- a/src/main/java/com/fivefy/domain/album/entity/Album.java
+++ b/src/main/java/com/fivefy/domain/album/entity/Album.java
@@ -1,0 +1,83 @@
+package com.fivefy.domain.album.entity;
+
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.domain.album.enums.AlbumStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "albums")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Album extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "artist_id", nullable = false)
+    private Long artistId;
+
+    @Column(name = "title", nullable = false, length = 150)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "cover_image_url", length = 255)
+    private String coverImageUrl;
+
+    @Column(name = "release_at", nullable = false)
+    private LocalDateTime releaseAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private AlbumStatus status;
+
+    @Column(name = "scheduled_publish_at")
+    private LocalDateTime scheduledPublishAt;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "track_count", nullable = false)
+    private Long trackCount;
+
+    @Column(name = "total_duration_sec", nullable = false)
+    private Long totalDurationSec;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public static Album create(
+            Long artistId,
+            String title,
+            String description,
+            String coverImageUrl,
+            LocalDateTime releaseAt,
+            LocalDateTime scheduledPublishAt
+    ) {
+        Album album = new Album();
+
+        album.artistId = artistId;
+        album.title = title;
+        album.description = description;
+        album.coverImageUrl = coverImageUrl;
+        album.releaseAt = releaseAt;
+        album.scheduledPublishAt = scheduledPublishAt;
+        album.status = AlbumStatus.UNPUBLISHED;
+        album.trackCount = 0L;
+        album.totalDurationSec = 0L;
+
+        return album;
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
@@ -1,7 +1,7 @@
 package com.fivefy.domain.album.entity;
 
 import com.fivefy.common.entity.BaseEntity;
-import com.fivefy.domain.artist.enums.ApplicationStatus;
+import com.fivefy.common.enums.ApplicationStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @Getter
 @Entity

--- a/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
@@ -1,0 +1,83 @@
+package com.fivefy.domain.album.entity;
+
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.domain.artist.enums.ApplicationStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "album_release_requests")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlbumReleaseRequest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requester_user_id", nullable = false)
+    private Long requesterUserId;
+
+    @Column(name = "artist_id", nullable = false)
+    private Long artistId;
+
+    @Column(name = "title", nullable = false, length = 150)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "cover_image_url", length = 255)
+    private String coverImageUrl;
+
+    @Column(name = "release_at", nullable = false)
+    private LocalDateTime releaseAt;
+
+    @Column(name = "scheduled_publish_at")
+    private LocalDateTime scheduledPublishAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ApplicationStatus status;
+
+    @Column(name = "reviewed_by_admin_id")
+    private Long reviewedByAdminId;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    @Column(name = "rejection_reason", length = 255)
+    private String rejectionReason;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static AlbumReleaseRequest create(
+            Long requesterUserId,
+            Long artistId,
+            String title,
+            String description,
+            String coverImageUrl,
+            LocalDateTime releaseAt,
+            LocalDateTime scheduledPublishAt
+    ) {
+        AlbumReleaseRequest request = new AlbumReleaseRequest();
+
+        request.requesterUserId = requesterUserId;
+        request.artistId = artistId;
+        request.title = title;
+        request.description = description;
+        request.coverImageUrl = coverImageUrl;
+        request.releaseAt = releaseAt;
+        request.scheduledPublishAt = scheduledPublishAt;
+        request.status = ApplicationStatus.PENDING;
+
+        return request;
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -67,6 +68,11 @@ public class AlbumReleaseRequest extends BaseEntity {
             LocalDateTime releaseAt,
             LocalDateTime scheduledPublishAt
     ) {
+        validateNonNull(requesterUserId, "requesterUserId");
+        validateNonNull(artistId, "artistId");
+        validateNonNull(title, "title");
+        validateNonNull(releaseAt, "releaseAt");
+
         AlbumReleaseRequest request = new AlbumReleaseRequest();
 
         request.requesterUserId = requesterUserId;

--- a/src/main/java/com/fivefy/domain/album/enums/AlbumStatus.java
+++ b/src/main/java/com/fivefy/domain/album/enums/AlbumStatus.java
@@ -1,0 +1,7 @@
+package com.fivefy.domain.album.enums;
+
+public enum AlbumStatus {
+    UNPUBLISHED,
+    PUBLISHED,
+    BLOCKED
+}

--- a/src/main/java/com/fivefy/domain/artist/entity/Artist.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/Artist.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -49,6 +50,9 @@ public class Artist extends BaseEntity {
             String bio,
             String profileImageUrl
     ) {
+        validateNonNull(ownerUserId, "ownerUserId");
+        validateNonNull(name, "name");
+
         Artist artist = new Artist();
 
         artist.ownerUserId = ownerUserId;

--- a/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
@@ -1,7 +1,7 @@
 package com.fivefy.domain.artist.entity;
 
 import com.fivefy.common.entity.BaseEntity;
-import com.fivefy.domain.artist.enums.ApplicationStatus;
+import com.fivefy.common.enums.ApplicationStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
 
 @Getter
 @Entity

--- a/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -55,6 +56,9 @@ public class ArtistApplication extends BaseEntity {
             String bio,
             String profileImageUrl
     ) {
+        validateNonNull(requesterUserId, "requesterUserId");
+        validateNonNull(requestedName, "requestedName");
+
         ArtistApplication application = new ArtistApplication();
 
         application.requesterUserId = requesterUserId;

--- a/src/main/java/com/fivefy/domain/track/entity/TrackReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackReleaseRequest.java
@@ -1,0 +1,117 @@
+package com.fivefy.domain.track.entity;
+
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.enums.TrackType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "track_release_requests")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrackReleaseRequest extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "requester_user_id", nullable = false)
+    private Long requesterUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "track_type", nullable = false, length = 30)
+    private TrackType trackType;
+
+    @Column(name = "artist_id")
+    private Long artistId;
+
+    @Column(name = "album_id")
+    private Long albumId;
+
+    @Column(name = "track_number")
+    private Long trackNumber;
+
+    @Column(name = "title", nullable = false, length = 150)
+    private String title;
+
+    @Column(name = "lyrics", columnDefinition = "TEXT")
+    private String lyrics;
+
+    @Column(name = "genre", nullable = false, length = 100)
+    private String genre;
+
+    @Column(name = "audio_url", nullable = false, length = 255)
+    private String audioUrl;
+
+    @Column(name = "duration_sec", nullable = false)
+    private Long durationSec;
+
+    @Column(name = "featured_artist_text", length = 255)
+    private String featuredArtistText;
+
+    @Column(name = "scheduled_publish_at")
+    private LocalDateTime scheduledPublishAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ApplicationStatus status;
+
+    @Column(name = "reviewed_by_admin_id")
+    private Long reviewedByAdminId;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    @Column(name = "rejection_reason", length = 255)
+    private String rejectionReason;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static TrackReleaseRequest create(
+            Long requesterUserId,
+            TrackType trackType,
+            Long artistId,
+            Long albumId,
+            Long trackNumber,
+            String title,
+            String lyrics,
+            String genre,
+            String audioUrl,
+            Long durationSec,
+            String featuredArtistText,
+            LocalDateTime scheduledPublishAt
+    ) {
+        validateNonNull(requesterUserId, "requesterUserId");
+        validateNonNull(trackType, "trackType");
+        validateNonNull(title, "title");
+        validateNonNull(genre, "genre");
+        validateNonNull(audioUrl, "audioUrl");
+        validateNonNull(durationSec, "durationSec");
+
+        TrackReleaseRequest request = new TrackReleaseRequest();
+
+        request.requesterUserId = requesterUserId;
+        request.trackType = trackType;
+        request.artistId = artistId;
+        request.albumId = albumId;
+        request.trackNumber = trackNumber;
+        request.title = title;
+        request.lyrics = lyrics;
+        request.genre = genre;
+        request.audioUrl = audioUrl;
+        request.durationSec = durationSec;
+        request.featuredArtistText = featuredArtistText;
+        request.scheduledPublishAt = scheduledPublishAt;
+        request.status = ApplicationStatus.PENDING;
+
+        return request;
+    }
+}


### PR DESCRIPTION
## 개요
음악 콘텐츠(앨범, 트랙)의 발매 프로세스를
요청 → 승인 → 공개 구조로 통합 설계

또한 아티스트/앨범/트랙 전반에 걸쳐
신청 상태 관리와 도메인 생성 시 검증 로직을 강화

## 변경 사항
1. 앨범 도메인 추가
	•	Album 엔티티 추가
	•	아티스트 소유 구조
	•	상태 관리 (UNPUBLISHED, PUBLISHED, BLOCKED)
	•	AlbumReleaseRequest 엔티티 추가
	•	앨범 발매 요청/승인 흐름 분리
	•	신청 상태 기반 관리 (PENDING, APPROVED, REJECTED)
	•	발매 프로세스 설계
	•	요청 → 승인 → 공개 구조로 모델링

2. 트랙 발매 요청 도메인 추가
	•	TrackReleaseRequest 엔티티 추가
	•	트랙 발매 요청 및 검수 흐름 관리
	•	예약 공개 시점, 리뷰 정보 필드 포함
	•	생성 시 필수값 검증 로직 추가

3. 공통 신청 상태 구조 개선
	•	ApplicationStatus를 common 패키지로 분리
	•	ArtistApplication, AlbumReleaseRequest, TrackReleaseRequest에서 공통 사용

4. 도메인 생성 검증 강화 (refactor)
	•	Artist, ArtistApplication 생성 시 null 검증 추가
	•	Album, AlbumReleaseRequest 생성 시 null 검증 추가
	•	create() 단계에서 잘못된 도메인 객체 생성 방지
	•	식별자 및 주요 필드 validation 강화

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앨범 출시 요청 워크플로우 추가
  * 트랙 출시 요청 워크플로우 추가
  * 앨범 상태 관리 기능 추가 (미발행, 발행, 차단)

* **버그 수정**
  * 아티스트 및 아티스트 신청 생성 시 필수 입력값 검증 강화

* **리팩터**
  * 공용 상태 관리 시스템 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->