### PR TITLE
feat: Like CRUD 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,12 @@ dependencies {
     asciidoctorExt 'org.asciidoctor:asciidoctorj:2.5.13'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+    // queryDSL
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.1"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.1:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // test
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,12 +79,6 @@ dependencies {
     asciidoctorExt 'org.asciidoctor:asciidoctorj:2.5.13'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-    // queryDSL
-    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.1"
-    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.1:jakarta"
-    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
     // test
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/fivefy/domain/album/enums/AlbumErrorCode.java
+++ b/src/main/java/com/fivefy/domain/album/enums/AlbumErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum AlbumErrorCode implements ErrorCode {
+    ERR_ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 앨범입니다"),
     ERR_ALBUM_ALREADY_PUBLISHED(HttpStatus.BAD_REQUEST, "이미 발매된 앨범입니다"),
     ERR_ALBUM_ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "이미 차단된 앨범입니다"),
     ERR_ALBUM_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 앨범입니다"),

--- a/src/main/java/com/fivefy/domain/like/controller/LikeController.java
+++ b/src/main/java/com/fivefy/domain/like/controller/LikeController.java
@@ -5,6 +5,7 @@ import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.domain.like.dto.request.LikeCreateRequest;
 import com.fivefy.domain.like.dto.response.LikeCreateResponse;
 import com.fivefy.domain.like.dto.response.LikeGetResponse;
+import com.fivefy.domain.like.enums.TargetType;
 import com.fivefy.domain.like.service.LikeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,8 +39,9 @@ public class LikeController {
     @GetMapping("/likes")
     public ResponseEntity<BaseResponse<PageResponse<LikeGetResponse>>> getAllLike(
             @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) TargetType targetType,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable) {
-        Page<LikeGetResponse> responses = likeService.getLikes(userId, pageable);
+        Page<LikeGetResponse> responses = likeService.getLikes(userId, targetType, pageable);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.success(HttpStatus.OK, "좋아요 목록 조회 성공", PageResponse.from(responses)));

--- a/src/main/java/com/fivefy/domain/like/controller/LikeController.java
+++ b/src/main/java/com/fivefy/domain/like/controller/LikeController.java
@@ -1,18 +1,21 @@
 package com.fivefy.domain.like.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.domain.like.dto.request.LikeCreateRequest;
 import com.fivefy.domain.like.dto.response.LikeCreateResponse;
+import com.fivefy.domain.like.dto.response.LikeGetResponse;
 import com.fivefy.domain.like.service.LikeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api")
 @RestController
@@ -30,5 +33,15 @@ public class LikeController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(BaseResponse.success(HttpStatus.CREATED, "좋아요 등록 성공", response));
+    }
+
+    @GetMapping("/likes")
+    public ResponseEntity<BaseResponse<PageResponse<LikeGetResponse>>> getAllLike(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable) {
+        Page<LikeGetResponse> responses = likeService.getLikes(userId, pageable);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(HttpStatus.OK, "좋아요 목록 조회 성공", PageResponse.from(responses)));
     }
 }

--- a/src/main/java/com/fivefy/domain/like/controller/LikeController.java
+++ b/src/main/java/com/fivefy/domain/like/controller/LikeController.java
@@ -44,4 +44,13 @@ public class LikeController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.success(HttpStatus.OK, "좋아요 목록 조회 성공", PageResponse.from(responses)));
     }
+
+    @DeleteMapping("/likes/{likeId}")
+    public ResponseEntity<BaseResponse> deleteLike(
+            @AuthenticationPrincipal Long userId, @PathVariable Long likeId) {
+        likeService.deleteLike(userId, likeId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(HttpStatus.OK, "좋아요 취소 성공", null));
+    }
 }

--- a/src/main/java/com/fivefy/domain/like/controller/LikeController.java
+++ b/src/main/java/com/fivefy/domain/like/controller/LikeController.java
@@ -1,0 +1,34 @@
+package com.fivefy.domain.like.controller;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.domain.like.dto.request.LikeCreateRequest;
+import com.fivefy.domain.like.dto.response.LikeCreateResponse;
+import com.fivefy.domain.like.service.LikeService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/likes")
+    public ResponseEntity<BaseResponse<LikeCreateResponse>> createLike(
+            @Valid @RequestBody LikeCreateRequest request,
+            @AuthenticationPrincipal Long userId) {
+        LikeCreateResponse response = likeService.createLike(
+                request.targetId(), request.targetType(), userId);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(BaseResponse.success(HttpStatus.CREATED, "좋아요 등록 성공", response));
+    }
+}

