### PR TITLE
test: 플레이리스트 및 트랙 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
@@ -1,0 +1,341 @@
+package com.fivefy.domain.playlist.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.contoller.PlaylistController;
+import com.fivefy.domain.playlist.dto.request.PlaylistCreateRequest;
+import com.fivefy.domain.playlist.dto.request.PlaylistUpdateRequest;
+import com.fivefy.domain.playlist.dto.response.PlaylistDeleteResponse;
+import com.fivefy.domain.playlist.dto.response.PlaylistResponse;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
+import com.fivefy.domain.playlist.service.PlaylistService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PlaylistController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlaylistControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private PlaylistService playlistService;
+    @MockitoBean private JwtUtil jwtUtil;
+
+    @Nested
+    @DisplayName("플레이리스트 생성")
+    class CreatePlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 생성 성공 시 201 반환")
+        void createPlaylistSuccess() throws Exception {
+            // given
+            PlaylistCreateRequest request = new PlaylistCreateRequest("운동할 때 듣는 노래", "신나는 음악 모음");
+            PlaylistResponse response = new PlaylistResponse(
+                    1L,
+                    100L,
+                    "운동할 때 듣는 노래",
+                    "신나는 음악 모음",
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    null
+            );
+
+            given(playlistService.createPlaylist(any(), any(PlaylistCreateRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/playlists")
+                            .param("userId", "1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 생성 성공"))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.title").value("운동할 때 듣는 노래"))
+                    .andExpect(jsonPath("$.data.description").value("신나는 음악 모음"));
+        }
+
+        @Test
+        @DisplayName("제목 없이 생성 요청 시 400 반환")
+        void createPlaylistWithoutTitle() throws Exception {
+            // given
+            PlaylistCreateRequest request = new PlaylistCreateRequest("", "설명");
+
+            // when & then
+            mockMvc.perform(post("/api/playlists")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("제목이 100자를 초과하면 400 반환")
+        void createPlaylistWithTooLongTitle() throws Exception {
+            // given
+            String longTitle = "a".repeat(101);
+            PlaylistCreateRequest request = new PlaylistCreateRequest(longTitle, "설명");
+
+            // when & then
+            mockMvc.perform(post("/api/playlists")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("중복 제목으로 생성 시 409 반환")
+        void createPlaylistWithDuplicateName() throws Exception {
+            // given
+            PlaylistCreateRequest request = new PlaylistCreateRequest("중복 제목", "설명");
+
+            given(playlistService.createPlaylist(any(), any(PlaylistCreateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME));
+
+            // when & then
+            mockMvc.perform(post("/api/playlists")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 목록 조회")
+    class GetPlaylists {
+
+        @Test
+        @DisplayName("플레이리스트 목록 조회 성공 시 200 반환")
+        void getPlaylistsSuccess() throws Exception {
+            // given
+            PlaylistResponse playlist1 = new PlaylistResponse(
+                    1L, 100L, "플리1", "설명1",
+                    LocalDateTime.now(), LocalDateTime.now(), null
+            );
+            PlaylistResponse playlist2 = new PlaylistResponse(
+                    2L, 101L, "플리2", "설명2",
+                    LocalDateTime.now(), LocalDateTime.now(), null
+            );
+
+            PageResponse<PlaylistResponse> response = new PageResponse<>(
+                    List.of(playlist1, playlist2),
+                    0,
+                    20,
+                    2L,
+                    1
+            );
+
+            given(playlistService.getPlaylists(any(Pageable.class))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/playlists")
+                            .param("page", "0")
+                            .param("size", "20"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 목록 조회 성공"))
+                    .andExpect(jsonPath("$.data.content.length()").value(2))
+                    .andExpect(jsonPath("$.data.content[0].title").value("플리1"))
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(20))
+                    .andExpect(jsonPath("$.data.totalElements").value(2))
+                    .andExpect(jsonPath("$.data.totalPages").value(1));
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 단건 조회")
+    class GetPlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 조회 성공 시 200 반환")
+        void getPlaylistSuccess() throws Exception {
+            // given
+            PlaylistResponse response = new PlaylistResponse(
+                    1L,
+                    100L,
+                    "내 플레이리스트",
+                    "설명",
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    null
+            );
+
+            given(playlistService.getPlaylist(1L)).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/playlists/1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 조회 성공"))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.title").value("내 플레이리스트"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플레이리스트 조회 시 404 반환")
+        void getPlaylistNotFound() throws Exception {
+            // given
+            given(playlistService.getPlaylist(1L))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/playlists/1"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 수정")
+    class UpdatePlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 수정 성공 시 200 반환")
+        void updatePlaylistSuccess() throws Exception {
+            // given
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("수정된 제목", "수정된 설명");
+            PlaylistResponse response = new PlaylistResponse(
+                    1L,
+                    100L,
+                    "수정된 제목",
+                    "수정된 설명",
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    null
+            );
+
+            given(playlistService.updatePlaylist(any(), eq(1L), any(PlaylistUpdateRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 수정 성공"))
+                    .andExpect(jsonPath("$.data.title").value("수정된 제목"))
+                    .andExpect(jsonPath("$.data.description").value("수정된 설명"));
+        }
+
+        @Test
+        @DisplayName("제목 없이 수정 요청 시 400 반환")
+        void updatePlaylistWithoutTitle() throws Exception {
+            // given
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("", "설명");
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("본인 소유가 아닌 플레이리스트 수정 시 403 반환")
+        void updatePlaylistForbidden() throws Exception {
+            // given
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("수정 제목", "설명");
+
+            given(playlistService.updatePlaylist(any(), eq(1L), any(PlaylistUpdateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN));
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage()));
+        }
+
+        @Test
+        @DisplayName("중복 제목으로 수정 시 409 반환")
+        void updatePlaylistDuplicateName() throws Exception {
+            // given
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("중복 제목", "설명");
+
+            given(playlistService.updatePlaylist(any(), eq(1L), any(PlaylistUpdateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME));
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 삭제")
+    class DeletePlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 삭제 성공 시 200 반환")
+        void deletePlaylistSuccess() throws Exception {
+            // given
+            PlaylistDeleteResponse response = new PlaylistDeleteResponse(
+                    1L,
+                    LocalDateTime.now()
+            );
+
+            given(playlistService.deletePlaylist(any(), eq(1L))).willReturn(response);
+
+            // when & then
+            mockMvc.perform(delete("/api/playlists/1"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 삭제 성공"))
+                    .andExpect(jsonPath("$.data.id").value(1L));
+        }
+
+        @Test
+        @DisplayName("본인 소유가 아닌 플레이리스트 삭제 시 403 반환")
+        void deletePlaylistForbidden() throws Exception {
+            // given
+            given(playlistService.deletePlaylist(any(), eq(1L)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN));
+
+            // when & then
+            mockMvc.perform(delete("/api/playlists/1"))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage()));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플레이리스트 삭제 시 404 반환")
+        void deletePlaylistNotFound() throws Exception {
+            // given
+            given(playlistService.deletePlaylist(any(), eq(1L)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(delete("/api/playlists/1"))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
@@ -272,6 +272,23 @@ class PlaylistControllerTest {
         }
 
         @Test
+        @DisplayName("존재하지 않는 플레이리스트 수정 시 404 반환")
+        void updatePlaylistNotFound() throws Exception {
+            // given
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("수정 제목", "설명");
+
+            given(playlistService.updatePlaylist(any(), eq(1L), any(PlaylistUpdateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+        }
+
+        @Test
         @DisplayName("중복 제목으로 수정 시 409 반환")
         void updatePlaylistDuplicateName() throws Exception {
             // given

--- a/src/test/java/com/fivefy/domain/playlist/entity/PlaylistTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/entity/PlaylistTest.java
@@ -1,0 +1,145 @@
+package com.fivefy.domain.playlist.entity;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PlaylistTest {
+
+    @Test
+    @DisplayName("플레이리스트 생성 성공")
+    void create_success() {
+        // given
+        Long userId = 1L;
+        String title = "title";
+        String description = "desc";
+
+        // when
+        Playlist playlist = Playlist.create(userId, title, description);
+
+        // then
+        assertThat(playlist.getUserId()).isEqualTo(userId);
+        assertThat(playlist.getTitle()).isEqualTo(title);
+        assertThat(playlist.getDescription()).isEqualTo(description);
+        assertThat(playlist.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("플레이리스트 생성 시 제목이 null이면 예외 발생")
+    void create_invalid_title_null() {
+        assertThatThrownBy(() ->
+                Playlist.create(1L, null, "desc")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.INVALID_TITLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("플레이리스트 생성 시 제목이 blank면 예외 발생")
+    void create_invalid_title_blank() {
+        assertThatThrownBy(() ->
+                Playlist.create(1L, "", "desc")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.INVALID_TITLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("플레이리스트 생성 시 제목이 100자를 초과하면 예외 발생")
+    void create_invalid_title_too_long() {
+        String tooLongTitle = "a".repeat(101);
+
+        assertThatThrownBy(() ->
+                Playlist.create(1L, tooLongTitle, "desc")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.INVALID_TITLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("플레이리스트 수정 성공")
+    void update_success() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+
+        // when
+        playlist.update("new", "newDesc");
+
+        // then
+        assertThat(playlist.getTitle()).isEqualTo("new");
+        assertThat(playlist.getDescription()).isEqualTo("newDesc");
+    }
+
+    @Test
+    @DisplayName("플레이리스트 수정 시 제목이 null이면 예외 발생")
+    void update_invalid_title_null() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+
+        // when & then
+        assertThatThrownBy(() ->
+                playlist.update(null, "desc")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.INVALID_TITLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("플레이리스트 수정 시 제목이 blank면 예외 발생")
+    void update_invalid_title_blank() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+
+        // when & then
+        assertThatThrownBy(() ->
+                playlist.update("", "desc")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.INVALID_TITLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("플레이리스트 수정 시 제목이 100자를 초과하면 예외 발생")
+    void update_invalid_title_too_long() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+        String tooLongTitle = "a".repeat(101);
+
+        // when & then
+        assertThatThrownBy(() ->
+                playlist.update(tooLongTitle, "desc")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.INVALID_TITLE.getMessage());
+    }
+
+    @Test
+    @DisplayName("플레이리스트 삭제 성공")
+    void delete_success() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+
+        // when
+        playlist.delete();
+
+        // then
+        assertThat(playlist.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 플레이리스트를 다시 삭제하면 예외 발생")
+    void delete_already_deleted() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+        playlist.delete();
+
+        // when & then
+        assertThatThrownBy(playlist::delete)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.ALREADY_DELETED_PLAYLIST.getMessage());
+    }
+}

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -1,0 +1,347 @@
+package com.fivefy.domain.playlist.service;
+
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.dto.request.PlaylistCreateRequest;
+import com.fivefy.domain.playlist.dto.request.PlaylistUpdateRequest;
+import com.fivefy.domain.playlist.dto.response.PlaylistDeleteResponse;
+import com.fivefy.domain.playlist.dto.response.PlaylistResponse;
+import com.fivefy.domain.playlist.entity.Playlist;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
+import com.fivefy.domain.playlist.repository.PlaylistRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PlaylistServiceTest {
+
+    @InjectMocks private PlaylistService playlistService;
+
+    @Mock private PlaylistRepository playlistRepository;
+
+    @Nested
+    @DisplayName("플레이리스트 생성")
+    class CreatePlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 생성 성공")
+        void createPlaylistSuccess() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            Playlist playlist = Playlist.create(userId, request.title(), request.description());
+            ReflectionTestUtils.setField(playlist, "id", 1L);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+                    .willReturn(false);
+            given(playlistRepository.save(any(Playlist.class))).willReturn(playlist);
+
+            // when
+            PlaylistResponse result = playlistService.createPlaylist(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.userId()).isEqualTo(userId);
+            assertThat(result.title()).isEqualTo("내 플레이리스트");
+            assertThat(result.description()).isEqualTo("설명");
+
+            verify(playlistRepository, times(1))
+                    .existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title());
+            verify(playlistRepository, times(1)).save(any(Playlist.class));
+        }
+
+        @Test
+        @DisplayName("중복 제목이면 예외 발생")
+        void createPlaylistDuplicateName() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("중복 제목", "설명");
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
+
+            verify(playlistRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 목록 조회")
+    class GetPlaylists {
+
+        @Test
+        @DisplayName("플레이리스트 목록 조회 성공")
+        void getPlaylistsSuccess() {
+            // given
+            Pageable pageable = PageRequest.of(0, 20);
+
+            Playlist playlist1 = Playlist.create(1L, "플리1", "설명1");
+            Playlist playlist2 = Playlist.create(2L, "플리2", "설명2");
+
+            ReflectionTestUtils.setField(playlist1, "id", 1L);
+            ReflectionTestUtils.setField(playlist2, "id", 2L);
+
+            Page<Playlist> page = new PageImpl<>(List.of(playlist1, playlist2), pageable, 2);
+
+            given(playlistRepository.findAllByDeletedAtIsNull(pageable)).willReturn(page);
+
+            // when
+            PageResponse<PlaylistResponse> result = playlistService.getPlaylists(pageable);
+
+            // then
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.page()).isEqualTo(0);
+            assertThat(result.size()).isEqualTo(20);
+            assertThat(result.totalElements()).isEqualTo(2L);
+            assertThat(result.totalPages()).isEqualTo(1);
+            assertThat(result.content().get(0).title()).isEqualTo("플리1");
+            assertThat(result.content().get(1).title()).isEqualTo("플리2");
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 단건 조회")
+    class GetPlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 단건 조회 성공")
+        void getPlaylistSuccess() {
+            // given
+            Long playlistId = 1L;
+
+            Playlist playlist = Playlist.create(1L, "내 플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when
+            PlaylistResponse result = playlistService.getPlaylist(playlistId);
+
+            // then
+            assertThat(result.id()).isEqualTo(playlistId);
+            assertThat(result.title()).isEqualTo("내 플리");
+            assertThat(result.description()).isEqualTo("설명");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플레이리스트 조회 시 예외 발생")
+        void getPlaylistNotFound() {
+            // given
+            Long playlistId = 1L;
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.getPlaylist(playlistId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 수정")
+    class UpdatePlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 수정 성공")
+        void updatePlaylistSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("수정된 제목", "수정된 설명");
+
+            Playlist playlist = Playlist.create(userId, "기존 제목", "기존 설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+                    .willReturn(false);
+
+            // when
+            PlaylistResponse result = playlistService.updatePlaylist(userId, playlistId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(playlistId);
+            assertThat(result.title()).isEqualTo("수정된 제목");
+            assertThat(result.description()).isEqualTo("수정된 설명");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플레이리스트 수정 시 예외 발생")
+        void updatePlaylistNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("수정 제목", "설명");
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.updatePlaylist(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("본인 소유가 아닌 플레이리스트 수정 시 예외 발생")
+        void updatePlaylistForbidden() {
+            // given
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Long playlistId = 1L;
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("수정 제목", "설명");
+
+            Playlist playlist = Playlist.create(otherUserId, "기존 제목", "기존 설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.updatePlaylist(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage());
+
+            verify(playlistRepository, never())
+                    .existsByUserIdAndTitleAndDeletedAtIsNull(anyLong(), anyString());
+        }
+
+        @Test
+        @DisplayName("제목이 변경되었고 중복 제목이면 예외 발생")
+        void updatePlaylistDuplicateName() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("새 제목", "설명");
+
+            Playlist playlist = Playlist.create(userId, "기존 제목", "기존 설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.updatePlaylist(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
+        }
+
+        @Test
+        @DisplayName("제목이 변경되지 않으면 중복 체크 없이 수정 성공")
+        void updatePlaylistSameTitleSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistUpdateRequest request = new PlaylistUpdateRequest("기존 제목", "새 설명");
+
+            Playlist playlist = Playlist.create(userId, "기존 제목", "기존 설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when
+            PlaylistResponse result = playlistService.updatePlaylist(userId, playlistId, request);
+
+            // then
+            assertThat(result.title()).isEqualTo("기존 제목");
+            assertThat(result.description()).isEqualTo("새 설명");
+
+            verify(playlistRepository, never())
+                    .existsByUserIdAndTitleAndDeletedAtIsNull(anyLong(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 삭제")
+    class DeletePlaylist {
+
+        @Test
+        @DisplayName("플레이리스트 삭제 성공")
+        void deletePlaylistSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+
+            Playlist playlist = Playlist.create(userId, "삭제할 플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when
+            PlaylistDeleteResponse result = playlistService.deletePlaylist(userId, playlistId);
+
+            // then
+            assertThat(result.id()).isEqualTo(playlistId);
+            assertThat(result.deletedAt()).isNotNull();
+            assertThat(playlist.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플레이리스트 삭제 시 예외 발생")
+        void deletePlaylistNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.deletePlaylist(userId, playlistId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("본인 소유가 아닌 플레이리스트 삭제 시 예외 발생")
+        void deletePlaylistForbidden() {
+            // given
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Long playlistId = 1L;
+
+            Playlist playlist = Playlist.create(otherUserId, "남의 플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.deletePlaylist(userId, playlistId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
@@ -229,7 +229,7 @@ public class PlaylistTrackControllerTest {
             // given
             PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 2);
 
-            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN))
+            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN))
                     .given(playlistTrackService)
                     .updateTrackOrder(any(), eq(1L), any(PlaylistTrackOrderUpdateRequest.class));
 
@@ -239,7 +239,7 @@ public class PlaylistTrackControllerTest {
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage()));
         }
 
         @Test
@@ -305,7 +305,7 @@ public class PlaylistTrackControllerTest {
         @DisplayName("플레이리스트 권한이 없으면 403 반환")
         void deleteTrackForbidden() throws Exception {
             // given
-            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN))
+            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN))
                     .given(playlistTrackService)
                     .deleteTrack(any(), eq(1L), eq(10L));
 
@@ -313,7 +313,7 @@ public class PlaylistTrackControllerTest {
             mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage()));
         }
 
         @Test

--- a/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.playlisttrack.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
 import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
 import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackOrderUpdateRequest;
 import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
@@ -20,8 +22,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -83,6 +85,60 @@ public class PlaylistTrackControllerTest {
                     .andDo(print())
                     .andExpect(status().isBadRequest());
         }
+
+        @Test
+        @DisplayName("플레이리스트 권한이 없으면 403 반환")
+        void addTrackForbidden() throws Exception {
+            // given
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            given(playlistTrackService.addTrack(any(), eq(1L), any(PlaylistTrackCreateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN));
+
+            // when & then
+            mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage()));
+        }
+
+        @Test
+        @DisplayName("플레이리스트가 존재하지 않으면 404 반환")
+        void addTrackPlaylistNotFound() throws Exception {
+            // given
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            given(playlistTrackService.addTrack(any(), eq(1L), any(PlaylistTrackCreateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("이미 추가된 트랙이면 409 반환")
+        void addTrackDuplicate() throws Exception {
+            // given
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            given(playlistTrackService.addTrack(any(), eq(1L), any(PlaylistTrackCreateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS));
+
+            // when & then
+            mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS.getMessage()));
+        }
     }
 
     @Nested
@@ -112,6 +168,20 @@ public class PlaylistTrackControllerTest {
                     .andExpect(jsonPath("$.data[0].position").value(1))
                     .andExpect(jsonPath("$.data[1].trackId").value(20L))
                     .andExpect(jsonPath("$.data[1].position").value(2));
+        }
+
+        @Test
+        @DisplayName("플레이리스트가 존재하지 않으면 404 반환")
+        void getTracksPlaylistNotFound() throws Exception {
+            // given
+            given(playlistTrackService.getTracks(any(), eq(1L)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(get("/api/playlists/{playlistId}/tracks", 1L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
         }
     }
 
@@ -152,6 +222,63 @@ public class PlaylistTrackControllerTest {
                     .andDo(print())
                     .andExpect(status().isBadRequest());
         }
+
+        @Test
+        @DisplayName("플레이리스트 권한이 없으면 403 반환")
+        void updateTrackOrderForbidden() throws Exception {
+            // given
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 2);
+
+            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN))
+                    .given(playlistTrackService)
+                    .updateTrackOrder(any(), eq(1L), any(PlaylistTrackOrderUpdateRequest.class));
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage()));
+        }
+
+        @Test
+        @DisplayName("플레이리스트가 존재하지 않으면 404 반환")
+        void updateTrackOrderPlaylistNotFound() throws Exception {
+            // given
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 2);
+
+            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND))
+                    .given(playlistTrackService)
+                    .updateTrackOrder(any(), eq(1L), any(PlaylistTrackOrderUpdateRequest.class));
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("트랙 순서 충돌 시 409 반환")
+        void updateTrackOrderConflict() throws Exception {
+            // given
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 2);
+
+            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT))
+                    .given(playlistTrackService)
+                    .updateTrackOrder(any(), eq(1L), any(PlaylistTrackOrderUpdateRequest.class));
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT.getMessage()));
+        }
     }
 
     @Nested
@@ -172,6 +299,36 @@ public class PlaylistTrackControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 트랙 삭제 성공"))
                     .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("플레이리스트 권한이 없으면 403 반환")
+        void deleteTrackForbidden() throws Exception {
+            // given
+            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN))
+                    .given(playlistTrackService)
+                    .deleteTrack(any(), eq(1L), eq(10L));
+
+            // when & then
+            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage()));
+        }
+
+        @Test
+        @DisplayName("삭제할 트랙이 존재하지 않으면 404 반환")
+        void deleteTrackNotFound() throws Exception {
+            // given
+            willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND))
+                    .given(playlistTrackService)
+                    .deleteTrack(any(), eq(1L), eq(10L));
+
+            // when & then
+            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage()));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
@@ -1,0 +1,177 @@
+package com.fivefy.domain.playlisttrack.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackOrderUpdateRequest;
+import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
+import com.fivefy.domain.playlisttrack.service.PlaylistTrackService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PlaylistTrackController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class PlaylistTrackControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockitoBean private PlaylistTrackService playlistTrackService;
+    @MockitoBean private JwtUtil jwtUtil;
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 추가")
+    class AddTrack {
+
+        @Test
+        @DisplayName("플레이리스트 트랙 추가 성공 시 201 반환")
+        void addTrackSuccess() throws Exception {
+            // given
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+            PlaylistTrackResponse response = new PlaylistTrackResponse(
+                    1L, 1L, 10L, 1, LocalDateTime.now()
+            );
+
+            given(playlistTrackService.addTrack(any(), any(), any(PlaylistTrackCreateRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 트랙 추가 성공"))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.playlistId").value(1L))
+                    .andExpect(jsonPath("$.data.trackId").value(10L))
+                    .andExpect(jsonPath("$.data.position").value(1));
+        }
+
+        @Test
+        @DisplayName("trackId가 없으면 400 반환")
+        void addTrackValidationFail() throws Exception {
+            // given
+            String invalidRequest = """
+                    {
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(invalidRequest))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 목록 조회")
+    class GetTracks {
+
+        @Test
+        @DisplayName("플레이리스트 트랙 목록 조회 성공 시 200 반환")
+        void getTracksSuccess() throws Exception {
+            // given
+            List<PlaylistTrackResponse> response = List.of(
+                    new PlaylistTrackResponse(1L, 1L, 10L, 1, LocalDateTime.now()),
+                    new PlaylistTrackResponse(2L, 1L, 20L, 2, LocalDateTime.now())
+            );
+
+            given(playlistTrackService.getTracks(any(), any()))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/playlists/{playlistId}/tracks", 1L))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 트랙 목록 조회 성공"))
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].trackId").value(10L))
+                    .andExpect(jsonPath("$.data[0].position").value(1))
+                    .andExpect(jsonPath("$.data[1].trackId").value(20L))
+                    .andExpect(jsonPath("$.data[1].position").value(2));
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 순서 변경")
+    class UpdateTrackOrder {
+
+        @Test
+        @DisplayName("플레이리스트 트랙 순서 변경 성공 시 200 반환")
+        void updateTrackOrderSuccess() throws Exception {
+            // given
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 2);
+
+            willDoNothing().given(playlistTrackService)
+                    .updateTrackOrder(any(), any(), any(PlaylistTrackOrderUpdateRequest.class));
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 트랙 순서 변경 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("position이 1 미만이면 400 반환")
+        void updateTrackOrderValidationFail() throws Exception {
+            // given
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 0);
+
+            // when & then
+            mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 삭제")
+    class DeleteTrack {
+
+        @Test
+        @DisplayName("플레이리스트 트랙 삭제 성공 시 200 반환")
+        void deleteTrackSuccess() throws Exception {
+            // given
+            willDoNothing().given(playlistTrackService)
+                    .deleteTrack(any(), any(), any());
+
+            // when & then
+            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("플레이리스트 트랙 삭제 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrackTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/entity/PlaylistTrackTest.java
@@ -1,0 +1,50 @@
+package com.fivefy.domain.playlisttrack.entity;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PlaylistTrackTest {
+
+    @Test
+    @DisplayName("트랙 순서 수정 성공")
+    void updatePosition_success() {
+        // given
+        PlaylistTrack track = PlaylistTrack.create(1L, 10L, 1);
+
+        // when
+        track.updatePosition(2);
+
+        // then
+        assertThat(track.getPosition()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("트랙 순서 수정 실패 - 유효하지 않은 위치")
+    void updatePosition_invalid() {
+        // given
+        PlaylistTrack track = PlaylistTrack.create(1L, 10L, 1);
+
+        // when & then
+        assertThatThrownBy(() -> track.updatePosition(0))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.INVALID_POSITION.getMessage());
+    }
+
+    @Test
+    @DisplayName("트랙 임시 순서 이동")
+    void moveToTemporaryPosition() {
+        // given
+        PlaylistTrack track = PlaylistTrack.create(1L, 10L, 1);
+
+        // when
+        track.moveToTemporaryPosition(-1);
+
+        // then
+        assertThat(track.getPosition()).isEqualTo(-1);
+    }
+}

--- a/src/test/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackServiceTest.java
@@ -1,0 +1,519 @@
+package com.fivefy.domain.playlisttrack.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playlist.entity.Playlist;
+import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
+import com.fivefy.domain.playlist.repository.PlaylistRepository;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
+import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackOrderUpdateRequest;
+import com.fivefy.domain.playlisttrack.dto.response.PlaylistTrackResponse;
+import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
+import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PlaylistTrackServiceTest {
+
+    @InjectMocks
+    private PlaylistTrackService playlistTrackService;
+
+    @Mock
+    private PlaylistTrackRepository playlistTrackRepository;
+
+    @Mock
+    private PlaylistRepository playlistRepository;
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 추가")
+    class AddTrack {
+
+        @Test
+        @DisplayName("플레이리스트 트랙 추가 성공")
+        void addTrackSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack savedTrack = PlaylistTrack.create(playlistId, 10L, 1);
+            ReflectionTestUtils.setField(savedTrack, "id", 1L);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, 10L))
+                    .willReturn(false);
+            given(playlistTrackRepository.countByPlaylistId(playlistId))
+                    .willReturn(0);
+            given(playlistTrackRepository.save(any(PlaylistTrack.class)))
+                    .willReturn(savedTrack);
+
+            // when
+            PlaylistTrackResponse result = playlistTrackService.addTrack(userId, playlistId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.playlistId()).isEqualTo(playlistId);
+            assertThat(result.trackId()).isEqualTo(10L);
+            assertThat(result.position()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("플레이리스트가 없으면 예외 발생")
+        void addTrackPlaylistNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.addTrack(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("본인 플레이리스트가 아니면 예외 발생")
+        void addTrackForbidden() {
+            // given
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Long playlistId = 1L;
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.addTrack(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 트랙이면 예외 발생")
+        void addTrackAlreadyExists() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, 10L))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.addTrack(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS.getMessage());
+
+            verify(playlistTrackRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("저장 중 position 충돌 시 예외 발생")
+        void addTrackPositionConflict() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, 10L))
+                    .willReturn(false);
+            given(playlistTrackRepository.countByPlaylistId(playlistId))
+                    .willReturn(0);
+            given(playlistTrackRepository.save(any(PlaylistTrack.class)))
+                    .willThrow(new DataIntegrityViolationException("unique constraint"));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.addTrack(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 목록 조회")
+    class GetTracks {
+
+        @Test
+        @DisplayName("플레이리스트 트랙 목록 조회 성공")
+        void getTracksSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            ReflectionTestUtils.setField(track1, "id", 1L);
+
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+            ReflectionTestUtils.setField(track2, "id", 2L);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(List.of(track1, track2));
+
+            // when
+            List<PlaylistTrackResponse> result = playlistTrackService.getTracks(userId, playlistId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).trackId()).isEqualTo(10L);
+            assertThat(result.get(0).position()).isEqualTo(1);
+            assertThat(result.get(1).trackId()).isEqualTo(20L);
+            assertThat(result.get(1).position()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("플레이리스트가 없으면 예외 발생")
+        void getTracksPlaylistNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.getTracks(userId, playlistId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("본인 플레이리스트가 아니면 예외 발생")
+        void getTracksForbidden() {
+            // given
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Long playlistId = 1L;
+
+            Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.getTracks(userId, playlistId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 순서 변경")
+    class UpdateTrackOrder {
+
+        @Test
+        @DisplayName("트랙 순서 변경 성공")
+        void updateTrackOrderSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(30L, 1);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+            PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
+
+            // when
+            playlistTrackService.updateTrackOrder(userId, playlistId, request);
+
+            // then
+            assertThat(track3.getPosition()).isEqualTo(1);
+            assertThat(track1.getPosition()).isEqualTo(2);
+            assertThat(track2.getPosition()).isEqualTo(3);
+            verify(playlistTrackRepository, times(1)).flush();
+        }
+
+        @Test
+        @DisplayName("플레이리스트가 없으면 예외 발생")
+        void updateTrackOrderPlaylistNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 1);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.updateTrackOrder(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("본인 플레이리스트가 아니면 예외 발생")
+        void updateTrackOrderForbidden() {
+            // given
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 1);
+
+            Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.updateTrackOrder(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("대상 트랙이 없으면 예외 발생")
+        void updateTrackOrderTrackNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(99L, 1);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(List.of(track1, track2));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.updateTrackOrder(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이동 위치가 범위를 벗어나면 예외 발생")
+        void updateTrackOrderInvalidPosition() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 5);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(List.of(track1, track2));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.updateTrackOrder(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.INVALID_PLAYLIST_TRACK_POSITION.getMessage());
+        }
+
+        @Test
+        @DisplayName("현재 위치와 같으면 flush 없이 종료")
+        void updateTrackOrderSamePosition() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 1);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(List.of(track1, track2));
+
+            // when
+            playlistTrackService.updateTrackOrder(userId, playlistId, request);
+
+            // then
+            verify(playlistTrackRepository, never()).flush();
+            assertThat(track1.getPosition()).isEqualTo(1);
+            assertThat(track2.getPosition()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("position이 1 미만이면 예외 발생")
+        void updateTrackOrderLessThanOne() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request =
+                    new PlaylistTrackOrderUpdateRequest(10L, 0);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(List.of(track1, track2));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    playlistTrackService.updateTrackOrder(userId, playlistId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.INVALID_PLAYLIST_TRACK_POSITION.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("플레이리스트 트랙 삭제")
+    class DeleteTrack {
+
+        @Test
+        @DisplayName("플레이리스트 트랙 삭제 성공")
+        void deleteTrackSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            Long trackId = 20L;
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+            PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
+
+            // when
+            playlistTrackService.deleteTrack(userId, playlistId, trackId);
+
+            // then
+            verify(playlistTrackRepository).delete(track2);
+            verify(playlistTrackRepository, times(2)).flush();
+            assertThat(track1.getPosition()).isEqualTo(1);
+            assertThat(track3.getPosition()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("플레이리스트가 없으면 예외 발생")
+        void deleteTrackPlaylistNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            Long trackId = 10L;
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.deleteTrack(userId, playlistId, trackId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("본인 플레이리스트가 아니면 예외 발생")
+        void deleteTrackForbidden() {
+            // given
+            Long userId = 1L;
+            Long otherUserId = 2L;
+            Long playlistId = 1L;
+            Long trackId = 10L;
+
+            Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.deleteTrack(userId, playlistId, trackId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제 대상 트랙이 없으면 예외 발생")
+        void deleteTrackTrackNotFound() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            Long trackId = 99L;
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+
+            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(List.of(track1, track2));
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.deleteTrack(userId, playlistId, trackId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 개요

> 플레이리스트 및 플레이리스트 트랙 도메인에 대해 컨트롤러, 서비스, 엔티티 단위 테스트를 추가하여 전체 흐름을 검증하고  
JaCoCo 커버리지 100%를 달성하였습니다.

## 변경 사항

- Playlist / PlaylistTrack 컨트롤러 테스트 코드 작성
- Playlist / PlaylistTrack 서비스 테스트 코드 작성
- 엔티티 도메인 로직(create, update, delete 등) 테스트 추가
- 플레이리스트 트랙 순서 변경 및 검증 로직 테스트 추가
- API 예외 케이스 테스트 보강
  - 403 (권한 없음)
  - 404 (리소스 없음)
  - 409 (중복 및 충돌)
- API 응답 문서에 409(CONFLICT) 케이스 추가

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 스크린샷
- Playlist, PlaylistTrack 도메인의 현 테스트 커버리지
<img width="1766" height="577" alt="image" src="https://github.com/user-attachments/assets/69329325-8c02-4f3a-adc4-d42979fbe3d2" />

## 체크리스트

- [ ] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * 플레이리스트 관리(생성·목록·단건 조회·수정·삭제)에 대한 통합 및 단위 테스트 추가
  * 플레이리스트 트랙 관리(추가·목록·순서 변경·삭제)에 대한 컨트롤러·서비스·엔티티 테스트 추가
  * 입력 유효성, 권한/소유권 검증, 존재하지 않음, 중복 및 위치 충돌 등 다양한 오류 시나리오(400/403/404/409) 검증 포함
<!-- end of auto-generated comment: release notes by coderabbit.ai -->