### PR TITLE
feat : 지갑 + 포인트 + 구독 3명

### DIFF
--- a/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
+++ b/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
@@ -1,0 +1,132 @@
+package com.fivefy.common.initializer;
+
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.repository.UserRepository;
+import com.fivefy.domain.wallet.entity.Wallet;
+import com.fivefy.domain.wallet.entity.PointHistory;
+import com.fivefy.domain.wallet.enums.PointType;
+import com.fivefy.domain.wallet.enums.PointHistoryType;
+import com.fivefy.domain.wallet.repository.WalletRepository;
+import com.fivefy.domain.wallet.repository.PointHistoryRepository;
+import com.fivefy.domain.subscription.entity.Subscription;
+import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
+import com.fivefy.domain.subscription.repository.SubscriptionRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+/**
+ * 더미데이터를 생성
+ * 1. 유저
+ * 2. 지갑
+ * 3. 포인트
+ * 4. 구독
+ *
+ * 설정 파일에
+ * <pre>
+ * {@code
+ * app:
+ *   add-wallet-dummy-test-data: true
+ * }
+ * </pre>
+ *
+ * 로 설정되어 있을 경우 test 데이터를 추가해 줍니다
+ */
+@Component
+@ConditionalOnProperty(name = "app.add-wallet-dummy-test-data", havingValue = "true", matchIfMissing = false)
+@Profile("!prod")
+@RequiredArgsConstructor
+public class TestDefaultUserInitializer implements ApplicationRunner {
+
+    private final UserRepository userRepository;
+    private final WalletRepository walletRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    // 비밀번호 평문으로 사용
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (userRepository.count() > 0) {
+
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 유저 1: 월간 패키지 구독 유저(한 달)
+        initUser("test1@fivefy.com", "test1234", "테스트유저1",
+                50000L, 0L, SubscriptionPlanType.MONTH, now
+        );
+
+        // 유저 2: 연간 구독 유저(일 년)
+        initUser("test2@fivefy.com", "test1234", "테스트유저2",
+                500000L, 0L, SubscriptionPlanType.MONTH, now
+        );
+
+        // 유저 3: 무료 유저(삼 일)
+        initUser("test3@fivefy.com", "test1234", "테스트유저3",
+                0L, 5000L, SubscriptionPlanType.FREE, now
+        );
+    }
+
+    private void initUser(String email, String rawPassword, String name,
+                          Long paidAmount, Long eventAmount,
+                          SubscriptionPlanType subscriptionPlanType, LocalDateTime now
+    ) {
+        // 유저 생성
+        User user = userRepository.save(
+                User.create(email, rawPassword, name)
+        );
+
+        // 지갑 생성 + 충전
+        Wallet wallet = Wallet.create(user.getId());
+        wallet.chargeBalance(paidAmount);
+        if (eventAmount > 0) {
+            wallet.chargeEventBalance(eventAmount);
+        }
+        walletRepository.save(wallet);
+
+        // 유료 포인트 충전 이력
+        pointHistoryRepository.save(PointHistory
+                .create(wallet.getId(), PointType.PAID, PointHistoryType.USE,
+                paidAmount, paidAmount, "테스트 유료 포인트 충전"
+                )
+        );
+
+        // 이벤트 포인트 충전 이력
+        if (eventAmount > 0) {
+            pointHistoryRepository.save(PointHistory
+                    .create(wallet.getId(), PointType.FREE, PointHistoryType.USE,
+                    eventAmount, eventAmount, "테스트 이벤트 포인트 지급"
+                    )
+            );
+        }
+
+        /**
+         * 구독 생성
+         * 1 : 한 달
+         * 2 : 일 년
+         * 3 : 삼 일(무료)
+         */
+        LocalDateTime expiryDate = switch (subscriptionPlanType) {
+            case MONTH -> now.plusMonths(1);
+            case YEAR -> now.plusYears(1);
+            case FREE -> now.plusDays(3);
+        };
+        LocalDateTime nextBillingDate = null;
+        if (subscriptionPlanType != SubscriptionPlanType.FREE) {
+            nextBillingDate = expiryDate;
+        }
+        subscriptionRepository.save(Subscription
+                .create(user.getId(), subscriptionPlanType, now, expiryDate, nextBillingDate
+                )
+        );
+    }
+}