--- a/src/main/java/com/fivefy/domain/like/dto/request/LikeCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/like/dto/request/LikeCreateRequest.java
@@ -1,0 +1,13 @@
+package com.fivefy.domain.like.dto.request;
+
+import com.fivefy.domain.like.enums.TargetType;
+import jakarta.validation.constraints.NotNull;
+
+public record LikeCreateRequest (
+
+        @NotNull (message = "targetId(은)는 필수 입니다")
+        Long targetId,
+        @NotNull (message = "targetType(은)는 필수 입니다")
+        TargetType targetType
+){
+}

--- a/src/main/java/com/fivefy/domain/like/dto/response/LikeCreateResponse.java
+++ b/src/main/java/com/fivefy/domain/like/dto/response/LikeCreateResponse.java
@@ -1,0 +1,23 @@
+package com.fivefy.domain.like.dto.response;
+
+import com.fivefy.domain.like.entity.Like;
+import com.fivefy.domain.like.enums.TargetType;
+
+import java.time.LocalDateTime;
+
+public record LikeCreateResponse (
+
+        Long id,
+        Long targetId,
+        TargetType targetType,
+        LocalDateTime createdAt
+){
+    public static LikeCreateResponse from(Like like) {
+        return new LikeCreateResponse(
+                like.getId(),
+                like.getTargetId(),
+                like.getTargetType(),
+                like.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/like/dto/response/LikeGetResponse.java
+++ b/src/main/java/com/fivefy/domain/like/dto/response/LikeGetResponse.java
@@ -1,6 +1,5 @@
 package com.fivefy.domain.like.dto.response;
 
-import com.fivefy.domain.like.entity.Like;
 import com.fivefy.domain.like.enums.TargetType;
 
 import java.time.LocalDateTime;
@@ -14,14 +13,4 @@ public record LikeGetResponse (
         String artistName,
         LocalDateTime createdAt
 ){
-    public static LikeGetResponse from(Like like, String targetName, String artistName) {
-        return new LikeGetResponse(
-                like.getId(),
-                like.getTargetId(),
-                like.getTargetType(),
-                targetName,
-                artistName,
-                like.getCreatedAt()
-        );
-    }
 }

--- a/src/main/java/com/fivefy/domain/like/dto/response/LikeGetResponse.java
+++ b/src/main/java/com/fivefy/domain/like/dto/response/LikeGetResponse.java
@@ -1,0 +1,27 @@
+package com.fivefy.domain.like.dto.response;
+
+import com.fivefy.domain.like.entity.Like;
+import com.fivefy.domain.like.enums.TargetType;
+
+import java.time.LocalDateTime;
+
+public record LikeGetResponse (
+
+        Long id,
+        Long targetId,
+        TargetType targetType,
+        String targetName,
+        String artistName,
+        LocalDateTime createdAt
+){
+    public static LikeGetResponse from(Like like, String targetName, String artistName) {
+        return new LikeGetResponse(
+                like.getId(),
+                like.getTargetId(),
+                like.getTargetType(),
+                targetName,
+                artistName,
+                like.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/like/enums/LikeErrorCode.java
+++ b/src/main/java/com/fivefy/domain/like/enums/LikeErrorCode.java
@@ -1,0 +1,19 @@
+package com.fivefy.domain.like.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum LikeErrorCode implements ErrorCode {
+
+    ERR_LIKE_INVALID_TARGET_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 타겟 ID입니다"),
+    ERR_LIKE_INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 타겟 타입입니다"),
+    ERR_LIKE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 좋아요한 대상입니다"),
+    ERR_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요가 존재하지 않습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/like/repository/LikeQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/like/repository/LikeQueryRepository.java
@@ -1,0 +1,11 @@
+package com.fivefy.domain.like.repository;
+
+import com.fivefy.domain.like.dto.response.LikeGetResponse;
+import com.fivefy.domain.like.enums.TargetType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LikeQueryRepository {
+
+    Page<LikeGetResponse> findLikesWithTarget(Long userId, TargetType targetType, Pageable pageable);
+}

--- a/src/main/java/com/fivefy/domain/like/repository/LikeQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/like/repository/LikeQueryRepositoryImpl.java
@@ -51,6 +51,7 @@ public class LikeQueryRepositoryImpl implements LikeQueryRepository {
                         .and(like.targetType.eq(TargetType.ALBUM)))
                 .leftJoin(artist).on(artist.id.eq(track.artistId.coalesce(album.artistId)))
                 .where(condition)
+                .orderBy(like.createdAt.asc(), like.id.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/fivefy/domain/like/repository/LikeQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/like/repository/LikeQueryRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.fivefy.domain.like.repository;
+
+import com.fivefy.domain.album.entity.QAlbum;
+import com.fivefy.domain.artist.entity.QArtist;
+import com.fivefy.domain.like.dto.response.LikeGetResponse;
+import com.fivefy.domain.like.entity.QLike;
+import com.fivefy.domain.like.enums.TargetType;
+import com.fivefy.domain.track.entity.QTrack;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class LikeQueryRepositoryImpl implements LikeQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final QLike like = QLike.like;
+    private final QTrack track = QTrack.track;
+    private final QAlbum album = QAlbum.album;
+    private final QArtist artist = QArtist.artist;
+
+    @Override
+    public Page<LikeGetResponse> findLikesWithTarget(
+            Long userId, TargetType targetType, Pageable pageable) {
+        BooleanExpression condition = like.userId.eq(userId);
+
+        if (targetType != null) {
+            condition = condition.and(like.targetType.eq(targetType));
+        }
+
+        List<LikeGetResponse> results = queryFactory
+                .select(Projections.constructor(LikeGetResponse.class,
+                        like.id,
+                        like.targetId,
+                        like.targetType,
+                        track.title.coalesce(album.title),
+                        artist.name,
+                        like.createdAt
+                ))
+                .from(like)
+                .leftJoin(track).on(track.id.eq(like.targetId)
+                        .and(like.targetType.eq(TargetType.TRACK)))
+                .leftJoin(album).on(album.id.eq(like.targetId)
+                        .and(like.targetType.eq(TargetType.ALBUM)))
+                .leftJoin(artist).on(artist.id.eq(track.artistId.coalesce(album.artistId)))
+                .where(condition)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(like.count())
+                .from(like)
+                .where(condition)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+}

--- a/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
@@ -1,0 +1,9 @@
+package com.fivefy.domain.like.repository;
+
+import com.fivefy.domain.like.entity.Like;
+import com.fivefy.domain.like.enums.TargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+    boolean existsByUserIdAndTargetIdAndTargetType(Long userId, Long targetId, TargetType targetType);
+}

--- a/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
@@ -2,16 +2,12 @@ package com.fivefy.domain.like.repository;
 
 import com.fivefy.domain.like.entity.Like;
 import com.fivefy.domain.like.enums.TargetType;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface LikeRepository extends JpaRepository<Like, Long> {
+public interface LikeRepository extends JpaRepository<Like, Long>, LikeQueryRepository {
+
     boolean existsByUserIdAndTargetIdAndTargetType(Long userId, Long targetId, TargetType targetType);
-
-    Page<Like> findAllByUserId(Long userId, Pageable pageable);
-
     Optional<Like> findByIdAndUserId(Long likeId, Long userId);
 }

--- a/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
@@ -2,8 +2,12 @@ package com.fivefy.domain.like.repository;
 
 import com.fivefy.domain.like.entity.Like;
 import com.fivefy.domain.like.enums.TargetType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUserIdAndTargetIdAndTargetType(Long userId, Long targetId, TargetType targetType);
+
+    Page<Like> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/fivefy/domain/like/repository/LikeRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUserIdAndTargetIdAndTargetType(Long userId, Long targetId, TargetType targetType);
 
     Page<Like> findAllByUserId(Long userId, Pageable pageable);
+
+    Optional<Like> findByIdAndUserId(Long likeId, Long userId);
 }

--- a/src/main/java/com/fivefy/domain/like/service/LikeService.java
+++ b/src/main/java/com/fivefy/domain/like/service/LikeService.java
@@ -74,6 +74,16 @@ public class LikeService {
                 });
     }
 
+    @Transactional
+    public void deleteLike(Long userId, Long likeId) {
+        getUser(userId);
+
+        Like like = likeRepository.findByIdAndUserId(likeId, userId)
+                .orElseThrow(() -> new BusinessException(LikeErrorCode.ERR_LIKE_NOT_FOUND));
+
+        likeRepository.delete(like);
+    }
+
     // 검증 헬퍼 메서드
     private User getUser(Long userId) {
         return userRepository.findById(userId)

--- a/src/main/java/com/fivefy/domain/like/service/LikeService.java
+++ b/src/main/java/com/fivefy/domain/like/service/LikeService.java
@@ -1,18 +1,14 @@
 package com.fivefy.domain.like.service;
 
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.album.entity.Album;
-import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.album.enums.AlbumErrorCode;
 import com.fivefy.domain.album.repository.AlbumRepository;
-import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.like.dto.response.LikeCreateResponse;
 import com.fivefy.domain.like.dto.response.LikeGetResponse;
 import com.fivefy.domain.like.entity.Like;
 import com.fivefy.domain.like.enums.LikeErrorCode;
 import com.fivefy.domain.like.enums.TargetType;
 import com.fivefy.domain.like.repository.LikeRepository;
-import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
@@ -25,6 +21,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+// TODO: Track/Album 삭제 시 연관 Like 삭제 처리 필요 / 방안: 이벤트 방식
+
 @Service
 @RequiredArgsConstructor
 public class LikeService {
@@ -33,7 +31,6 @@ public class LikeService {
     private final UserRepository userRepository;
     private final TrackRepository trackRepository;
     private final AlbumRepository albumRepository;
-    private final ArtistRepository artistRepository;
 
     @Transactional
     public LikeCreateResponse createLike(Long targetId, TargetType targetType, Long userId) {
@@ -55,23 +52,10 @@ public class LikeService {
     }
 
     @Transactional(readOnly = true)
-    public Page<LikeGetResponse> getLikes(Long userId, Pageable pageable) {
+    public Page<LikeGetResponse> getLikes(Long userId, TargetType targetType, Pageable pageable) {
         getUser(userId);
 
-        return likeRepository.findAllByUserId(userId, pageable)
-                .map(like -> {
-                    if (like.getTargetType() == TargetType.TRACK) {
-                        Track track = trackRepository.findById(like.getTargetId())
-                                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
-                        String artistName = getArtistName(track.getArtistId());
-                        return LikeGetResponse.from(like, track.getTitle(), artistName);
-                    } else {
-                        Album album = albumRepository.findById(like.getTargetId())
-                                .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND));
-                        String artistName = getArtistName(album.getArtistId());
-                        return LikeGetResponse.from(like, album.getTitle(), artistName);
-                    }
-                });
+        return likeRepository.findLikesWithTarget(userId, targetType, pageable);
     }
 
     @Transactional
@@ -99,12 +83,5 @@ public class LikeService {
                     .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND))
                     .getId();
         };
-    }
-
-    private String getArtistName(Long artistId) {
-        if (artistId == null) return null;
-        return artistRepository.findById(artistId)
-                .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND))
-                .getName();
     }
 }

--- a/src/main/java/com/fivefy/domain/like/service/LikeService.java
+++ b/src/main/java/com/fivefy/domain/like/service/LikeService.java
@@ -1,13 +1,18 @@
 package com.fivefy.domain.like.service;
 
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.entity.Album;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.album.enums.AlbumErrorCode;
 import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.like.dto.response.LikeCreateResponse;
+import com.fivefy.domain.like.dto.response.LikeGetResponse;
 import com.fivefy.domain.like.entity.Like;
 import com.fivefy.domain.like.enums.LikeErrorCode;
 import com.fivefy.domain.like.enums.TargetType;
 import com.fivefy.domain.like.repository.LikeRepository;
+import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
@@ -15,6 +20,8 @@ import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +33,7 @@ public class LikeService {
     private final UserRepository userRepository;
     private final TrackRepository trackRepository;
     private final AlbumRepository albumRepository;
+    private final ArtistRepository artistRepository;
 
     @Transactional
     public LikeCreateResponse createLike(Long targetId, TargetType targetType, Long userId) {
@@ -46,6 +54,26 @@ public class LikeService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public Page<LikeGetResponse> getLikes(Long userId, Pageable pageable) {
+        getUser(userId);
+
+        return likeRepository.findAllByUserId(userId, pageable)
+                .map(like -> {
+                    if (like.getTargetType() == TargetType.TRACK) {
+                        Track track = trackRepository.findById(like.getTargetId())
+                                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+                        String artistName = getArtistName(track.getArtistId());
+                        return LikeGetResponse.from(like, track.getTitle(), artistName);
+                    } else {
+                        Album album = albumRepository.findById(like.getTargetId())
+                                .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND));
+                        String artistName = getArtistName(album.getArtistId());
+                        return LikeGetResponse.from(like, album.getTitle(), artistName);
+                    }
+                });
+    }
+
     // 검증 헬퍼 메서드
     private User getUser(Long userId) {
         return userRepository.findById(userId)
@@ -61,5 +89,12 @@ public class LikeService {
                     .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND))
                     .getId();
         };
+    }
+
+    private String getArtistName(Long artistId) {
+        if (artistId == null) return null;
+        return artistRepository.findById(artistId)
+                .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND))
+                .getName();
     }
 }

