### PR TITLE
feat: 공통 응답 추가

### DIFF
--- a/src/main/java/com/fivefy/common/dto/response/BaseResponse.java
+++ b/src/main/java/com/fivefy/common/dto/response/BaseResponse.java
@@ -1,0 +1,28 @@
+package com.fivefy.common.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.http.HttpStatus;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BaseResponse<T>(
+        boolean success,
+        HttpStatus status,
+        String message,
+        T data
+) {
+
+    // 성공 응답
+    public static <T> BaseResponse<T> success(HttpStatus status, String message, T data) {
+        return new BaseResponse<>(true, status, message, data);
+    }
+
+    // 실패 응답 - data가 null인 에러 응답
+    public static <T> BaseResponse<T> fail(HttpStatus status, String message) {
+        return new BaseResponse<>(false, status, message, null);
+    }
+
+    // 실패 응답 - validation으로 여러 오류 메세지 발생 시 data 이용하여 응답
+    public static <T> BaseResponse<T> fail(HttpStatus status, String message, T data) {
+        return new BaseResponse<>(false, status, message, data);
+    }
+}

--- a/src/main/java/com/fivefy/common/dto/response/PageResponse.java
+++ b/src/main/java/com/fivefy/common/dto/response/PageResponse.java
@@ -20,4 +20,3 @@ public record PageResponse<T>(
                 page.getTotalPages());
     }
 }
-

--- a/src/main/java/com/fivefy/common/dto/response/PageResponse.java
+++ b/src/main/java/com/fivefy/common/dto/response/PageResponse.java
@@ -1,0 +1,23 @@
+package com.fivefy.common.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages());
+    }
+}
+


### PR DESCRIPTION
## 개요

> 공통 응답 규격인 BaseResponse와 페이지 형식의 공통 응답 PageResponse 추가

## 변경 사항

- API 공통 응답 포맷을 정의하기 위해 Java Record 타입의 BaseResponse 구현
- 성공(success), 실패(fail) 처리를 위한 정적 팩토리 메서드 제공
- Spring Data JPA의 Page 객체를 공통 응답 규격으로 변환하기 위한 record 구현
- 컨텐츠 리스트, 현재 페이지, 페이지 크기, 전체 요소 수, 전체 페이지 수 포함

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 성공/실패 상태를 포함하는 표준화된 API 응답 형식을 도입했습니다.
* Null 필드를 제외하여 더 간결한 JSON 응답을 제공합니다.
* 페이지네이션 정보(페이지, 크기, 총 요소, 총 페이지)를 지원하는 응답 모델을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->