--- a/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
+++ b/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
@@ -67,7 +67,7 @@ public class TestDefaultUserInitializer implements ApplicationRunner {
 
         // 유저 2: 연간 구독 유저(일 년)
         initUser("test2@fivefy.com", "test1234", "테스트유저2",
-                500000L, 0L, SubscriptionPlanType.MONTH, now
+                500000L, 0L, SubscriptionPlanType.YEAR, now
         );
 
         // 유저 3: 무료 유저(삼 일)
@@ -95,7 +95,7 @@ public class TestDefaultUserInitializer implements ApplicationRunner {
 
         // 유료 포인트 충전 이력
         pointHistoryRepository.save(PointHistory
-                .create(wallet.getId(), PointType.PAID, PointHistoryType.USE,
+                .create(wallet.getId(), PointType.PAID, PointHistoryType.CHARGE,
                 paidAmount, paidAmount, "테스트 유료 포인트 충전"
                 )
         );
@@ -103,7 +103,7 @@ public class TestDefaultUserInitializer implements ApplicationRunner {
         // 이벤트 포인트 충전 이력
         if (eventAmount > 0) {
             pointHistoryRepository.save(PointHistory
-                    .create(wallet.getId(), PointType.FREE, PointHistoryType.USE,
+                    .create(wallet.getId(), PointType.FREE, PointHistoryType.CHARGE,
                     eventAmount, eventAmount, "테스트 이벤트 포인트 지급"
                     )
             );

--- a/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
+++ b/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
@@ -17,6 +17,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -48,7 +49,7 @@ public class TestDefaultUserInitializer implements ApplicationRunner {
     private final WalletRepository walletRepository;
     private final PointHistoryRepository pointHistoryRepository;
     private final SubscriptionRepository subscriptionRepository;
-    // 비밀번호 평문으로 사용
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     @Transactional
@@ -82,7 +83,7 @@ public class TestDefaultUserInitializer implements ApplicationRunner {
     ) {
         // 유저 생성
         User user = userRepository.save(
-                User.create(email, rawPassword, name)
+                User.create(email, passwordEncoder.encode(rawPassword), name)
         );
 
         // 지갑 생성 + 충전

--- a/src/main/java/com/fivefy/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/fivefy/domain/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.fivefy.domain.order.repository;
+
+import com.fivefy.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,10 @@
+package com.fivefy.domain.subscription.repository;
+
+import com.fivefy.domain.subscription.entity.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+    Optional<Subscription> findByUserId(Long userId);
+}

--- a/src/main/java/com/fivefy/domain/wallet/entity/Wallet.java
+++ b/src/main/java/com/fivefy/domain/wallet/entity/Wallet.java
@@ -49,4 +49,30 @@ public class Wallet extends BaseEntity {
 
         return wallet;
     }
+
+    /**
+     * 충전(유료 재화)
+     * @param amount
+     */
+    public void chargeBalance(Long amount) {
+        this.balance += amount;
+        this.totalBalance = this.balance + this.eventBalance;
+    }
+    public void chargeEventBalance(Long amount) {
+        this.eventBalance += amount;
+        this.totalBalance = this.balance + this.eventBalance;
+    }
+
+    /**
+     * 사용 : 구독 구매
+     * @param amount
+     */
+    public void useBalance(Long amount) {
+        this.balance -= amount;
+        this.totalBalance = this.balance + this.eventBalance;
+    }
+    public void useEventBalance(Long amount) {
+        this.eventBalance -= amount;
+        this.totalBalance = this.balance + this.eventBalance;
+    }
 }

--- a/src/main/java/com/fivefy/domain/wallet/enums/PointHistoryType.java
+++ b/src/main/java/com/fivefy/domain/wallet/enums/PointHistoryType.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.wallet.enums;
 
 public enum PointHistoryType {
+    CHARGE,     // 충전
     USE,        // 사용
     REFUND      // 환불
 }

--- a/src/main/java/com/fivefy/domain/wallet/repository/PointHistoryRepository.java
+++ b/src/main/java/com/fivefy/domain/wallet/repository/PointHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.fivefy.domain.wallet.repository;
+
+import com.fivefy.domain.wallet.entity.PointHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+}

--- a/src/main/java/com/fivefy/domain/wallet/repository/WalletRepository.java
+++ b/src/main/java/com/fivefy/domain/wallet/repository/WalletRepository.java
@@ -1,0 +1,10 @@
+package com.fivefy.domain.wallet.repository;
+
+import com.fivefy.domain.wallet.entity.Wallet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface WalletRepository extends JpaRepository<Wallet, Long> {
+    Optional<Wallet> findByUserId(Long userId);
+}


### PR DESCRIPTION
## 개요

> 유저 더미데이터(지갑, 구독 포함) 생성


## 변경 사항
- 지갑 내 포인트 보유, 구독 된 유저 3체의 더미데이터 생성
- user의 Repository는 생성하지 않았습니다. UserRepository 기본 구조만 생성하시면 테스트 가능합니다.

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)


## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 유료·무료 잔액을 구분한 지갑 잔액 관리 기능 추가
  * 구독 관리 기능 추가 (플랜별 만료·청구일 반영)
  * 주문 관리 기능 추가
  * 테스트용 기본 사용자 및 데이터 자동 생성 기능 추가

* **개선사항**
  * 포인트(충전/사용/환불/충전내역) 이력 추적 추가
  * 사용자별 지갑 및 구독 조회 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->