### PR TITLE
feat: Track 엔티티 및 관련 Enum 추가

### DIFF
--- a/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
+++ b/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
@@ -1,7 +1,7 @@
 package com.fivefy.domain.playlist.entity;
 
 import com.fivefy.common.entity.BaseEntity;
-import com.fivefy.common.util.ValidationUtils;
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,8 +34,8 @@ public class Playlist extends BaseEntity {
     private LocalDateTime deletedAt;
 
     public static Playlist create(Long userId, String title, String description) {
-        ValidationUtils.validateNonNull(userId, "userId");
-        ValidationUtils.validateNonNull(title, "title");
+        validateNonNull(userId, "userId");
+        validateNonNull(title, "title");
 
         Playlist playlist = new Playlist();
         playlist.userId = userId;

--- a/src/main/java/com/fivefy/domain/popularchart/entity/PopularChart.java
+++ b/src/main/java/com/fivefy/domain/popularchart/entity/PopularChart.java
@@ -1,6 +1,6 @@
 package com.fivefy.domain.popularchart.entity;
 
-import com.fivefy.common.util.ValidationUtils;
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -36,10 +36,10 @@ public class PopularChart {
     private LocalDateTime snapshotDate;
 
     public static PopularChart create(Long trackId, Integer rank, Long playCount, LocalDateTime snapshotDate) {
-        ValidationUtils.validateNonNull(trackId, "trackId");
-        ValidationUtils.validateNonNull(rank, "rank");
-        ValidationUtils.validateNonNull(playCount, "playCount");
-        ValidationUtils.validateNonNull(snapshotDate, "snapshotDate");
+        validateNonNull(trackId, "trackId");
+        validateNonNull(rank, "rank");
+        validateNonNull(playCount, "playCount");
+        validateNonNull(snapshotDate, "snapshotDate");
 
         PopularChart chart = new PopularChart();
         chart.trackId = trackId;

--- a/src/main/java/com/fivefy/domain/track/entity/Track.java
+++ b/src/main/java/com/fivefy/domain/track/entity/Track.java
@@ -1,0 +1,93 @@
+package com.fivefy.domain.track.entity;
+
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.common.util.ValidationUtils;
+import com.fivefy.domain.track.enums.TrackStatus;
+import com.fivefy.domain.track.enums.TrackType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "tracks")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Track extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long ownerUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TrackType trackType;
+
+    private Long artistId;
+
+    private Long albumId;
+
+    private Long trackNumber;
+
+    @Column(nullable = false, length = 150)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String lyrics;
+
+    @Column(nullable = false, length = 100)
+    private String genre;
+
+    @Column(nullable = false, length = 255)
+    private String audioUrl;
+
+    @Column(nullable = false)
+    private Long durationSec;
+
+    @Column(length = 255)
+    private String featuredArtistText;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TrackStatus status;
+
+    private LocalDateTime scheduledPublishAt;
+
+    private LocalDateTime publishedAt;
+
+    @Column(nullable = false)
+    private Long playCount;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    public static Track create(Long ownerUserId, TrackType trackType, String title, String genre, String audioUrl, Long durationSec) {
+        ValidationUtils.validateNonNull(ownerUserId, "ownerUserId");
+        ValidationUtils.validateNonNull(trackType, "trackType");
+        ValidationUtils.validateNonNull(title, "title");
+        ValidationUtils.validateNonNull(genre, "genre");
+        ValidationUtils.validateNonNull(audioUrl, "audioUrl");
+        ValidationUtils.validateNonNull(durationSec, "durationSec");
+
+        Track track = new Track();
+        track.ownerUserId = ownerUserId;
+        track.trackType = trackType;
+        track.title = title;
+        track.genre = genre;
+        track.audioUrl = audioUrl;
+        track.durationSec = durationSec;
+
+        track.status = TrackStatus.UNPUBLISHED;
+        track.playCount = 0L;
+
+        return track;
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/entity/Track.java
+++ b/src/main/java/com/fivefy/domain/track/entity/Track.java
@@ -1,7 +1,7 @@
 package com.fivefy.domain.track.entity;
 
 import com.fivefy.common.entity.BaseEntity;
-import com.fivefy.common.util.ValidationUtils;
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
 import jakarta.persistence.*;
@@ -70,12 +70,12 @@ public class Track extends BaseEntity {
     private LocalDateTime deletedAt;
 
     public static Track create(Long ownerUserId, TrackType trackType, String title, String genre, String audioUrl, Long durationSec) {
-        ValidationUtils.validateNonNull(ownerUserId, "ownerUserId");
-        ValidationUtils.validateNonNull(trackType, "trackType");
-        ValidationUtils.validateNonNull(title, "title");
-        ValidationUtils.validateNonNull(genre, "genre");
-        ValidationUtils.validateNonNull(audioUrl, "audioUrl");
-        ValidationUtils.validateNonNull(durationSec, "durationSec");
+        validateNonNull(ownerUserId, "ownerUserId");
+        validateNonNull(trackType, "trackType");
+        validateNonNull(title, "title");
+        validateNonNull(genre, "genre");
+        validateNonNull(audioUrl, "audioUrl");
+        validateNonNull(durationSec, "durationSec");
 
         Track track = new Track();
         track.ownerUserId = ownerUserId;

--- a/src/main/java/com/fivefy/domain/track/enums/TrackStatus.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackStatus.java
@@ -1,0 +1,8 @@
+package com.fivefy.domain.track.enums;
+
+public enum TrackStatus {
+
+    PUBLISHED,   // 공개됨
+    UNPUBLISHED, // 비공개
+    BLOCKED      // 차단됨
+}

--- a/src/main/java/com/fivefy/domain/track/enums/TrackType.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackType.java
@@ -1,0 +1,7 @@
+package com.fivefy.domain.track.enums;
+
+public enum TrackType {
+
+    FREE_CREATION,   // 자유 창작
+    OFFICIAL_RELEASE // 정식 발매
+}


### PR DESCRIPTION
## 개요

> Track 엔티티와 그에 관련된 Enum (TrackType, TrackStatus) 추가

## 변경 사항

- Track 엔티티 생성 및 정적 메서드 create 추가
- TrackType Enum 추가 (FREE_CREATION, OFFICIAL_RELEASE)
- TrackStatus Enum 추가 (PUBLISHED, UNPUBLISHED, BLOCKED)
- 필수값에 대한 null 검증 로직 적용

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 음악 트랙 관리용 엔티티 추가 — 트랙 정보(제목, 장르, 오디오 URL, 길이 등), 소유자, 상태 및 재생수 관리
  * 트랙 상태 추가: 발행됨, 미발행, 차단됨
  * 트랙 타입 추가: 자유 창작, 정식 발매

* **Refactor**
  * 일부 생성 로직의 입력 유효성 검사 호출 방식 정리 (동작 변경 없음)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->