### PR TITLE
feat: 회원가입 기능 추가

### DIFF
--- a/src/main/java/com/fivefy/common/config/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/fivefy/common/config/security/JwtAuthenticationEntryPoint.java
@@ -15,6 +15,8 @@ import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
+import static com.fivefy.common.enums.AuthErrorCode.ERR_AUTH_UNAUTHORIZED;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -32,7 +34,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         Object exception = request.getAttribute("exception");
         AuthErrorCode errorCode = (exception instanceof AuthErrorCode authErrorCode)
                 ? authErrorCode
-                : AuthErrorCode.ERR_AUTH_UNAUTHORIZED;
+                : ERR_AUTH_UNAUTHORIZED;
 
         log.info("JwtAuthenticationEntryPoint 호출 : {}", errorCode.getMessage());
 

--- a/src/main/java/com/fivefy/common/config/security/JwtFilter.java
+++ b/src/main/java/com/fivefy/common/config/security/JwtFilter.java
@@ -1,6 +1,5 @@
 package com.fivefy.common.config.security;
 
-import com.fivefy.common.enums.AuthErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -19,6 +18,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+
+import static com.fivefy.common.enums.AuthErrorCode.*;
 
 @Slf4j
 @Component
@@ -51,19 +52,19 @@ public class JwtFilter extends OncePerRequestFilter {
 
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다");
-            request.setAttribute("exception", AuthErrorCode.ERR_AUTH_EXPIRED_TOKEN);
+            request.setAttribute("exception", ERR_AUTH_EXPIRED_TOKEN);
         } catch (UnsupportedJwtException e) {
             log.info("지원하지 않는 JWT 토큰입니다");
-            request.setAttribute("exception", AuthErrorCode.ERR_AUTH_INVALID_TOKEN);
+            request.setAttribute("exception", ERR_AUTH_INVALID_TOKEN);
         } catch (MalformedJwtException e) {
             log.info("잘못된 JWT 토큰입니다");
-            request.setAttribute("exception", AuthErrorCode.ERR_AUTH_INVALID_TOKEN);
+            request.setAttribute("exception", ERR_AUTH_INVALID_TOKEN);
         } catch (IllegalArgumentException e) {
             log.info("JWT 토큰이 비어있습니다");
-            request.setAttribute("exception", AuthErrorCode.ERR_AUTH_EMPTY_TOKEN);
+            request.setAttribute("exception", ERR_AUTH_EMPTY_TOKEN);
         } catch (Exception e) {
             log.error("인증 처리 중 오류 발생", e);
-            request.setAttribute("exception", AuthErrorCode.ERR_AUTH_UNAUTHORIZED);
+            request.setAttribute("exception", ERR_AUTH_UNAUTHORIZED);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/fivefy/domain/user/controller/UserController.java
+++ b/src/main/java/com/fivefy/domain/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.fivefy.domain.user.controller;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.domain.user.dto.request.UserSignupRequest;
+import com.fivefy.domain.user.dto.response.UserSignupResponse;
+import com.fivefy.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/users/signup")
+    public ResponseEntity<BaseResponse<UserSignupResponse>> signupUser(@Valid @RequestBody UserSignupRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                BaseResponse.success(HttpStatus.CREATED, "회원가입 성공", userService.signupUser(request))
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/user/dto/request/UserSignupRequest.java
+++ b/src/main/java/com/fivefy/domain/user/dto/request/UserSignupRequest.java
@@ -1,0 +1,21 @@
+package com.fivefy.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UserSignupRequest(
+        @NotBlank(message = "이름은 필수입니다")
+        @Size(min = 2, max = 10, message = "이름은 2~10자여야 합니다")
+        String name,
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "이메일 형식이어야 합니다")
+        String email,
+        @NotBlank(message = "비밀번호는 필수입니다")
+        @Pattern(
+                regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()])[a-zA-Z\\d!@#$%^&*()]{8,20}$",
+                message = "비밀번호는 8~20자며, 영문, 숫자, 특수문자를 각각 최소 1개씩 포함해야 합니다"
+        )
+        String password
+) {}