--- a/src/main/java/com/fivefy/domain/like/service/LikeService.java
+++ b/src/main/java/com/fivefy/domain/like/service/LikeService.java
@@ -1,0 +1,65 @@
+package com.fivefy.domain.like.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.enums.AlbumErrorCode;
+import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.like.dto.response.LikeCreateResponse;
+import com.fivefy.domain.like.entity.Like;
+import com.fivefy.domain.like.enums.LikeErrorCode;
+import com.fivefy.domain.like.enums.TargetType;
+import com.fivefy.domain.like.repository.LikeRepository;
+import com.fivefy.domain.track.enums.TrackErrorCode;
+import com.fivefy.domain.track.repository.TrackRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final UserRepository userRepository;
+    private final TrackRepository trackRepository;
+    private final AlbumRepository albumRepository;
+
+    @Transactional
+    public LikeCreateResponse createLike(Long targetId, TargetType targetType, Long userId) {
+        User user = getUser(userId);
+        Long validatedTargetId = getValidatedTargetId(targetId, targetType);
+
+        // 중복 방지
+        if (likeRepository.existsByUserIdAndTargetIdAndTargetType(userId, validatedTargetId, targetType)) {
+            throw new BusinessException(LikeErrorCode.ERR_LIKE_ALREADY_EXISTS);
+        }
+
+        try {
+            Like like = Like.create(user.getId(), validatedTargetId, targetType);
+            likeRepository.save(like);
+            return LikeCreateResponse.from(like);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(LikeErrorCode.ERR_LIKE_ALREADY_EXISTS);
+        }
+    }
+
+    // 검증 헬퍼 메서드
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
+    }
+
+    private Long getValidatedTargetId(Long targetId, TargetType targetType) {
+        return switch (targetType) {
+            case TRACK -> trackRepository.findById(targetId)
+                    .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND))
+                    .getId();
+            case ALBUM -> albumRepository.findById(targetId)
+                    .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND))
+                    .getId();
+        };
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/enums/TrackErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum TrackErrorCode implements ErrorCode {
+    ERR_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지않는 트랙입니다"),
     ERR_TRACK_ALREADY_PUBLISHED(HttpStatus.BAD_REQUEST, "이미 공개된 트랙입니다"),
     ERR_TRACK_ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "이미 차단된 트랙입니다"),
     ERR_TRACK_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 트랙입니다"),


