### PR TITLE
test: follow 등록,조회,취소,알림설정 단위 테스트

### DIFF
--- a/src/main/java/com/fivefy/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/fivefy/domain/follow/controller/FollowController.java
@@ -51,8 +51,8 @@ public class FollowController {
             @AuthenticationPrincipal Long userId, @PathVariable Long artistId) {
         followService.deleteFollow(userId, artistId);
 
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(BaseResponse.success(HttpStatus.NO_CONTENT, "팔로우 취소 성공", null));
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(HttpStatus.OK, "팔로우 취소 성공", null));
     }
 
     @PatchMapping("/follows/{artistId}/notifications")

--- a/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
@@ -96,4 +96,62 @@ class FollowControllerTest {
                     .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS.getMessage()));
         }
     }
+
+    @Nested
+    @DisplayName("팔로우 목록 조회")
+    class GetFollows {
+
+        @Test
+        @DisplayName("팔로우 목록 조회 성공 시 200 반환")
+        void getFollows_success() throws Exception {
+            // given
+            FollowGetResponse followGetResponse = new FollowGetResponse(1L, ARTIST_ID, true);
+            PageImpl<FollowGetResponse> page = new PageImpl<>(
+                    List.of(followGetResponse), PageRequest.of(0, 20), 1
+            );
+
+            given(followService.getFollows(any(), any())).willReturn(page);
+
+            // when & then
+            mockMvc.perform(get("/api/follows")
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("팔로우 목록 조회 성공"))
+                    .andExpect(jsonPath("$.data.content[0].artistId").value(ARTIST_ID))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("팔로우 취소")
+    class DeleteFollow {
+
+        @Test
+        @DisplayName("팔로우 취소 성공 시 200 반환")
+        void deleteFollow_success() throws Exception {
+            // given
+            doNothing().when(followService).deleteFollow(any(), eq(ARTIST_ID));
+
+            // when & then
+            mockMvc.perform(delete("/api/follows/{artistId}", ARTIST_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("팔로우 취소 성공"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 팔로우 취소 시 404 반환")
+        void deleteFollow_notFound() throws Exception {
+            // given
+            doThrow(new BusinessException(FollowErrorCode.ERR_FOLLOW_NOT_FOUND))
+                    .when(followService).deleteFollow(any(), eq(ARTIST_ID));
+
+            // when & then
+            mockMvc.perform(delete("/api/follows/{artistId}", ARTIST_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()));
+        }
+    }
 }

--- a/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
@@ -1,0 +1,99 @@
+package com.fivefy.domain.follow.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.follow.dto.request.FollowCreateRequest;
+import com.fivefy.domain.follow.dto.response.FollowCreateResponse;
+import com.fivefy.domain.follow.dto.response.FollowGetResponse;
+import com.fivefy.domain.follow.enums.FollowErrorCode;
+import com.fivefy.domain.follow.service.FollowService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FollowController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class FollowControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private FollowService followService;
+    @MockitoBean private JwtUtil jwtUtil;
+
+    private static final Long ARTIST_ID = 2L;
+
+    @Nested
+    @DisplayName("팔로우 등록")
+    class CreateFollow {
+
+        @Test
+        @DisplayName("팔로우 등록 성공 시 201 반환")
+        void createFollow_success() throws Exception {
+            // given
+            FollowCreateRequest request = new FollowCreateRequest(ARTIST_ID);
+            FollowCreateResponse response = new FollowCreateResponse(1L, ARTIST_ID, true, LocalDateTime.now());
+
+            given(followService.createFollow(any(), eq(ARTIST_ID))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/follows")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("팔로우 등록 성공"))
+                    .andExpect(jsonPath("$.data.artistId").value(ARTIST_ID));
+        }
+
+        @Test
+        @DisplayName("artistId null 시 400 반환")
+        void createFollow_invalidRequest() throws Exception {
+            // given
+            FollowCreateRequest request = new FollowCreateRequest(null);
+
+            // when & then
+            mockMvc.perform(post("/api/follows")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("중복 팔로우 시 409 반환")
+        void createFollow_duplicate() throws Exception {
+            // given
+            FollowCreateRequest request = new FollowCreateRequest(ARTIST_ID);
+            given(followService.createFollow(any(), eq(ARTIST_ID)))
+                    .willThrow(new BusinessException(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS));
+
+            // when & then
+            mockMvc.perform(post("/api/follows")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS.getMessage()));
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
@@ -154,4 +154,35 @@ class FollowControllerTest {
                     .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()));
         }
     }
+
+    @Nested
+    @DisplayName("알림 설정 토글")
+    class ToggleNotification {
+
+        @Test
+        @DisplayName("알림 설정 토글 성공 시 200 반환")
+        void toggleNotification_success() throws Exception {
+            // given
+            doNothing().when(followService).toggleNotification(any(), eq(ARTIST_ID));
+
+            // when & then
+            mockMvc.perform(patch("/api/follows/{artistId}/notifications", ARTIST_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("알림 설정 변경 성공"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 팔로우 토글 시 404 반환")
+        void toggleNotification_notFound() throws Exception {
+            // given
+            doThrow(new BusinessException(FollowErrorCode.ERR_FOLLOW_NOT_FOUND))
+                    .when(followService).toggleNotification(any(), eq(ARTIST_ID));
+
+            // when & then
+            mockMvc.perform(patch("/api/follows/{artistId}/notifications", ARTIST_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()));
+        }
+    }
 }

--- a/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
@@ -1,0 +1,138 @@
+package com.fivefy.domain.follow.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistExceptionEnum;
+import com.fivefy.domain.artist.repository.ArtistRepository;
+import com.fivefy.domain.follow.dto.response.FollowCreateResponse;
+import com.fivefy.domain.follow.entity.Follow;
+import com.fivefy.domain.follow.enums.FollowErrorCode;
+import com.fivefy.domain.follow.repository.FollowRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+@ExtendWith(MockitoExtension.class)
+class FollowServiceTest {
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @InjectMocks
+    private FollowService followService;
+
+    private User mockUser;
+    private Artist mockArtist;
+    private Follow mockFollow;
+
+    private static final Long USER_ID = 1L;
+    private static final Long ARTIST_ID = 2L;
+
+    @BeforeEach
+    void setUp() {
+        mockUser = mock(User.class);
+        mockArtist = mock(Artist.class);
+        mockFollow = Follow.create(ARTIST_ID, USER_ID);
+
+        lenient().when(mockUser.getId()).thenReturn(USER_ID);
+        lenient().when(mockArtist.getId()).thenReturn(ARTIST_ID);
+    }
+
+    // createFollow 성공
+    @Test
+    @DisplayName("팔로우 등록 성공")
+    void createFollow_success() {
+        // given
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(mockUser));
+        given(artistRepository.findById(ARTIST_ID)).willReturn(Optional.of(mockArtist));
+        given(followRepository.existsByUserIdAndArtistId(USER_ID, ARTIST_ID)).willReturn(false);
+        given(followRepository.save(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        FollowCreateResponse response = followService.createFollow(USER_ID, ARTIST_ID);
+
+        // then
+        assertThat(response.artistId()).isEqualTo(ARTIST_ID);
+        assertThat(response.notificationEnabled()).isTrue();
+        verify(followRepository).save(any(Follow.class));
+    }
+
+    // createFollow 실패
+    @Test
+    @DisplayName("팔로우 등록 실패 - 존재하지 않는 유저")
+    void createFollow_userNotFound() {
+        // given
+        given(userRepository.findById(any())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> followService.createFollow(USER_ID, ARTIST_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("팔로우 등록 실패 - 존재하지 않는 아티스트")
+    void createFollow_artistNotFound() {
+        // given
+        given(userRepository.findById(any())).willReturn(Optional.of(mockUser));
+        given(artistRepository.findById(any())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> followService.createFollow(USER_ID, ARTIST_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ArtistExceptionEnum.ERR_ARTIST_NOT_FOUND.getMessage());
+    }
+
+    // createFollow 중복 체크
+    @Test
+    @DisplayName("팔로우 등록 실패 - 중복 팔로우 (existsBy 검증)")
+    void createFollow_duplicateByExists() {
+        // given
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(mockUser));
+        given(artistRepository.findById(ARTIST_ID)).willReturn(Optional.of(mockArtist));
+        given(followRepository.existsByUserIdAndArtistId(USER_ID, ARTIST_ID)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> followService.createFollow(USER_ID, ARTIST_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS.getMessage());
+
+        verify(followRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("팔로우 등록 실패 - 중복 팔로우 (DB UniqueConstraint 위반)")
+    void createFollow_duplicateByDBConstraint() {
+        // given
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(mockUser));
+        given(artistRepository.findById(ARTIST_ID)).willReturn(Optional.of(mockArtist));
+        given(followRepository.existsByUserIdAndArtistId(USER_ID, ARTIST_ID)).willReturn(false);
+        given(followRepository.save(any())).willThrow(DataIntegrityViolationException.class);
+
+        // when & then
+        assertThatThrownBy(() -> followService.createFollow(USER_ID, ARTIST_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS.getMessage());
+    }
+}

--- a/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
@@ -199,4 +199,44 @@ class FollowServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage());
     }
+
+    // toggleNotification
+    @Test
+    @DisplayName("알림 설정 토글 성공 - true → false")
+    void toggleNotification_trueToFalse() {
+        // given
+        given(followRepository.findByUserIdAndArtistId(USER_ID, ARTIST_ID)).willReturn(Optional.of(mockFollow));
+
+        // when
+        followService.toggleNotification(USER_ID, ARTIST_ID);
+
+        // then
+        assertThat(mockFollow.getNotificationEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("알림 설정 토글 성공 - false → true")
+    void toggleNotification_falseToTrue() {
+        // given
+        given(followRepository.findByUserIdAndArtistId(USER_ID, ARTIST_ID)).willReturn(Optional.of(mockFollow));
+
+        // when
+        followService.toggleNotification(USER_ID, ARTIST_ID); // true → false
+        followService.toggleNotification(USER_ID, ARTIST_ID); // false → true
+
+        // then
+        assertThat(mockFollow.getNotificationEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("알림 설정 토글 실패 - 팔로우 없음")
+    void toggleNotification_notFound() {
+        // given
+        given(followRepository.findByUserIdAndArtistId(any(), any())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> followService.toggleNotification(USER_ID, ARTIST_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage());
+    }
 }

--- a/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
@@ -5,6 +5,7 @@ import com.fivefy.domain.artist.entity.Artist;
 import com.fivefy.domain.artist.enums.ArtistExceptionEnum;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.follow.dto.response.FollowCreateResponse;
+import com.fivefy.domain.follow.dto.response.FollowGetResponse;
 import com.fivefy.domain.follow.entity.Follow;
 import com.fivefy.domain.follow.enums.FollowErrorCode;
 import com.fivefy.domain.follow.repository.FollowRepository;
@@ -19,7 +20,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -134,5 +140,37 @@ class FollowServiceTest {
         assertThatThrownBy(() -> followService.createFollow(USER_ID, ARTIST_ID))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS.getMessage());
+    }
+
+    // getFollows 페이징 조회
+    @Test
+    @DisplayName("팔로우 목록 조회 성공 - 페이징")
+    void getFollows_success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<Follow> followPage = new PageImpl<>(List.of(mockFollow), pageable, 1);
+
+        given(userRepository.findById(USER_ID)).willReturn(Optional.of(mockUser));
+        given(followRepository.findAllByUserId(USER_ID, pageable)).willReturn(followPage);
+
+        // when
+        Page<FollowGetResponse> responses = followService.getFollows(USER_ID, pageable);
+
+        // then
+        assertThat(responses.getContent()).hasSize(1);
+        assertThat(responses.getTotalElements()).isEqualTo(1);
+        assertThat(responses.getContent().get(0).artistId()).isEqualTo(ARTIST_ID);
+    }
+
+    @Test
+    @DisplayName("팔로우 목록 조회 실패 - 존재하지 않는 유저")
+    void getFollows_userNotFound() {
+        // given
+        given(userRepository.findById(any())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> followService.getFollows(USER_ID, PageRequest.of(0, 20)))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
     }
 }

--- a/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/fivefy/domain/follow/service/FollowServiceTest.java
@@ -173,4 +173,30 @@ class FollowServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
     }
+
+    // deleteFollow
+    @Test
+    @DisplayName("팔로우 취소 성공")
+    void deleteFollow_success() {
+        // given
+        given(followRepository.findByUserIdAndArtistId(USER_ID, ARTIST_ID)).willReturn(Optional.of(mockFollow));
+
+        // when
+        followService.deleteFollow(USER_ID, ARTIST_ID);
+
+        // then
+        verify(followRepository).delete(mockFollow);
+    }
+
+    @Test
+    @DisplayName("팔로우 취소 실패 - 팔로우 없음")
+    void deleteFollow_notFound() {
+        // given
+        given(followRepository.findByUserIdAndArtistId(any(), any())).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> followService.deleteFollow(USER_ID, ARTIST_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage());
+    }
 }


### PR DESCRIPTION
## 개요

Follow 도메인 팔로우 등록/취소/목록조회/알림토글 기능에 대한 유닛 테스트(Service, Controller)

## 변경 사항
- FollowServiceTest 추가
  - createFollow: 성공, 유저 없음, 아티스트 없음, 중복(existsBy), 중복(DB UniqueConstraint)
  - getFollows: 페이징 조회 성공, 유저 없음
  - deleteFollow: 성공, 팔로우 없음
  - toggleNotification: true→false, false→true, 팔로우 없음
- FollowControllerTest 추가
  - createFollow: 성공(201), artistId null(400), 중복(409)
  - getFollows: 성공(200)
  - deleteFollow: 성공(200), 팔로우 없음(404)
  - toggleNotification: 성공(200), 팔로우 없음(404)
## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 팔로우 기능의 안정성이 개선되었습니다.

* **테스트**
  * 팔로우 생성, 목록 조회, 취소, 알림 설정 토글 등 주요 기능에 대한 포괄적인 자동화 테스트가 추가되어 서비스의 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->