### PR TITLE
feat: 인증/인가 에러 처리 분리 (401/403)

### DIFF
--- a/src/main/java/com/fivefy/common/config/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/fivefy/common/config/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package com.fivefy.common.config.security;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            @NonNull HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        log.info("접근 권한이 없습니다: {}", accessDeniedException.getMessage());
+
+        BaseResponse<Void> errorResponse = BaseResponse.fail(HttpStatus.FORBIDDEN, "접근 권한이 없습니다");
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
@@ -19,6 +19,7 @@ public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -30,9 +31,12 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/users/signup",
                                 "/api/users/login"
-                        ).permitAll().anyRequest().authenticated())
+                        ).permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated())
                 .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint(jwtAuthenticationEntryPoint))
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }


### PR DESCRIPTION
## 개요

> 403 Forbidden 에러 핸들러 추가

## 관련 이슈

closes #52
closes #53 

## 변경 사항

- JwtAccessDeniedHandler 추가하여 403 Forbidden 처리
- SecurityConfig에 accessDeniedHandler 설정
- /api/admin/** 경로에 ADMIN 역할 권한 검증 추가
- 401(인증 실패)과 403(권한 부족) 명확히 구분

## 변경 유형

- [x] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자 전용 엔드포인트에 대한 명시적 접근 제어 추가
  * 권한 없음 오류에 대한 개선된 에러 처리 추가
  * 접근 거부 시 일관된 JSON 형식의 오류 응답 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->