### PR TITLE
test: 로그인, 회원가입의 controller, service 유닛 테스트

### DIFF
--- a/src/main/java/com/fivefy/FivefyApplication.java
+++ b/src/main/java/com/fivefy/FivefyApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class FivefyApplication {

--- a/src/main/java/com/fivefy/common/config/jpa/JpaAuditingConfig.java
+++ b/src/main/java/com/fivefy/common/config/jpa/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.fivefy.common.config.jpa;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
@@ -1,9 +1,10 @@
 package com.fivefy.domain.user.controller;
 
-import com.fivefy.common.config.security.JwtAuthenticationEntryPoint;
 import com.fivefy.common.config.security.JwtUtil;
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.user.dto.request.UserLoginRequest;
 import com.fivefy.domain.user.dto.request.UserSignupRequest;
+import com.fivefy.domain.user.dto.response.UserLoginResponse;
 import com.fivefy.domain.user.dto.response.UserSignupResponse;
 import com.fivefy.domain.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -20,11 +22,11 @@ import tools.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 
 import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_DUPLICATED_EMAIL;
+import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_LOGIN_FAIL;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(UserController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -110,6 +112,92 @@ class UserControllerTest {
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.message").value(ERR_USER_DUPLICATED_EMAIL.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인")
+    class Login {
+
+        @Test
+        @DisplayName("로그인 성공 시 200 반환 및 AT 응답")
+        void loginSuccess() throws Exception {
+            // given
+            UserLoginRequest request = new UserLoginRequest("test@test.com", "Test1234!");
+            UserLoginResponse result = UserLoginResponse.of("accessToken", "refreshToken");
+            given(userService.loginUser(any())).willReturn(result);
+
+            // when & then
+            mockMvc.perform(post("/api/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.accessToken").value("accessToken"))
+                    .andExpect(jsonPath("$.data.refreshToken").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("로그인 성공 시 쿠키에 RT 설정")
+        void loginSuccessWithRefreshTokenCookie() throws Exception {
+            // given
+            UserLoginRequest request = new UserLoginRequest("test@test.com", "Test1234!");
+            UserLoginResponse result = UserLoginResponse.of("accessToken", "refreshToken");
+            given(userService.loginUser(any())).willReturn(result);
+
+            // when & then
+            mockMvc.perform(post("/api/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(cookie().value("refreshToken", "refreshToken"))
+                    .andExpect(cookie().httpOnly("refreshToken", true))
+                    .andExpect(cookie().secure("refreshToken", true));
+        }
+
+        @Test
+        @DisplayName("로그인 성공 시 캐시 금지 헤더 포함")
+        void loginSuccessWithCacheControlHeader() throws Exception {
+            // given
+            UserLoginRequest request = new UserLoginRequest("test@test.com", "Test1234!");
+            UserLoginResponse result = UserLoginResponse.of("accessToken", "refreshToken");
+            given(userService.loginUser(any())).willReturn(result);
+
+            // when & then
+            mockMvc.perform(post("/api/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
+                    .andExpect(header().string(HttpHeaders.PRAGMA, "no-cache"));
+        }
+
+        @Test
+        @DisplayName("이메일 없이 로그인 시 400 반환")
+        void loginWithoutEmail() throws Exception {
+            // given
+            UserLoginRequest request = new UserLoginRequest("", "Test1234!");
+
+            // when & then
+            mockMvc.perform(post("/api/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("로그인 실패 시 401 반환")
+        void loginFail() throws Exception {
+            // given
+            UserLoginRequest request = new UserLoginRequest("test@test.com", "wrongPassword1!");
+            given(userService.loginUser(any()))
+                    .willThrow(new BusinessException(ERR_USER_LOGIN_FAIL));
+
+            // when & then
+            mockMvc.perform(post("/api/users/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").value(ERR_USER_LOGIN_FAIL.getMessage()));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,115 @@
+package com.fivefy.domain.user.controller;
+
+import com.fivefy.common.config.security.JwtAuthenticationEntryPoint;
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.user.dto.request.UserSignupRequest;
+import com.fivefy.domain.user.dto.response.UserSignupResponse;
+import com.fivefy.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+
+import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_DUPLICATED_EMAIL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private UserService userService;
+    @MockitoBean private JwtUtil jwtUtil;
+
+    @Nested
+    @DisplayName("회원가입")
+    class Signup {
+
+        @Test
+        @DisplayName("회원가입 성공 시 201 반환")
+        void signupSuccess() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest("테스트", "test@test.com", "Test1234!");
+            UserSignupResponse response = new UserSignupResponse(1L, "테스트", "test@test.com", LocalDateTime.now());
+            given(userService.signupUser(any(UserSignupRequest.class))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/users/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                    .andExpect(jsonPath("$.data.name").value("테스트"));
+        }
+
+        @Test
+        @DisplayName("이름 없이 회원가입 시 400 반환")
+        void signupWithoutName() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest("", "test@test.com", "Test1234!");
+
+            // when & then
+            mockMvc.perform(post("/api/users/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("이메일 형식이 아니면 400 반환")
+        void signupWithInvalidEmail() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest("테스트", "invalid-email", "Test1234!");
+
+            // when & then
+            mockMvc.perform(post("/api/users/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("비밀번호 형식이 맞지 않으면 400 반환")
+        void signupWithInvalidPassword() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest("테스트", "test@test.com", "1234");
+
+            // when & then
+            mockMvc.perform(post("/api/users/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("중복 이메일 회원가입 시 409 반환")
+        void signupWithDuplicateEmail() throws Exception {
+            // given
+            UserSignupRequest request = new UserSignupRequest("테스트", "test@test.com", "Test1234!");
+            given(userService.signupUser(any()))
+                    .willThrow(new BusinessException(ERR_USER_DUPLICATED_EMAIL));
+
+            // when & then
+            mockMvc.perform(post("/api/users/signup")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(ERR_USER_DUPLICATED_EMAIL.getMessage()));
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
@@ -143,6 +143,7 @@ class UserServiceTest {
         void setUp() {
             request = new UserLoginRequest("test@test.com", "Test1234!");
             user = User.create("test@test.com", "encodedPassword", "테스트");
+            ReflectionTestUtils.setField(user, "id", 1L);
         }
 
         @Test

--- a/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
@@ -1,0 +1,232 @@
+package com.fivefy.domain.user.service;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.user.dto.request.UserLoginRequest;
+import com.fivefy.domain.user.dto.request.UserSignupRequest;
+import com.fivefy.domain.user.dto.response.UserLoginResponse;
+import com.fivefy.domain.user.dto.response.UserSignupResponse;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.repository.UserRepository;
+import com.fivefy.domain.wallet.entity.Wallet;
+import com.fivefy.domain.wallet.repository.WalletRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_DUPLICATED_EMAIL;
+import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_LOGIN_FAIL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private WalletRepository walletRepository;
+    @Mock private JwtUtil jwtUtil;
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    @Nested
+    @DisplayName("회원가입")
+    class Signup {
+
+        private UserSignupRequest request;
+
+        @BeforeEach
+        void setUp() {
+            request = new UserSignupRequest("테스트", "test@test.com", "Test1234!");
+        }
+
+        @Test
+        @DisplayName("회원가입 성공")
+        void signupSuccess() {
+            // given
+            given(userRepository.existsByEmail(request.email())).willReturn(false);
+            given(passwordEncoder.encode(request.password())).willReturn("encodedPassword");
+
+            User user = User.create(request.email(), "encodedPassword", request.name());
+            ReflectionTestUtils.setField(user, "id", 1L);
+            given(userRepository.save(any(User.class))).willReturn(user);
+
+            // when
+            UserSignupResponse response = userService.signupUser(request);
+
+            // then
+            assertThat(response.email()).isEqualTo(request.email());
+            assertThat(response.name()).isEqualTo(request.name());
+            verify(walletRepository, times(1)).save(any(Wallet.class));
+        }
+
+        @Test
+        @DisplayName("중복 이메일 회원가입 시 예외 발생")
+        void duplicateEmailException() {
+            // given
+            given(userRepository.existsByEmail(request.email())).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userService.signupUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_DUPLICATED_EMAIL.getMessage());
+
+            verify(userRepository, never()).save(any(User.class));
+            verify(walletRepository, never()).save(any(Wallet.class));
+        }
+
+        @Test
+        @DisplayName("비밀번호는 암호화되어 저장")
+        void passwordEncode() {
+            // given
+            given(userRepository.existsByEmail(request.email())).willReturn(false);
+            given(passwordEncoder.encode(request.password())).willReturn("encodedPassword");
+
+            User user = User.create(request.email(), "encodedPassword", request.name());
+            ReflectionTestUtils.setField(user, "id", 1L);
+            given(userRepository.save(any(User.class))).willReturn(user);
+
+            // when
+            userService.signupUser(request);
+
+            // then
+            verify(passwordEncoder, times(1)).encode("Test1234!");
+            verify(userRepository).save(argThat(savedUser ->
+                    savedUser.getPassword().equals("encodedPassword")
+            ));
+        }
+
+        @Test
+        @DisplayName("동시 요청으로 DataIntegrityViolationException 발생 시 중복 이메일 예외로 변환")
+        void dataIntegrityViolationExceptionConvertToDuplicateEmailException() {
+            // given
+            given(userRepository.existsByEmail(request.email())).willReturn(false);
+            given(passwordEncoder.encode(request.password())).willReturn("encodedPassword");
+            given(userRepository.save(any(User.class))).willThrow(DataIntegrityViolationException.class);
+
+            // when & then
+            assertThatThrownBy(() -> userService.signupUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_DUPLICATED_EMAIL.getMessage());
+
+            verify(walletRepository, never()).save(any(Wallet.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인")
+    class Login {
+
+        private UserLoginRequest request;
+        private User user;
+
+        @BeforeEach
+        void setUp() {
+            request = new UserLoginRequest("test@test.com", "Test1234!");
+            user = User.create("test@test.com", "encodedPassword", "테스트");
+        }
+
+        @Test
+        @DisplayName("로그인 성공")
+        void loginSuccess() {
+            // given
+            given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(true);
+            given(jwtUtil.createAccessToken(any(), any())).willReturn("accessToken");
+            given(jwtUtil.createRefreshToken()).willReturn("refreshToken");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+            // when
+            UserLoginResponse response = userService.loginUser(request);
+
+            // then
+            assertThat(response.accessToken()).isEqualTo("accessToken");
+            assertThat(response.refreshToken()).isEqualTo("refreshToken");
+        }
+
+        @Test
+        @DisplayName("로그인 성공 시 RT가 Redis에 저장")
+        void refreshTokenSaveToRedis() {
+            // given
+            given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(true);
+            given(jwtUtil.createAccessToken(any(), any())).willReturn("accessToken");
+            given(jwtUtil.createRefreshToken()).willReturn("refreshToken");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+            // when
+            userService.loginUser(request);
+
+            // then
+            verify(valueOperations).set(
+                    eq("RT:" + user.getId()),
+                    eq("refreshToken"),
+                    eq(Duration.ofDays(7))
+            );
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일로 로그인 시 예외 발생")
+        void userNotFoundEmailThrowException() {
+            // given
+            given(userRepository.findByEmail(request.email())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userService.loginUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_LOGIN_FAIL.getMessage());
+
+            verify(jwtUtil, never()).createAccessToken(any(), any());
+            verify(passwordEncoder, times(1)).matches(any(), any());
+        }
+
+        @Test
+        @DisplayName("비밀번호 불일치 시 예외 발생")
+        void passwordMismatch() {
+            // given
+            given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
+            given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> userService.loginUser(request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_LOGIN_FAIL.getMessage());
+
+            verify(redisTemplate, never()).opsForValue();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이메일도 더미 해시 비교를 수행")
+        void userNotFoundEmailMatchesPassword() {
+            // given
+            given(userRepository.findByEmail(request.email())).willReturn(Optional.empty());
+            given(passwordEncoder.matches(any(), any())).willReturn(false);
+
+            // when
+            assertThatThrownBy(() -> userService.loginUser(request))
+                    .isInstanceOf(BusinessException.class);
+
+            // then — 이메일이 없어도 passwordEncoder.matches()가 반드시 1회 호출됨
+            verify(passwordEncoder, times(1)).matches(any(), any());
+        }
+    }
+}


### PR DESCRIPTION
## 개요

> 회원가입 및 로그인 기능에 대한 유닛 테스트(Service, Controller)를 추가하여 비즈니스 로직의 안정성을 확보,
> 테스트 환경 최적화를 위한 설정 리팩토링을 진행

## 변경 사항

- 서비스 레이어 단위 테스트 (UserServiceTest)
  - 회원가입 검증: 정상 가입 프로세스, 비밀번호 암호화 저장, 중복 이메일 예외 처리를 검증했습니다.
  - 동시성 방어 테스트: 동시 요청으로 인해 DB 수준에서 발생하는 DataIntegrityViolationException을 비즈니스 예외로 적절히 변환하는지 확인했습니다.
  - 로그인 검증: ID/PW 일치 여부에 따른 토큰 발급 및 Redis 내 Refresh Token 저장(TTL 포함) 로직을 검증했습니다.
- 컨트롤러 레이어 단위 테스트 (UserControllerTest)
  - WebMvcTest 활용: @WebMvcTest를 통해 보안 필터를 제외한 순수 HTTP 요청/응답 및 유효성 검증 로직을 독립적으로 테스트했습니다.
  - 입력값 검증: 이름, 이메일 형식, 비밀번호 복잡도 등 Bean Validation 실패 시 400 Bad Request 반환 여부를 확인했습니다.
  - 보안 응답 검증: 로그인 성공 시 바디 내 refreshToken 제외 여부와 쿠키의 보안 옵션(HttpOnly, Secure) 및 캐시 제어 헤더 설정을 검증했습니다.
- 설정 리팩토링
  - JPA Auditing 분리: 메인 클래스의 @EnableJpaAuditing을 별도 JpaAuditingConfig 클래스로 분리했습니다.
  - 테스트 독립성 확보: 위 분리를 통해 WebMvcTest 등 슬라이스 테스트 시 불필요한 JPA 빈 로딩으로 인한 컨텍스트 초기화 에러를 해결했습니다.


## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 스크린샷
- User 도메인의 현 테스트 커버리지
<img width="699" height="174" alt="로그인까지의 테스트 커버리지" src="https://github.com/user-attachments/assets/609495de-f38e-4b30-b7ed-3ded1a9b55fc" />

## 체크리스트

- [ ] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * JPA 감사(Auditing) 설정을 애플리케이션 진입점에서 분리해 전용 구성으로 재배치하여 설정 관리를 개선했습니다.

* **Tests**
  * 회원가입 및 로그인 관련 컨트롤러/서비스의 포괄적인 단위 테스트를 추가해 인증 흐름, 유효성 검사, 중복 처리, 토큰 발급 및 쿠키/캐시 헤더 동작 등을 검증하여 안정성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->