### PR TITLE
refactor: 도메인 ErrorCode 네이밍 통일 및 인덱스/삭제 정책 정리

### DIFF
--- a/src/main/java/com/fivefy/domain/album/entity/Album.java
+++ b/src/main/java/com/fivefy/domain/album/entity/Album.java
@@ -2,7 +2,7 @@ package com.fivefy.domain.album.entity;
 
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.album.enums.AlbumExceptionEnum;
+import com.fivefy.domain.album.enums.AlbumErrorCode;
 import com.fivefy.domain.album.enums.AlbumStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -16,7 +16,13 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity
-@Table(name = "albums")
+@Table(
+        name = "albums",
+        indexes = {
+                @Index(name = "idx_album_artist_id", columnList = "artist_id"),
+                @Index(name = "idx_album_status", columnList = "status")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Album extends BaseEntity {
 
@@ -93,7 +99,7 @@ public class Album extends BaseEntity {
         validateNotDeleted();
 
         if (status == AlbumStatus.PUBLISHED) {
-            throw new BusinessException(AlbumExceptionEnum.ERR_ALBUM_ALREADY_PUBLISHED);
+            throw new BusinessException(AlbumErrorCode.ERR_ALBUM_ALREADY_PUBLISHED);
         }
         this.status = AlbumStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();
@@ -103,7 +109,7 @@ public class Album extends BaseEntity {
         validateNotDeleted();
 
         if (status == AlbumStatus.BLOCKED) {
-            throw new BusinessException(AlbumExceptionEnum.ERR_ALBUM_ALREADY_BLOCKED);
+            throw new BusinessException(AlbumErrorCode.ERR_ALBUM_ALREADY_BLOCKED);
         }
         this.status = AlbumStatus.BLOCKED;
     }
@@ -114,11 +120,11 @@ public class Album extends BaseEntity {
         validateNotDeleted();
 
         if (trackCount < 0L) {
-            throw new BusinessException(AlbumExceptionEnum.ERR_INVALID_TRACK_COUNT);
+            throw new BusinessException(AlbumErrorCode.ERR_INVALID_TRACK_COUNT);
         }
 
         if (totalDurationSec < 0L) {
-            throw new BusinessException(AlbumExceptionEnum.ERR_INVALID_TOTAL_DURATION_SEC);
+            throw new BusinessException(AlbumErrorCode.ERR_INVALID_TOTAL_DURATION_SEC);
         }
 
         this.trackCount = trackCount;
@@ -127,14 +133,14 @@ public class Album extends BaseEntity {
 
     public void softDelete() {
         if (this.deletedAt != null) {
-            throw new BusinessException(AlbumExceptionEnum.ERR_ALBUM_ALREADY_DELETED);
+            throw new BusinessException(AlbumErrorCode.ERR_ALBUM_ALREADY_DELETED);
         }
         this.deletedAt = LocalDateTime.now();
     }
 
     private void validateNotDeleted() {
         if (this.deletedAt != null) {
-            throw new BusinessException(AlbumExceptionEnum.ERR_DELETED_ALBUM_CANNOT_BE_UPDATED);
+            throw new BusinessException(AlbumErrorCode.ERR_DELETED_ALBUM_CANNOT_BE_UPDATED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
@@ -3,7 +3,7 @@ package com.fivefy.domain.album.entity;
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.album.enums.AlbumReleaseExceptionEnum;
+import com.fivefy.domain.album.enums.AlbumReleaseErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,7 +16,14 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity
-@Table(name = "album_release_requests")
+@Table(
+        name = "album_release_requests",
+        indexes = {
+                @Index(name = "idx_album_release_request_requester_user_id", columnList = "requester_user_id"),
+                @Index(name = "idx_album_release_request_artist_id", columnList = "artist_id"),
+                @Index(name = "idx_album_release_request_status", columnList = "status")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AlbumReleaseRequest extends BaseEntity {
 
@@ -114,7 +121,7 @@ public class AlbumReleaseRequest extends BaseEntity {
     private void validatePending() {
         if (this.status != ApplicationStatus.PENDING) {
             throw new BusinessException(
-                    AlbumReleaseExceptionEnum.ERR_ALBUM_RELEASE_ALREADY_PROCESSED);
+                    AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_ALREADY_PROCESSED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/album/enums/AlbumErrorCode.java
+++ b/src/main/java/com/fivefy/domain/album/enums/AlbumErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum AlbumExceptionEnum implements ErrorCode {
+public enum AlbumErrorCode implements ErrorCode {
     ERR_ALBUM_ALREADY_PUBLISHED(HttpStatus.BAD_REQUEST, "이미 발매된 앨범입니다"),
     ERR_ALBUM_ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "이미 차단된 앨범입니다"),
     ERR_ALBUM_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 앨범입니다"),
@@ -16,7 +16,7 @@ public enum AlbumExceptionEnum implements ErrorCode {
     private final HttpStatus httpStatus;
     private final String message;
 
-    AlbumExceptionEnum(HttpStatus httpStatus, String message) {
+    AlbumErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/album/enums/AlbumReleaseErrorCode.java
+++ b/src/main/java/com/fivefy/domain/album/enums/AlbumReleaseErrorCode.java
@@ -5,14 +5,14 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum AlbumReleaseExceptionEnum implements ErrorCode {
+public enum AlbumReleaseErrorCode implements ErrorCode {
     ERR_ALBUM_RELEASE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 앨범 등록 요청입니다");
 
 
     private final HttpStatus httpStatus;
     private final String message;
 
-    AlbumReleaseExceptionEnum(HttpStatus httpStatus, String message) {
+    AlbumReleaseErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/artist/entity/Artist.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/Artist.java
@@ -2,7 +2,7 @@ package com.fivefy.domain.artist.entity;
 
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.artist.enums.ArtistExceptionEnum;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.artist.enums.ArtistStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -16,7 +16,12 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity
-@Table(name = "artists")
+@Table(
+        name = "artists",
+        indexes = {
+                @Index(name = "idx_artist_owner_user_id", columnList = "owner_user_id")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Artist extends BaseEntity {
 
@@ -82,7 +87,7 @@ public class Artist extends BaseEntity {
         validateNotDeleted();
 
         if (this.status == ArtistStatus.SUSPENDED) {
-            throw new BusinessException(ArtistExceptionEnum.ERR_ARTIST_ALREADY_SUSPENDED);
+            throw new BusinessException(ArtistErrorCode.ERR_ARTIST_ALREADY_SUSPENDED);
         }
         this.status = ArtistStatus.SUSPENDED;
     }
@@ -91,14 +96,14 @@ public class Artist extends BaseEntity {
         validateNotDeleted();
 
         if (this.status == ArtistStatus.ACTIVE) {
-            throw new BusinessException(ArtistExceptionEnum.ERR_ARTIST_ALREADY_ACTIVATED);
+            throw new BusinessException(ArtistErrorCode.ERR_ARTIST_ALREADY_ACTIVATED);
         }
         this.status = ArtistStatus.ACTIVE;
     }
 
     public void softDelete() {
         if (this.deletedAt != null) {
-            throw new BusinessException(ArtistExceptionEnum.ERR_ARTIST_ALREADY_DELETED);
+            throw new BusinessException(ArtistErrorCode.ERR_ARTIST_ALREADY_DELETED);
         }
         this.deletedAt = LocalDateTime.now();
     }
@@ -110,7 +115,7 @@ public class Artist extends BaseEntity {
 
     private void validateNotDeleted() {
         if (this.deletedAt != null) {
-            throw new BusinessException(ArtistExceptionEnum.ERR_DELETED_ARTIST_CANNOT_BE_UPDATED);
+            throw new BusinessException(ArtistErrorCode.ERR_DELETED_ARTIST_CANNOT_BE_UPDATED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/ArtistApplication.java
@@ -3,7 +3,7 @@ package com.fivefy.domain.artist.entity;
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.artist.enums.ArtistApplicationExceptionEnum;
+import com.fivefy.domain.artist.enums.ArtistApplicationErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,7 +16,13 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity
-@Table(name = "artist_applications")
+@Table(
+        name = "artist_applications",
+        indexes = {
+                @Index(name = "idx_artist_application_requester_user_id", columnList = "requester_user_id"),
+                @Index(name = "idx_artist_application_status", columnList = "status")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArtistApplication extends BaseEntity {
 
@@ -97,7 +103,7 @@ public class ArtistApplication extends BaseEntity {
     private void validatePending() {
         if (this.status != ApplicationStatus.PENDING) {
             throw new BusinessException(
-                    ArtistApplicationExceptionEnum.ERR_ARTIST_APPLICATION_ALREADY_PROCESSED);
+                    ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_ALREADY_PROCESSED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/artist/enums/ArtistApplicationErrorCode.java
+++ b/src/main/java/com/fivefy/domain/artist/enums/ArtistApplicationErrorCode.java
@@ -5,13 +5,13 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum ArtistApplicationExceptionEnum implements ErrorCode {
+public enum ArtistApplicationErrorCode implements ErrorCode {
     ERR_ARTIST_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 아티스트 등록 요청입니다");
 
     private final HttpStatus httpStatus;
     private final String message;
 
-    ArtistApplicationExceptionEnum(HttpStatus httpStatus, String message) {
+    ArtistApplicationErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/artist/enums/ArtistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/artist/enums/ArtistErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum ArtistExceptionEnum implements ErrorCode {
+public enum ArtistErrorCode implements ErrorCode {
     ERR_ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 아티스트입니다"),
     ERR_ARTIST_ALREADY_SUSPENDED(HttpStatus.BAD_REQUEST, "이미 정지된 아티스트입니다"),
     ERR_ARTIST_ALREADY_ACTIVATED(HttpStatus.BAD_REQUEST, "이미 활성화된 아티스트입니다"),
@@ -15,7 +15,7 @@ public enum ArtistExceptionEnum implements ErrorCode {
     private final HttpStatus httpStatus;
     private final String message;
 
-    ArtistExceptionEnum(HttpStatus httpStatus, String message) {
+    ArtistErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/follow/service/FollowService.java
+++ b/src/main/java/com/fivefy/domain/follow/service/FollowService.java
@@ -2,7 +2,7 @@ package com.fivefy.domain.follow.service;
 
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.artist.entity.Artist;
-import com.fivefy.domain.artist.enums.ArtistExceptionEnum;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.follow.dto.response.FollowCreateResponse;
 import com.fivefy.domain.follow.dto.response.FollowGetResponse;
@@ -18,8 +18,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -82,7 +80,7 @@ public class FollowService {
 
     private Artist getArtist(Long artistId) {
         return artistRepository.findById(artistId)
-                .orElseThrow(() -> new BusinessException(ArtistExceptionEnum.ERR_ARTIST_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND));
     }
 
     // 권한 체크

--- a/src/main/java/com/fivefy/domain/track/entity/Track.java
+++ b/src/main/java/com/fivefy/domain/track/entity/Track.java
@@ -2,7 +2,7 @@ package com.fivefy.domain.track.entity;
 
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.track.enums.TrackExceptionEnum;
+import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
 import jakarta.persistence.*;
@@ -17,7 +17,15 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity
-@Table(name = "tracks")
+@Table(
+        name = "tracks",
+        indexes = {
+                @Index(name = "idx_track_owner_user_id", columnList = "owner_user_id"),
+                @Index(name = "idx_track_artist_id", columnList = "artist_id"),
+                @Index(name = "idx_track_album_id", columnList = "album_id"),
+                @Index(name = "idx_track_status", columnList = "status")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Track extends BaseEntity {
 
@@ -133,11 +141,11 @@ public class Track extends BaseEntity {
         validateNonNull(durationSec, "durationSec");
 
         if (trackNumber <= 0L) {
-            throw new BusinessException(TrackExceptionEnum.ERR_INVALID_TRACK_NUMBER);
+            throw new BusinessException(TrackErrorCode.ERR_INVALID_TRACK_NUMBER);
         }
 
         if (durationSec <= 0L) {
-            throw new BusinessException(TrackExceptionEnum.ERR_INVALID_DURATION_SEC);
+            throw new BusinessException(TrackErrorCode.ERR_INVALID_DURATION_SEC);
         }
 
         Track track = new Track();
@@ -164,7 +172,7 @@ public class Track extends BaseEntity {
         validateNotDeleted();
 
         if (this.status == TrackStatus.PUBLISHED) {
-            throw new BusinessException(TrackExceptionEnum.ERR_TRACK_ALREADY_PUBLISHED);
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_ALREADY_PUBLISHED);
         }
         this.status = TrackStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();
@@ -174,7 +182,7 @@ public class Track extends BaseEntity {
         validateNotDeleted();
 
         if (this.status == TrackStatus.BLOCKED) {
-            throw new BusinessException(TrackExceptionEnum.ERR_TRACK_ALREADY_BLOCKED);
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_ALREADY_BLOCKED);
         }
         this.status = TrackStatus.BLOCKED;
     }
@@ -183,14 +191,14 @@ public class Track extends BaseEntity {
         validateNotDeleted();
 
         if (this.status != TrackStatus.PUBLISHED) {
-            throw new BusinessException(TrackExceptionEnum.ERR_TRACK_NOT_PUBLISHED);
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_PUBLISHED);
         }
         this.playCount++;
     }
 
     public void softDelete() {
         if (this.deletedAt != null) {
-            throw new BusinessException(TrackExceptionEnum.ERR_TRACK_ALREADY_DELETED);
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_ALREADY_DELETED);
         }
         this.deletedAt = LocalDateTime.now();
     }
@@ -210,7 +218,7 @@ public class Track extends BaseEntity {
 
     private void validateNotDeleted() {
         if (this.deletedAt != null) {
-            throw new BusinessException(TrackExceptionEnum.ERR_DELETED_TRACK_CANNOT_BE_UPDATED);
+            throw new BusinessException(TrackErrorCode.ERR_DELETED_TRACK_CANNOT_BE_UPDATED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
@@ -2,7 +2,7 @@ package com.fivefy.domain.track.entity;
 
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.track.enums.TrackCommentExceptionEnum;
+import com.fivefy.domain.track.enums.TrackCommentErrorCode;
 import com.fivefy.domain.track.enums.TrackCommentStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -16,7 +16,13 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity
-@Table(name = "track_comments")
+@Table(
+        name = "track_comments",
+        indexes = {
+                @Index(name = "idx_track_comment_track_id", columnList = "track_id"),
+                @Index(name = "idx_track_comment_user_id", columnList = "user_id")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrackComment extends BaseEntity {
 
@@ -24,22 +30,24 @@ public class TrackComment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    @Column(nullable = false)
+    @Column(name = "track_id", nullable = false)
     private Long trackId;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "status", nullable = false)
     private TrackCommentStatus status;
 
     @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     public static TrackComment create(Long userId, Long trackId, String content) {
@@ -65,9 +73,8 @@ public class TrackComment extends BaseEntity {
 
     public void softDelete() {
         if (this.deletedAt != null) {
-            throw new BusinessException(TrackCommentExceptionEnum.ERR_TRACK_COMMENT_ALREADY_DELETED);
+            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_ALREADY_DELETED);
         }
-        this.status = TrackCommentStatus.DELETED;
         this.deletedAt = LocalDateTime.now();
     }
 
@@ -79,7 +86,7 @@ public class TrackComment extends BaseEntity {
 
     private void validateNotDeleted() {
         if (this.deletedAt != null) {
-            throw new BusinessException(TrackCommentExceptionEnum.ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED);
+            throw new BusinessException(TrackCommentErrorCode.ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/entity/TrackReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackReleaseRequest.java
@@ -3,7 +3,7 @@ package com.fivefy.domain.track.entity;
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.track.enums.TrackReleaseExceptionEnum;
+import com.fivefy.domain.track.enums.TrackReleaseErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -17,7 +17,15 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
 @Getter
 @Entity
-@Table(name = "track_release_requests")
+@Table(
+        name = "track_release_requests",
+        indexes = {
+                @Index(name = "idx_track_release_request_requester_user_id", columnList = "requester_user_id"),
+                @Index(name = "idx_track_release_request_artist_id", columnList = "artist_id"),
+                @Index(name = "idx_track_release_request_album_id", columnList = "album_id"),
+                @Index(name = "idx_track_release_request_status", columnList = "status")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TrackReleaseRequest extends BaseEntity {
 
@@ -143,7 +151,7 @@ public class TrackReleaseRequest extends BaseEntity {
 
     private void validatePending() {
         if (this.status != ApplicationStatus.PENDING) {
-            throw new BusinessException(TrackReleaseExceptionEnum.ERR_TRACK_RELEASE_ALREADY_PROCESSED);
+            throw new BusinessException(TrackReleaseErrorCode.ERR_TRACK_RELEASE_ALREADY_PROCESSED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum TrackCommentExceptionEnum implements ErrorCode {
+public enum TrackCommentErrorCode implements ErrorCode {
     ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 트랙 댓글은 수정할 수 없습니다"),
     ERR_TRACK_COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 트랫 댓글입니다");
 
@@ -13,7 +13,7 @@ public enum TrackCommentExceptionEnum implements ErrorCode {
     private final HttpStatus httpStatus;
     private final String message;
 
-    TrackCommentExceptionEnum(HttpStatus httpStatus, String message) {
+    TrackCommentErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/track/enums/TrackCommentStatus.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackCommentStatus.java
@@ -2,6 +2,5 @@ package com.fivefy.domain.track.enums;
 
 public enum TrackCommentStatus {
 
-    PUBLISHED, // 게시됨
-    DELETED    // 삭제됨
+    PUBLISHED // 게시됨
 }

--- a/src/main/java/com/fivefy/domain/track/enums/TrackErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackErrorCode.java
@@ -5,20 +5,20 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum TrackExceptionEnum implements ErrorCode {
+public enum TrackErrorCode implements ErrorCode {
     ERR_TRACK_ALREADY_PUBLISHED(HttpStatus.BAD_REQUEST, "이미 공개된 트랙입니다"),
     ERR_TRACK_ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "이미 차단된 트랙입니다"),
     ERR_TRACK_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 트랙입니다"),
     ERR_TRACK_NOT_PUBLISHED(HttpStatus.BAD_REQUEST, "공개되지 않은 트랙입니다"),
     ERR_DELETED_TRACK_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 트랙은 수정할 수 없습니다"),
-    ERR_INVALID_TRACK_NUMBER(HttpStatus.BAD_REQUEST, "트랙 번호는 0 이상이어야 합니다" ),
-    ERR_INVALID_DURATION_SEC(HttpStatus.BAD_REQUEST, "총 재생 시간은 0 이상이어야 합니다");
+    ERR_INVALID_TRACK_NUMBER(HttpStatus.BAD_REQUEST, "트랙 번호는 1 이상이어야 합니다" ),
+    ERR_INVALID_DURATION_SEC(HttpStatus.BAD_REQUEST, "총 재생 시간은 1 이상이어야 합니다");
 
 
     private final HttpStatus httpStatus;
     private final String message;
 
-    TrackExceptionEnum(HttpStatus httpStatus, String message) {
+    TrackErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/track/enums/TrackReleaseErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackReleaseErrorCode.java
@@ -5,13 +5,13 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum TrackReleaseExceptionEnum implements ErrorCode {
+public enum TrackReleaseErrorCode implements ErrorCode {
     ERR_TRACK_RELEASE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 요청입니다");
 
     private final HttpStatus httpStatus;
     private final String message;
 
-    TrackReleaseExceptionEnum(HttpStatus httpStatus, String message) {
+    TrackReleaseErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }


### PR DESCRIPTION
## 개요
도메인 전반의 예외 코드 네이밍과 삭제 정책을 일관되게 정리
주요 엔티티의 조회 성능과 데이터 무결성을 고려해 인덱스 및 검증 기준을 보완

기능 추가보다는 도메인 규칙과 코드 컨벤션을 통일하는 리팩토링에 초점을 맞춤

## 변경 사항

1. ErrorCode 네이밍 통일
	•	*ExceptionEnum → *ErrorCode 로 명칭 통일
	•	도메인별 예외 코드 클래스명 및 참조 코드 일괄 정리
	•	예외 메시지 및 코드 표현 방식 일관성 개선

2. 주요 엔티티 인덱스 추가
	•	Album, Artist, Track 등 주요 엔티티에 인덱스 추가
	•	조회 가능성이 높은 컬럼 기준으로 인덱스 구조 보완

3. soft delete 정책 통일
	•	soft delete 기준을 deletedAt 기반으로 통일
	•	삭제 상태 표현을 별도 status가 아닌 deletedAt 존재 여부로 정리
	•	삭제된 엔티티에 대한 수정/상태 변경 방지 로직 정비

4. Track 검증 기준 보완
	•	트랙 번호(trackNumber) 검증 기준을 1 이상으로 수정
	•	재생 시간(durationSec) 검증 기준을 1 이상으로 수정
	•	음수/0 허용 여부를 명확하게 정리하여 도메인 규칙 반영

5. 기타 정리
	•	도메인 전반의 예외 코드 참조부 수정
	•	import 및 관련 코드 정리
	•	전반적인 가독성과 일관성 개선

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)
- [ ] 
## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 앨범, 아티스트, 트랙, 트랙 댓글 테이블에 데이터베이스 인덱스 추가로 조회 성능 향상

* **버그 수정**
  * 트랙 번호와 재생 시간 유효성 검사 기준 변경 (최솟값: 0 이상 → 1 이상)
  * 트랙 댓글 소프트 삭제 로직 개선

* **Refactor**
  * 에러 코드 체계 표준화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->