### PR TITLE
refactor: null 검증 로직을 ValidationUtils로 공통화

### DIFF
--- a/src/main/java/com/fivefy/domain/album/entity/Album.java
+++ b/src/main/java/com/fivefy/domain/album/entity/Album.java
@@ -11,6 +11,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
+
 @Getter
 @Entity
 @Table(name = "albums")

--- a/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
@@ -10,6 +10,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
+
 @Getter
 @Entity
 @Table(name = "album_release_requests")

--- a/src/main/java/com/fivefy/domain/artist/entity/Artist.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/Artist.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
-import java.util.Objects;
+
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity

--- a/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
@@ -10,6 +10,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
+
 @Getter
 @Entity
 @Table(name = "artist_applications")

--- a/src/main/java/com/fivefy/domain/track/entity/TrackReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackReleaseRequest.java
@@ -11,6 +11,8 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
+
 @Getter
 @Entity
 @Table(name = "track_release_requests")


### PR DESCRIPTION
## 개요
도메인 엔티티 전반에 흩어져 있던 null 검증 로직을
ValidationUtils로 공통화하여 중복을 제거하고 일관성을 확보

## 변경 사항

	•	null 검증 로직 공통화
	•	ValidationUtils.validateNonNull로 통일
	•	각 도메인 엔티티 수정
	•	기존 개별 검증 로직 제거
	•	공통 유틸 호출 방식으로 변경
	•	코드 가독성 개선
	•	static import 적용으로 검증 코드 간결화
	•	재사용성 향상
	•	동일 검증 로직을 여러 도메인에서 일관되게 사용 가능

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Refactor**
  * 도메인 엔티티에서 입력 유효성 검증 로직을 표준화하여 코드 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->