### PR TITLE
feat: 플레이리스트 트랙 CRUD API 기본 구현

### DIFF
--- a/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
+++ b/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
@@ -56,6 +56,8 @@ public class Playlist extends BaseEntity {
     }
 
     public void update(String title, String description) {
+        validateNotDeleted();
+
         if (title == null || title.isBlank() || title.length() > 100) {
             throw new BusinessException(PlaylistErrorCode.INVALID_TITLE);
         }
@@ -65,6 +67,13 @@ public class Playlist extends BaseEntity {
     }
 
     public void delete() {
+        validateNotDeleted();
         this.deletedAt = LocalDateTime.now();
+    }
+
+    private void validateNotDeleted() {
+        if (this.deletedAt != null) {
+            throw new BusinessException(PlaylistErrorCode.ALREADY_DELETED_PLAYLIST);
+        }
     }
 }

--- a/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
@@ -15,12 +15,14 @@ public enum PlaylistErrorCode implements ErrorCode {
     DUPLICATE_PLAYLIST_NAME(HttpStatus.CONFLICT, "이미 동일한 이름의 플레이리스트가 존재합니다"),
     PLAYLIST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 수정 권한이 없습니다"),
     PLAYLIST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 삭제 권한이 없습니다"),
+    ALREADY_DELETED_PLAYLIST(HttpStatus.BAD_REQUEST, "이미 삭제된 플레이리스트입니다"),
 
     // PlaylistTrack
     PLAYLIST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트에 대한 권한이 없습니다"),
     PLAYLIST_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트 트랙을 찾을 수 없습니다"),
     PLAYLIST_TRACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 플레이리스트에 추가된 트랙입니다"),
-    INVALID_PLAYLIST_TRACK_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 트랙 순서입니다");
+    INVALID_PLAYLIST_TRACK_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 플레이리스트 트랙 순서입니다"),
+    INVALID_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 플레이리스트 순서 값입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
@@ -17,9 +17,10 @@ public enum PlaylistErrorCode implements ErrorCode {
     PLAYLIST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 삭제 권한이 없습니다"),
 
     // PlaylistTrack
-    PLAYLIST_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트 트랙을 찾을 수 없습니다."),
-    PLAYLIST_TRACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 플레이리스트에 추가된 트랙입니다."),
-    INVALID_PLAYLIST_TRACK_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 트랙 순서입니다.");
+    PLAYLIST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트에 대한 권한이 없습니다"),
+    PLAYLIST_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트 트랙을 찾을 수 없습니다"),
+    PLAYLIST_TRACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 플레이리스트에 추가된 트랙입니다"),
+    INVALID_PLAYLIST_TRACK_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 트랙 순서입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
@@ -9,11 +9,17 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PlaylistErrorCode implements ErrorCode {
 
+    // Playlist
     PLAYLIST_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트를 찾을 수 없습니다"),
     INVALID_TITLE(HttpStatus.BAD_REQUEST, "플레이리스트 제목은 필수입니다"),
     DUPLICATE_PLAYLIST_NAME(HttpStatus.CONFLICT, "이미 동일한 이름의 플레이리스트가 존재합니다"),
     PLAYLIST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 수정 권한이 없습니다"),
-    PLAYLIST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 삭제 권한이 없습니다");
+    PLAYLIST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 삭제 권한이 없습니다"),
+
+    // PlaylistTrack
+    PLAYLIST_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트 트랙을 찾을 수 없습니다."),
+    PLAYLIST_TRACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 플레이리스트에 추가된 트랙입니다."),
+    INVALID_PLAYLIST_TRACK_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 트랙 순서입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
@@ -22,7 +22,8 @@ public enum PlaylistErrorCode implements ErrorCode {
     PLAYLIST_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트 트랙을 찾을 수 없습니다"),
     PLAYLIST_TRACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 플레이리스트에 추가된 트랙입니다"),
     INVALID_PLAYLIST_TRACK_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 플레이리스트 트랙 순서입니다"),
-    INVALID_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 플레이리스트 순서 값입니다");
+    INVALID_POSITION(HttpStatus.BAD_REQUEST, "유효하지 않은 플레이리스트 순서 값입니다"),
+    PLAYLIST_TRACK_POSITION_CONFLICT(HttpStatus.CONFLICT, "트랙 순서 충돌이 발생했습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackController.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackController.java
@@ -1,0 +1,73 @@
+package com.fivefy.domain.playlisttrack.controller;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackOrderUpdateRequest;
+import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
+import com.fivefy.domain.playlisttrack.service.PlaylistTrackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/playlists/{playlistId}/tracks")
+public class PlaylistTrackController {
+
+    private final PlaylistTrackService playlistTrackService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<PlaylistTrackResponse>> addTrack(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long playlistId,
+            @Valid @RequestBody PlaylistTrackCreateRequest request
+    ) {
+        PlaylistTrackResponse response = playlistTrackService.addTrack(userId, playlistId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BaseResponse.success(HttpStatus.CREATED, "플레이리스트 트랙 추가 성공", response));
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<List<PlaylistTrackResponse>>> getTracks(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long playlistId
+    ) {
+        List<PlaylistTrackResponse> response = playlistTrackService.getTracks(userId, playlistId);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "플레이리스트 트랙 목록 조회 성공", response)
+        );
+    }
+
+    @PatchMapping("/index")
+    public ResponseEntity<BaseResponse<Void>> updateTrackOrder(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long playlistId,
+            @Valid @RequestBody PlaylistTrackOrderUpdateRequest request
+    ) {
+        playlistTrackService.updateTrackOrder(userId, playlistId, request);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "플레이리스트 트랙 순서 변경 성공", null)
+        );
+    }
+
+    @DeleteMapping("/{trackId}")
+    public ResponseEntity<BaseResponse<Void>> deleteTrack(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long playlistId,
+            @PathVariable Long trackId
+    ) {
+        playlistTrackService.deleteTrack(userId, playlistId, trackId);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "플레이리스트 트랙 삭제 성공", null)
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/playlisttrack/dto/request/PlaylistTrackCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/dto/request/PlaylistTrackCreateRequest.java
@@ -1,0 +1,9 @@
+package com.fivefy.domain.playlisttrack.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PlaylistTrackCreateRequest(
+        @NotNull(message = "트랙 ID는 필수입니다")
+        Long trackId
+) {
+}

--- a/src/main/java/com/fivefy/domain/playlisttrack/dto/request/PlaylistTrackOrderUpdateRequest.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/dto/request/PlaylistTrackOrderUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.fivefy.domain.playlisttrack.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record PlaylistTrackOrderUpdateRequest(
+        @NotNull(message = "트랙 ID는 필수입니다")
+        Long trackId,
+        @NotNull(message = "트랙 순서는 필수입니다")
+        @Min(value = 1, message = "트랙 순서는 1 이상이어야 합니다")
+        Integer position
+) {
+}

--- a/src/main/java/com/fivefy/domain/playlisttrack/dto/response/PlaylistTrackResponse.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/dto/response/PlaylistTrackResponse.java
@@ -5,7 +5,7 @@ import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
 import java.time.LocalDateTime;
 
 public record PlaylistTrackResponse(
-        Long playlistTrackId,
+        Long id,
         Long playlistId,
         Long trackId,
         Integer position,

--- a/src/main/java/com/fivefy/domain/playlisttrack/dto/response/PlaylistTrackResponse.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/dto/response/PlaylistTrackResponse.java
@@ -2,18 +2,22 @@ package com.fivefy.domain.playlisttrack.dto.response;
 
 import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
 
+import java.time.LocalDateTime;
+
 public record PlaylistTrackResponse(
         Long playlistTrackId,
         Long playlistId,
         Long trackId,
-        Integer position
+        Integer position,
+        LocalDateTime createdAt
 ) {
     public static PlaylistTrackResponse from(PlaylistTrack playlistTrack) {
         return new PlaylistTrackResponse(
                 playlistTrack.getId(),
                 playlistTrack.getPlaylistId(),
                 playlistTrack.getTrackId(),
-                playlistTrack.getPosition()
+                playlistTrack.getPosition(),
+                playlistTrack.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/playlisttrack/dto/response/PlaylistTrackResponse.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/dto/response/PlaylistTrackResponse.java
@@ -1,0 +1,19 @@
+package com.fivefy.domain.playlisttrack.dto.response;
+
+import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
+
+public record PlaylistTrackResponse(
+        Long playlistTrackId,
+        Long playlistId,
+        Long trackId,
+        Integer position
+) {
+    public static PlaylistTrackResponse from(PlaylistTrack playlistTrack) {
+        return new PlaylistTrackResponse(
+                playlistTrack.getId(),
+                playlistTrack.getPlaylistId(),
+                playlistTrack.getTrackId(),
+                playlistTrack.getPosition()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrack.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrack.java
@@ -40,4 +40,9 @@ public class PlaylistTrack extends BaseEntity {
 
         return playlistTrack;
     }
+
+    public void updatePosition(Integer position) {
+        validateNonNull(position, "position");
+        this.position = position;
+    }
 }

--- a/src/main/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrack.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrack.java
@@ -12,8 +12,18 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "playlist_tracks",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"playlist_id", "position"})
+@Table(
+        name = "playlist_tracks",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_playlist_track_playlist_position",
+                        columnNames = {"playlist_id", "position"}
+                ),
+                @UniqueConstraint(
+                        name = "uk_playlist_track_playlist_track",
+                        columnNames = {"playlist_id", "track_id"}
+                )
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlaylistTrack extends BaseEntity {

--- a/src/main/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrack.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrack.java
@@ -2,6 +2,9 @@ package com.fivefy.domain.playlisttrack.entity;
 
 import com.fivefy.common.entity.BaseEntity;
 import static com.fivefy.common.util.ValidationUtils.validateNonNull;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -43,6 +46,15 @@ public class PlaylistTrack extends BaseEntity {
 
     public void updatePosition(Integer position) {
         validateNonNull(position, "position");
+
+        if (position <= 0) {
+            throw new BusinessException(PlaylistErrorCode.INVALID_POSITION);
+        }
+
         this.position = position;
+    }
+
+    public void moveToTemporaryPosition(int tempPosition) {
+        this.position = tempPosition;
     }
 }

--- a/src/main/java/com/fivefy/domain/playlisttrack/repository/PlaylistTrackRepository.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/repository/PlaylistTrackRepository.java
@@ -1,0 +1,15 @@
+package com.fivefy.domain.playlisttrack.repository;
+
+import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PlaylistTrackRepository extends JpaRepository<PlaylistTrack, Long> {
+
+    List<PlaylistTrack> findAllByPlaylistIdOrderByPositionAsc(Long playlistId);
+    Optional<PlaylistTrack> findByPlaylistIdAndTrackId(Long playlistId, Long trackId);
+    boolean existsByPlaylistIdAndTrackId(Long playlistId, Long trackId);
+    int countByPlaylistId(Long playlistId);
+}

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.playlisttrack.service;
 
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
 import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
 import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackOrderUpdateRequest;
 import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
@@ -22,9 +23,10 @@ public class PlaylistTrackService {
     private final PlaylistTrackRepository playlistTrackRepository;
 
     @Transactional
-    public void addTrack(Long playlistId, PlaylistTrackCreateRequest request) {
+    public PlaylistTrackResponse addTrack(Long playlistId, PlaylistTrackCreateRequest request) {
+        // 동일한 플레이리스트에 같은 트랙이 이미 존재하는지 검사
         if (playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, request.trackId())) {
-            throw new BusinessException(PLAYLIST_TRACK_ALREADY_EXISTS);
+            throw new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS);
         }
 
         int nextPosition = playlistTrackRepository.countByPlaylistId(playlistId) + 1;
@@ -35,7 +37,9 @@ public class PlaylistTrackService {
                 nextPosition
         );
 
-        playlistTrackRepository.save(playlistTrack);
+        PlaylistTrack savedPlaylistTrack = playlistTrackRepository.save(playlistTrack);
+
+        return PlaylistTrackResponse.from(savedPlaylistTrack);
     }
 
     public List<PlaylistTrackResponse> getTracks(Long playlistId) {
@@ -52,12 +56,13 @@ public class PlaylistTrackService {
         PlaylistTrack target = playlistTracks.stream()
                 .filter(playlistTrack -> playlistTrack.getTrackId().equals(request.trackId()))
                 .findFirst()
-                .orElseThrow(() -> new BusinessException(PLAYLIST_TRACK_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND));
 
         int newPosition = request.position();
 
+        // 변경할 순서가 유효한 범위인지 검사
         if (newPosition < 1 || newPosition > playlistTracks.size()) {
-            throw new BusinessException(INVALID_PLAYLIST_TRACK_POSITION);
+            throw new BusinessException(PlaylistErrorCode.INVALID_PLAYLIST_TRACK_POSITION);
         }
 
         playlistTracks.remove(target);
@@ -75,7 +80,7 @@ public class PlaylistTrackService {
         PlaylistTrack target = playlistTracks.stream()
                 .filter(playlistTrack -> playlistTrack.getTrackId().equals(trackId))
                 .findFirst()
-                .orElseThrow(() -> new BusinessException(PLAYLIST_TRACK_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND));
 
         playlistTracks.remove(target);
         playlistTrackRepository.delete(target);

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -10,6 +10,7 @@ import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
 import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
 import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,9 +47,12 @@ public class PlaylistTrackService {
                 nextPosition
         );
 
-        PlaylistTrack savedPlaylistTrack = playlistTrackRepository.save(playlistTrack);
-
-        return PlaylistTrackResponse.from(savedPlaylistTrack);
+        try {
+            PlaylistTrack savedPlaylistTrack = playlistTrackRepository.save(playlistTrack);
+            return PlaylistTrackResponse.from(savedPlaylistTrack);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT);
+        }
     }
 
     public List<PlaylistTrackResponse> getTracks(Long userId, Long playlistId) {

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -1,7 +1,9 @@
 package com.fivefy.domain.playlisttrack.service;
 
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.entity.Playlist;
 import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
+import com.fivefy.domain.playlist.repository.PlaylistRepository;
 import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
 import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackOrderUpdateRequest;
 import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
@@ -13,17 +15,24 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.fivefy.domain.playlist.enums.PlaylistErrorCode.*;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PlaylistTrackService {
 
     private final PlaylistTrackRepository playlistTrackRepository;
+    private final PlaylistRepository playlistRepository;
 
     @Transactional
-    public PlaylistTrackResponse addTrack(Long playlistId, PlaylistTrackCreateRequest request) {
+    public PlaylistTrackResponse addTrack(Long userId, Long playlistId, PlaylistTrackCreateRequest request) {
+        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+                .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+        // 본인이 생성한 플레이리스트만 트랙 추가 가능
+        if (!playlist.isOwner(userId)) {
+            throw new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN);
+        }
+
         // 동일한 플레이리스트에 같은 트랙이 이미 존재하는지 검사
         if (playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, request.trackId())) {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS);
@@ -42,7 +51,15 @@ public class PlaylistTrackService {
         return PlaylistTrackResponse.from(savedPlaylistTrack);
     }
 
-    public List<PlaylistTrackResponse> getTracks(Long playlistId) {
+    public List<PlaylistTrackResponse> getTracks(Long userId, Long playlistId) {
+        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+                .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+        // 본인이 생성한 플레이리스트만 트랙 추가 가능
+        if (!playlist.isOwner(userId)) {
+            throw new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN);
+        }
+
         return playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId)
                 .stream()
                 .map(PlaylistTrackResponse::from)
@@ -50,7 +67,15 @@ public class PlaylistTrackService {
     }
 
     @Transactional
-    public void updateTrackOrder(Long playlistId, PlaylistTrackOrderUpdateRequest request) {
+    public void updateTrackOrder(Long userId, Long playlistId, PlaylistTrackOrderUpdateRequest request) {
+        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+                .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+        // 본인이 생성한 플레이리스트만 순서 변경 가능
+        if (!playlist.isOwner(userId)) {
+            throw new BusinessException(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN);
+        }
+
         List<PlaylistTrack> playlistTracks = playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId);
 
         PlaylistTrack target = playlistTracks.stream()
@@ -65,16 +90,31 @@ public class PlaylistTrackService {
             throw new BusinessException(PlaylistErrorCode.INVALID_PLAYLIST_TRACK_POSITION);
         }
 
+        // 현재 위치와 동일하면 그대로 종료
+        if (target.getPosition().equals(newPosition)) {
+            return;
+        }
+
+        // 유니크 제약 충돌 방지를 위해 대상 트랙을 임시 위치로 이동
+        target.updatePosition(-1);
+        playlistTrackRepository.flush();
+
         playlistTracks.remove(target);
         playlistTracks.add(newPosition - 1, target);
 
-        for (int i = 0; i < playlistTracks.size(); i++) {
-            playlistTracks.get(i).updatePosition(i + 1);
-        }
+        reorderPositions(playlistTracks);
     }
 
     @Transactional
-    public void deleteTrack(Long playlistId, Long trackId) {
+    public void deleteTrack(Long userId, Long playlistId, Long trackId) {
+        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+                .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+        // 본인이 생성한 플레이리스트만 삭제 가능
+        if (!playlist.isOwner(userId)) {
+            throw new BusinessException(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN);
+        }
+
         List<PlaylistTrack> playlistTracks = playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId);
 
         PlaylistTrack target = playlistTracks.stream()
@@ -85,6 +125,10 @@ public class PlaylistTrackService {
         playlistTracks.remove(target);
         playlistTrackRepository.delete(target);
 
+        reorderPositions(playlistTracks);
+    }
+
+    private void reorderPositions(List<PlaylistTrack> playlistTracks) {
         for (int i = 0; i < playlistTracks.size(); i++) {
             playlistTracks.get(i).updatePosition(i + 1);
         }

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -1,0 +1,87 @@
+package com.fivefy.domain.playlisttrack.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackOrderUpdateRequest;
+import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
+import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
+import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.fivefy.domain.playlist.enums.PlaylistErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaylistTrackService {
+
+    private final PlaylistTrackRepository playlistTrackRepository;
+
+    @Transactional
+    public void addTrack(Long playlistId, PlaylistTrackCreateRequest request) {
+        if (playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, request.trackId())) {
+            throw new BusinessException(PLAYLIST_TRACK_ALREADY_EXISTS);
+        }
+
+        int nextPosition = playlistTrackRepository.countByPlaylistId(playlistId) + 1;
+
+        PlaylistTrack playlistTrack = PlaylistTrack.create(
+                playlistId,
+                request.trackId(),
+                nextPosition
+        );
+
+        playlistTrackRepository.save(playlistTrack);
+    }
+
+    public List<PlaylistTrackResponse> getTracks(Long playlistId) {
+        return playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId)
+                .stream()
+                .map(PlaylistTrackResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void updateTrackOrder(Long playlistId, PlaylistTrackOrderUpdateRequest request) {
+        List<PlaylistTrack> playlistTracks = playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId);
+
+        PlaylistTrack target = playlistTracks.stream()
+                .filter(playlistTrack -> playlistTrack.getTrackId().equals(request.trackId()))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(PLAYLIST_TRACK_NOT_FOUND));
+
+        int newPosition = request.position();
+
+        if (newPosition < 1 || newPosition > playlistTracks.size()) {
+            throw new BusinessException(INVALID_PLAYLIST_TRACK_POSITION);
+        }
+
+        playlistTracks.remove(target);
+        playlistTracks.add(newPosition - 1, target);
+
+        for (int i = 0; i < playlistTracks.size(); i++) {
+            playlistTracks.get(i).updatePosition(i + 1);
+        }
+    }
+
+    @Transactional
+    public void deleteTrack(Long playlistId, Long trackId) {
+        List<PlaylistTrack> playlistTracks = playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId);
+
+        PlaylistTrack target = playlistTracks.stream()
+                .filter(playlistTrack -> playlistTrack.getTrackId().equals(trackId))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(PLAYLIST_TRACK_NOT_FOUND));
+
+        playlistTracks.remove(target);
+        playlistTrackRepository.delete(target);
+
+        for (int i = 0; i < playlistTracks.size(); i++) {
+            playlistTracks.get(i).updatePosition(i + 1);
+        }
+    }
+}

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -55,7 +55,7 @@ public class PlaylistTrackService {
         Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
-        // 본인이 생성한 플레이리스트만 트랙 추가 가능
+        // 본인이 생성한 플레이리스트만 트랙 조회 가능
         if (!playlist.isOwner(userId)) {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN);
         }
@@ -95,10 +95,6 @@ public class PlaylistTrackService {
             return;
         }
 
-        // 유니크 제약 충돌 방지를 위해 대상 트랙을 임시 위치로 이동
-        target.updatePosition(-1);
-        playlistTrackRepository.flush();
-
         playlistTracks.remove(target);
         playlistTracks.add(newPosition - 1, target);
 
@@ -124,11 +120,18 @@ public class PlaylistTrackService {
 
         playlistTracks.remove(target);
         playlistTrackRepository.delete(target);
+        playlistTrackRepository.flush(); // 삭제 먼저 DB에 반영
 
         reorderPositions(playlistTracks);
     }
 
     private void reorderPositions(List<PlaylistTrack> playlistTracks) {
+        for (int i = 0; i < playlistTracks.size(); i++) {
+            playlistTracks.get(i).moveToTemporaryPosition(-(i + 1));
+        }
+
+        playlistTrackRepository.flush(); // 전부 -1로 먼저 반영
+
         for (int i = 0; i < playlistTracks.size(); i++) {
             playlistTracks.get(i).updatePosition(i + 1);
         }

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -28,12 +28,12 @@ public class PlaylistTrackService {
         Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
-        // 본인이 생성한 플레이리스트만 트랙 추가 가능
+        // 본인 플레이리스트만 트랙 추가 가능
         if (!playlist.isOwner(userId)) {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN);
         }
 
-        // 동일한 플레이리스트에 같은 트랙이 이미 존재하는지 검사
+        // 동일 트랙 중복 추가 방지
         if (playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, request.trackId())) {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS);
         }
@@ -55,7 +55,7 @@ public class PlaylistTrackService {
         Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
-        // 본인이 생성한 플레이리스트만 트랙 조회 가능
+        // 본인 플레이리스트만 트랙 조회 가능
         if (!playlist.isOwner(userId)) {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN);
         }
@@ -71,7 +71,7 @@ public class PlaylistTrackService {
         Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
-        // 본인이 생성한 플레이리스트만 순서 변경 가능
+        // 본인 플레이리스트만 트랙 순서 변경 가능
         if (!playlist.isOwner(userId)) {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN);
         }
@@ -85,19 +85,21 @@ public class PlaylistTrackService {
 
         int newPosition = request.position();
 
-        // 변경할 순서가 유효한 범위인지 검사
+        // 이동할 위치는 1 ~ 트랙 개수 범위여야 함
         if (newPosition < 1 || newPosition > playlistTracks.size()) {
             throw new BusinessException(PlaylistErrorCode.INVALID_PLAYLIST_TRACK_POSITION);
         }
 
-        // 현재 위치와 동일하면 그대로 종료
+        // 현재 위치와 같으면 변경할 필요 없음
         if (target.getPosition().equals(newPosition)) {
             return;
         }
 
+        // 기존 위치에서 제거한 뒤, 요청한 위치에 다시 넣음
         playlistTracks.remove(target);
         playlistTracks.add(newPosition - 1, target);
 
+        // 변경된 순서대로 position 재정렬
         reorderPositions(playlistTracks);
     }
 
@@ -106,7 +108,7 @@ public class PlaylistTrackService {
         Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
-        // 본인이 생성한 플레이리스트만 삭제 가능
+        // 본인 플레이리스트만 트랙 삭제 가능
         if (!playlist.isOwner(userId)) {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN);
         }
@@ -118,20 +120,32 @@ public class PlaylistTrackService {
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND));
 
+        // 삭제 대상 트랙을 목록과 DB에서 제거
         playlistTracks.remove(target);
         playlistTrackRepository.delete(target);
-        playlistTrackRepository.flush(); // 삭제 먼저 DB에 반영
 
+        // position 충돌 방지를 위해 삭제를 먼저 DB에 반영
+        playlistTrackRepository.flush();
+
+        // 변경된 순서대로 position 재정렬
         reorderPositions(playlistTracks);
     }
 
+    /**
+     * position 중복 방지를 위해
+     * 모든 값을 음수로 변경 후 flush,
+     * 이후 1부터 순서대로 다시 할당
+     */
     private void reorderPositions(List<PlaylistTrack> playlistTracks) {
+        // 임시로 음수 position 부여 (중복 방지)
         for (int i = 0; i < playlistTracks.size(); i++) {
             playlistTracks.get(i).moveToTemporaryPosition(-(i + 1));
         }
 
-        playlistTrackRepository.flush(); // 전부 -1로 먼저 반영
+        // 변경된 음수 position을 DB에 먼저 반영
+        playlistTrackRepository.flush();
 
+        // position을 1부터 순서대로 다시 부여
         for (int i = 0; i < playlistTracks.size(); i++) {
             playlistTracks.get(i).updatePosition(i + 1);
         }


### PR DESCRIPTION
## 개요

> 플레이리스트 트랙 도메인의 기본 CRUD API(트랙 추가, 조회, 순서 변경, 삭제)를 구현했습니다.

## 변경 사항

- PlaylistTrack 엔티티 및 플레이리스트-트랙 매핑 도메인 로직 구현
- PlaylistTrackController / Service / Repository 계층 구현

- 플레이리스트 트랙 CRUD API 구현
  - 트랙 추가 (POST /api/playlists/{playlistId}/tracks)
  - 트랙 목록 조회 (GET /api/playlists/{playlistId}/tracks)
  - 트랙 순서 변경 (PATCH /api/playlists/{playlistId}/tracks/index)
  - 트랙 삭제 (DELETE /api/playlists/{playlistId}/tracks/{trackId})

- 플레이리스트 소유자 기반 권한 검증 로직 추가
- 플레이리스트 접근 권한 에러 코드 추가

- 트랙 순서 변경 시 `(playlist_id, position)` 유니크 제약 충돌 방지 로직 적용
- 순서 재정렬 로직을 `reorderPositions()` 메서드로 분리하여 중복 제거

- soft delete 데이터 검증 로직 보완

## 변경 유형

- [x] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

### 1. 트랙 추가
> POST /api/playlists/{playlistId}/tracks 호출 후 응답 확인

### 2. 트랙 목록 조회 (추가 확인)
> GET /api/playlists/{playlistId}/tracks 호출 후 position 순서 확인

### 3. 트랙 순서 변경
> PATCH /api/playlists/{playlistId}/tracks/index 호출 후 응답 확인

### 4. 트랙 순서 변경 후 목록 조회
> GET /api/playlists/{playlistId}/tracks 호출 후 position 변경 확인

### 5. 트랙 삭제
> DELETE /api/playlists/{playlistId}/tracks/{trackId} 호출 후 응답 확인

### 6. 트랙 삭제 후 목록 조회
> GET /api/playlists/{playlistId}/tracks 호출 후 삭제 및 position 재정렬 확인

## 스크린샷

- 트랙 추가 응답 body
<img width="1392" height="817" alt="image" src="https://github.com/user-attachments/assets/dae6c609-50f5-40eb-98d8-c32211b870ce" />

- 트랙 목록 조회 응답 body
<img width="1393" height="1164" alt="image" src="https://github.com/user-attachments/assets/0952d16a-2658-42d3-bf22-3cde9c5d7824" />

- 트랙 순서 변경 응답 body
<img width="1392" height="633" alt="image" src="https://github.com/user-attachments/assets/95cbbeb8-fa41-4ca2-9006-03c18d42330e" />

- 트랙 순서 변경 후 목록 조회 (before / after 비교)
<img width="1393" height="1164" alt="image" src="https://github.com/user-attachments/assets/0952d16a-2658-42d3-bf22-3cde9c5d7824" />
<img width="1393" height="1152" alt="image" src="https://github.com/user-attachments/assets/32cfaf8d-1495-4c9e-88e9-ff63ccac3dc5" />

- 트랙 삭제 응답 body
<img width="1392" height="588" alt="image" src="https://github.com/user-attachments/assets/dd37f0d2-3023-4565-a5b8-618b7a5bbcd6" />

- 트랙 삭제 후 목록 조회 (position 재정렬 확인)
<img width="1395" height="925" alt="image" src="https://github.com/user-attachments/assets/18ca330e-3852-432e-90ee-cf026bf886db" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 플레이리스트 트랙 관리 기능 추가 — 트랙 추가, 플레이리스트별 트랙 조회, 트랙 순서 변경(인덱스), 트랙 삭제 지원
* **버그 수정 / 검증 강화**
  * 이미 삭제된 플레이리스트에 대한 작업 차단
  * 트랙 중복 추가 방지 및 트랙 순서 값(최소값·범위) 검증 강화
  * 트랙 순서 재정렬 시 충돌 방지 로직 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->