### PR TITLE
feat: like entity 생성 및 관련 enum추가

### DIFF
--- a/src/main/java/com/fivefy/domain/like/entity/Like.java
+++ b/src/main/java/com/fivefy/domain/like/entity/Like.java
@@ -1,0 +1,50 @@
+package com.fivefy.domain.like.entity;
+
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.domain.like.enums.TargetType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "likes",
+        indexes = {
+                @Index(name = "idx_likes_user_id", columnList = "user_id") //
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "target_id", "target_type"})
+        }
+)
+@NoArgsConstructor (access = AccessLevel.PROTECTED)
+public class Like extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column (nullable = false)
+    private Long userId;
+
+    @Column (nullable = false)
+    private Long targetId;
+
+    @Column (nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TargetType targetType;
+
+    public static Like create(Long userId, Long targetId, TargetType targetType) {
+        validateNonNull(userId, "userId");
+        validateNonNull(targetId, "targetId");
+        validateNonNull(targetType, "targetType");
+
+        Like like = new Like();
+        like.userId = userId;
+        like.targetId = targetId;
+        like.targetType = targetType;
+
+        return like;
+    }
+}

--- a/src/main/java/com/fivefy/domain/like/enums/TargetType.java
+++ b/src/main/java/com/fivefy/domain/like/enums/TargetType.java
@@ -1,0 +1,6 @@
+package com.fivefy.domain.like.enums;
+
+public enum TargetType {
+    TRACK,
+    ALBUM
+}


### PR DESCRIPTION
## 개요

## 변경 사항

- 정적 팩토리 메서드 create() 추가
- (userId, targetId, targetType) unique 제약 추가
- 관련 enums 추가

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 음악 콘텐츠에 대한 좋아요 기능이 추가되었습니다. 사용자는 트랙과 앨범을 즐겨찾기할 수 있으며, 각 사용자당 콘텐츠마다 하나의 좋아요만 가능하도록 설계되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->