--- a/src/main/java/com/fivefy/domain/user/dto/response/UserSignupResponse.java
+++ b/src/main/java/com/fivefy/domain/user/dto/response/UserSignupResponse.java
@@ -1,0 +1,21 @@
+package com.fivefy.domain.user.dto.response;
+
+import com.fivefy.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record UserSignupResponse(
+        Long userId,
+        String name,
+        String email,
+        LocalDateTime createdAt
+) {
+    public static UserSignupResponse from(User user) {
+        return new UserSignupResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/user/enums/UserErrorCode.java
+++ b/src/main/java/com/fivefy/domain/user/enums/UserErrorCode.java
@@ -1,0 +1,16 @@
+package com.fivefy.domain.user.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    ERR_USER_DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일이 존재합니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/fivefy/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.fivefy.domain.user.repository;
+
+import com.fivefy.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/fivefy/domain/user/service/UserService.java
+++ b/src/main/java/com/fivefy/domain/user/service/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
 
         User user = User.create(request.email(), encodedPassword, request.name());
         User savedUser = userRepository.save(user);
-        Wallet wallet = Wallet.create(user.getId());
+        Wallet wallet = Wallet.create(savedUser.getId());
         walletRepository.save(wallet);
 
         return UserSignupResponse.from(savedUser);

--- a/src/main/java/com/fivefy/domain/user/service/UserService.java
+++ b/src/main/java/com/fivefy/domain/user/service/UserService.java
@@ -1,0 +1,48 @@
+package com.fivefy.domain.user.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.user.dto.request.UserSignupRequest;
+import com.fivefy.domain.user.dto.response.UserSignupResponse;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.repository.UserRepository;
+import com.fivefy.domain.wallet.entity.Wallet;
+import com.fivefy.domain.wallet.repository.WalletRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_DUPLICATED_EMAIL;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final WalletRepository walletRepository;
+
+    /**
+     회원가입
+     1. 이메일 중복 검증
+     2. 비밀번호 암호화
+     3. User 생성 및 DB 저장
+     4. Wallet 생성 및 DB 저장
+     5. return
+     */
+    @Transactional
+    public UserSignupResponse signupUser(UserSignupRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new BusinessException(ERR_USER_DUPLICATED_EMAIL);
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.password());
+
+        User user = User.create(request.email(), encodedPassword, request.name());
+        User savedUser = userRepository.save(user);
+        Wallet wallet = Wallet.create(user.getId());
+        walletRepository.save(wallet);
+
+        return UserSignupResponse.from(savedUser);
+    }
+}


### PR DESCRIPTION
## 개요

> 회원가입 API 구현 및 JWT 인증 필터의 가독성 리팩토링

## 변경 사항

- 서비스 로직 (UserService)
  - BCryptPasswordEncoder를 통한 비밀번호 암호화 저장.
  - 회원가입 시 사용자 전용 지갑(Wallet)을 자동 생성하며, @Transactional을 통해 두 작업의 원자성 보장.
  - 이메일 중복 시 커스텀 예외(ERR_USER_DUPLICATED_EMAIL) 발생.
- DTO 및 유효성 검사
  - UserSignupRequest: 이메일 형식 및 비밀번호 복잡도(영문/숫자/특수문자 조합) 검증 적용.
  - UserSignupResponse: 엔티티 노출을 방지하기 위한 정적 팩토리 메서드(from) 구현.
- AuthErrorCode에 대한 static import를 적용하여 필터 내 불필요한 클래스 참조 제거 및 코드 간결화

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> POST /api/users/signup 호출 후 응답 확인

## 스크린샷
<img width="852" height="520" alt="스크린샷 2026-04-13 오후 5 19 57" src="https://github.com/user-attachments/assets/8675d59a-b976-47f4-bd27-8d9bc918a677" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 회원가입 기능이 추가되었습니다. 이메일, 비밀번호, 이름을 통해 새로운 계정을 생성할 수 있습니다.
  * 회원가입 시 중복된 이메일에 대한 검증이 적용됩니다.

* **Refactor**
  * 인증 관련 내부 코드 구조가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->