### PR DESCRIPTION
## 개요
Like 도메인 전체 구현 (좋아요 등록/목록 조회/취소)
유저/타겟 검증, 동시성 중복 방어, QueryDSL 기반 조회 최적화 포함

## 변경 사항
- Like 엔티티 추가 (userId, targetId, targetType, UniqueConstraint)
- 좋아요 등록: 유저/타겟(Track, Album) 존재 여부 검증, existsBy + DataIntegrityViolationException 이중 중복 방어
- 좋아요 목록 조회: QueryDSL로 Track/Album/Artist 조인 쿼리 최적화 (N+1 → 쿼리 3번), targetType 필터링 지원
- 좋아요 취소: findByIdAndUserId로 조회 + 권한 체크 한 번에 처리
- LikeQueryRepository/Impl 추가 (QueryDSL)
- LikeErrorCode 추가 (ALREADY_EXISTS, NOT_FOUND, INVALID_TARGET_ID/TYPE)
- TODO: Track/Album 삭제 시 연관 Like 삭제 처리 필요 (이벤트 방식 고려)

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

POST /api/likes
{ "targetId": 1, "targetType": "TRACK" }

좋아요 목록 조회 (전체)
GET /api/likes

좋아요 목록 조회 (타입 필터링)
GET /api/likes?targetType=TRACK

좋아요 취소
DELETE /api/likes/{likeId}

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 트랙과 앨범에 좋아요 기능을 추가했습니다.
  * 사용자가 좋아요한 항목을 조회, 추가, 삭제할 수 있습니다.
  * 페이지네이션을 지원하여 좋아요 목록을 효율적으로 조회할 수 있습니다.

* **개선 사항**
  * 앨범 및 트랙 미존재 시 명확한 오류 메시지를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->