### PR TITLE
feat: 재생 CRUD API 기본 구현

### DIFF
--- a/src/main/java/com/fivefy/domain/playback/controller/PlaybackController.java
+++ b/src/main/java/com/fivefy/domain/playback/controller/PlaybackController.java
@@ -1,0 +1,84 @@
+package com.fivefy.domain.playback.controller;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.domain.playback.dto.request.PlaybackPauseRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackPlayRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackSkipRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackStopRequest;
+import com.fivefy.domain.playback.dto.response.PlaybackResponse;
+import com.fivefy.domain.playback.service.PlaybackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class PlaybackController {
+
+    private final PlaybackService playbackService;
+
+    @PostMapping("/playbacks/play")
+    public ResponseEntity<BaseResponse<PlaybackResponse>> play(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PlaybackPlayRequest request
+    ) {
+        PlaybackResponse response = playbackService.play(userId, request);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "재생 시작 성공", response)
+        );
+    }
+
+    @PostMapping("/playbacks/pause")
+    public ResponseEntity<BaseResponse<PlaybackResponse>> pause(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PlaybackPauseRequest request
+    ) {
+        PlaybackResponse response = playbackService.pause(userId, request);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "재생 일시정지 성공", response)
+        );
+    }
+
+    @PostMapping("/playbacks/stop")
+    public ResponseEntity<BaseResponse<PlaybackResponse>> stop(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PlaybackStopRequest request
+    ) {
+        PlaybackResponse response = playbackService.stop(userId, request);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "곡 정지 성공", response)
+        );
+    }
+
+    @PostMapping("/playbacks/skip")
+    public ResponseEntity<BaseResponse<PlaybackResponse>> skip(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody PlaybackSkipRequest request
+    ) {
+        PlaybackResponse response = playbackService.skip(userId, request);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "곡 건너뛰기 성공", response)
+        );
+    }
+
+    @GetMapping("/me/playback-history")
+    public ResponseEntity<BaseResponse<List<PlaybackResponse>>> getPlaybackHistory(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<PlaybackResponse> response = playbackService.getPlaybackHistory(userId);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "재생 기록 조회 성공", response)
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackPauseRequest.java
+++ b/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackPauseRequest.java
@@ -1,0 +1,9 @@
+package com.fivefy.domain.playback.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PlaybackPauseRequest(
+        @NotNull(message = "id는 필수입니다")
+        Long id
+) {
+}

--- a/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackPlayRequest.java
+++ b/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackPlayRequest.java
@@ -1,0 +1,15 @@
+package com.fivefy.domain.playback.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PlaybackPlayRequest(
+        @NotNull(message = "playlistId는 필수입니다")
+        Long playlistId,
+        @NotNull(message = "trackId는 필수입니다")
+        Long trackId,
+        @NotBlank(message = "sessionId는 필수입니다")
+        String sessionId,
+        String deviceId
+) {
+}

--- a/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackSkipRequest.java
+++ b/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackSkipRequest.java
@@ -1,0 +1,9 @@
+package com.fivefy.domain.playback.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PlaybackSkipRequest(
+        @NotNull(message = "id는 필수입니다")
+        Long id
+) {
+}

--- a/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackStopRequest.java
+++ b/src/main/java/com/fivefy/domain/playback/dto/request/PlaybackStopRequest.java
@@ -1,0 +1,9 @@
+package com.fivefy.domain.playback.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PlaybackStopRequest(
+        @NotNull(message = "id는 필수입니다")
+        Long id
+) {
+}

--- a/src/main/java/com/fivefy/domain/playback/dto/response/PlaybackResponse.java
+++ b/src/main/java/com/fivefy/domain/playback/dto/response/PlaybackResponse.java
@@ -1,0 +1,36 @@
+package com.fivefy.domain.playback.dto.response;
+
+import com.fivefy.domain.playback.entity.Playback;
+import com.fivefy.domain.playback.enums.PlaybackStatus;
+
+import java.time.LocalDateTime;
+
+public record PlaybackResponse(
+        Long id,
+        Long playlistId,
+        Long trackId,
+        Long userId,
+        String sessionId,
+        String deviceId,
+        PlaybackStatus status,
+        Integer playedDuration,
+        LocalDateTime startedAt,
+        LocalDateTime lastPlayedAt,
+        LocalDateTime endedAt
+) {
+    public static PlaybackResponse from(Playback playback) {
+        return new PlaybackResponse(
+                playback.getId(),
+                playback.getPlaylistId(),
+                playback.getTrackId(),
+                playback.getUserId(),
+                playback.getSessionId(),
+                playback.getDeviceId(),
+                playback.getStatus(),
+                playback.getPlayedDuration(),
+                playback.getStartedAt(),
+                playback.getLastPlayedAt(),
+                playback.getEndedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -39,7 +39,12 @@ public class Playback {
     private Integer playedDuration;
 
     @Column(nullable = false)
-    private LocalDateTime playedAt;
+    private LocalDateTime startedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime lastPlayedAt;
+
+    private LocalDateTime endedAt;
 
     public static Playback create(Long trackId, Long userId, String sessionId, String deviceId) {
         ValidationUtils.validateNonNull(trackId, "trackId");
@@ -52,9 +57,12 @@ public class Playback {
         playback.sessionId = sessionId;
         playback.deviceId = deviceId;
 
-        playback.status = PlaybackStatus.START;
+        playback.status = PlaybackStatus.PLAYING;
         playback.playedDuration = 0;
-        playback.playedAt = LocalDateTime.now();
+
+        LocalDateTime now = LocalDateTime.now();
+        playback.startedAt = now;
+        playback.lastPlayedAt = now;
 
         return playback;
     }

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -24,6 +24,9 @@ public class Playback {
     private Long id;
 
     @Column(nullable = false)
+    private Long playlistId;
+
+    @Column(nullable = false)
     private Long trackId;
 
     @Column(nullable = false)
@@ -50,23 +53,21 @@ public class Playback {
 
     private LocalDateTime endedAt;
 
-    public static Playback create(Long trackId, Long userId, String sessionId, String deviceId) {
-        return create(trackId, userId, sessionId, deviceId, LocalDateTime.now());
-    }
-
-    public static Playback create(Long trackId, Long userId, String sessionId, String deviceId, LocalDateTime now) {
+    public static Playback create(Long playlistId, Long trackId, Long userId, String sessionId, String deviceId) {
+        ValidationUtils.validateNonNull(playlistId, "playlistId");
         ValidationUtils.validateNonNull(trackId, "trackId");
         ValidationUtils.validateNonNull(userId, "userId");
         ValidationUtils.validateNonNull(sessionId, "sessionId");
-        ValidationUtils.validateNonNull(now, "now");
 
         Playback playback = new Playback();
+        playback.playlistId = playlistId;
         playback.trackId = trackId;
         playback.userId = userId;
         playback.sessionId = sessionId;
         playback.deviceId = deviceId;
         playback.status = PlaybackStatus.PLAYING;
         playback.playedDuration = 0;
+        LocalDateTime now = LocalDateTime.now();
         playback.startedAt = now;
         playback.lastPlayedAt = now;
 
@@ -92,95 +93,67 @@ public class Playback {
     }
 
     public void resume() {
-        resume(LocalDateTime.now());
-    }
-
-    public void resume(LocalDateTime now) {
-        ValidationUtils.validateNonNull(now, "now");
-
         if (this.status != PlaybackStatus.PAUSED) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
         this.status = PlaybackStatus.PLAYING;
-        this.lastPlayedAt = now;
+        this.lastPlayedAt = LocalDateTime.now();
     }
 
     public void pause() {
-        pause(LocalDateTime.now());
-    }
+        if (this.status != PlaybackStatus.PLAYING) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
 
-    public void pause(LocalDateTime now) {
-        validatePlayingState();
-        accumulatePlayedDuration(now);
+        accumulatePlayedDuration();
         this.status = PlaybackStatus.PAUSED;
     }
 
-    public void skip() {
-        skip(LocalDateTime.now());
-    }
-
-    public void skip(LocalDateTime now) {
-        validateSkippableState();
-
-        if (this.status == PlaybackStatus.PLAYING) {
-            accumulatePlayedDuration(now);
-        }
-
-        this.status = PlaybackStatus.SKIPPED;
-        this.endedAt = now;
-    }
-
     public void stop() {
-        stop(LocalDateTime.now());
-    }
-
-    public void stop(LocalDateTime now) {
-        validateSkippableState();
-
-        if (this.status == PlaybackStatus.PLAYING) {
-            accumulatePlayedDuration(now);
-        }
-
-        this.status = PlaybackStatus.STOPPED;
-        this.endedAt = now;
-    }
-
-    public void complete() {
-        complete(LocalDateTime.now());
-    }
-
-    public void complete(LocalDateTime now) {
-        ValidationUtils.validateNonNull(now, "now");
-
-        if (this.status != PlaybackStatus.PLAYING) {
-            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
-        }
-
-        accumulatePlayedDuration(now);
-        this.status = PlaybackStatus.COMPLETED;
-        this.endedAt = now;
-    }
-
-    private void validatePlayingState() {
-        if (this.status != PlaybackStatus.PLAYING) {
-            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
-        }
-    }
-
-    private void validateSkippableState() {
         if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
+
+        if (this.status == PlaybackStatus.PLAYING) {
+            accumulatePlayedDuration();
+        }
+
+        this.status = PlaybackStatus.STOPPED;
+        this.endedAt = LocalDateTime.now();
     }
 
-    private void accumulatePlayedDuration(LocalDateTime now) {
-        ValidationUtils.validateNonNull(now, "now");
+    public void skip() {
+        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
 
+        if (this.status == PlaybackStatus.PLAYING) {
+            accumulatePlayedDuration();
+        }
+
+        this.status = PlaybackStatus.SKIPPED;
+        this.endedAt = LocalDateTime.now();
+    }
+
+    public void complete() {
+        if (this.status != PlaybackStatus.PLAYING) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        accumulatePlayedDuration();
+        this.status = PlaybackStatus.COMPLETED;
+        this.endedAt = LocalDateTime.now();
+    }
+
+    private void accumulatePlayedDuration() {
+        LocalDateTime now = LocalDateTime.now();
         long seconds = Duration.between(this.lastPlayedAt, now).getSeconds();
+
         if (seconds > 0) {
             this.playedDuration += (int) seconds;
         }
+
         this.lastPlayedAt = now;
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -1,13 +1,17 @@
 package com.fivefy.domain.playback.entity;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.util.ValidationUtils;
+import com.fivefy.domain.playback.enums.PlaybackErrorCode;
 import com.fivefy.domain.playback.enums.PlaybackStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @Entity
@@ -56,14 +60,95 @@ public class Playback {
         playback.userId = userId;
         playback.sessionId = sessionId;
         playback.deviceId = deviceId;
-
         playback.status = PlaybackStatus.PLAYING;
         playback.playedDuration = 0;
-
         LocalDateTime now = LocalDateTime.now();
         playback.startedAt = now;
         playback.lastPlayedAt = now;
 
         return playback;
+    }
+
+    public boolean isOwner(Long userId) {
+        return Objects.equals(this.userId, userId);
+    }
+
+    public boolean isPaused() {
+        return this.status == PlaybackStatus.PAUSED;
+    }
+
+    public boolean isPlaying() {
+        return this.status == PlaybackStatus.PLAYING;
+    }
+
+    public boolean isEnded() {
+        return this.status == PlaybackStatus.STOPPED
+                || this.status == PlaybackStatus.SKIPPED
+                || this.status == PlaybackStatus.COMPLETED;
+    }
+
+    public void resume() {
+        if (this.status != PlaybackStatus.PAUSED) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        this.status = PlaybackStatus.PLAYING;
+        this.lastPlayedAt = LocalDateTime.now();
+    }
+
+    public void pause() {
+        if (this.status != PlaybackStatus.PLAYING) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        accumulatePlayedDuration();
+        this.status = PlaybackStatus.PAUSED;
+    }
+
+    public void skip() {
+        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        if (this.status == PlaybackStatus.PLAYING) {
+            accumulatePlayedDuration();
+        }
+
+        this.status = PlaybackStatus.SKIPPED;
+        this.endedAt = LocalDateTime.now();
+    }
+
+    public void stop() {
+        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        if (this.status == PlaybackStatus.PLAYING) {
+            accumulatePlayedDuration();
+        }
+
+        this.status = PlaybackStatus.STOPPED;
+        this.endedAt = LocalDateTime.now();
+    }
+
+    public void complete() {
+        if (this.status != PlaybackStatus.PLAYING) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        accumulatePlayedDuration();
+        this.status = PlaybackStatus.COMPLETED;
+        this.endedAt = LocalDateTime.now();
+    }
+
+    private void accumulatePlayedDuration() {
+        LocalDateTime now = LocalDateTime.now();
+        long seconds = Duration.between(this.lastPlayedAt, now).getSeconds();
+
+        if (seconds > 0) {
+            this.playedDuration += (int) seconds;
+        }
+
+        this.lastPlayedAt = now;
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -78,22 +78,28 @@ public class Playback {
         return Objects.equals(this.userId, userId);
     }
 
-    public boolean isPaused() {
-        return this.status == PlaybackStatus.PAUSED;
-    }
-
     public boolean isPlaying() {
         return this.status == PlaybackStatus.PLAYING;
     }
 
-    public boolean isEnded() {
-        return this.status == PlaybackStatus.STOPPED
-                || this.status == PlaybackStatus.SKIPPED
-                || this.status == PlaybackStatus.COMPLETED;
+    public boolean isPaused() {
+        return this.status == PlaybackStatus.PAUSED;
+    }
+
+    public boolean isStopped() {
+        return this.status == PlaybackStatus.STOPPED;
+    }
+
+    public boolean isSkipped() {
+        return this.status == PlaybackStatus.SKIPPED;
+    }
+
+    public boolean isCompleted() {
+        return this.status == PlaybackStatus.COMPLETED;
     }
 
     public void resume() {
-        if (this.status != PlaybackStatus.PAUSED) {
+        if (!isPaused()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
@@ -102,7 +108,7 @@ public class Playback {
     }
 
     public void pause() {
-        if (this.status != PlaybackStatus.PLAYING) {
+        if (!isPlaying()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
@@ -111,11 +117,11 @@ public class Playback {
     }
 
     public void stop() {
-        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
+        if (!isPlaying() && !isPaused()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
-        if (this.status == PlaybackStatus.PLAYING) {
+        if (isPlaying()) {
             accumulatePlayedDuration();
         }
 
@@ -124,11 +130,11 @@ public class Playback {
     }
 
     public void skip() {
-        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
+        if (!isPlaying() && !isPaused()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
-        if (this.status == PlaybackStatus.PLAYING) {
+        if (isPlaying()) {
             accumulatePlayedDuration();
         }
 
@@ -137,7 +143,7 @@ public class Playback {
     }
 
     public void complete() {
-        if (this.status != PlaybackStatus.PLAYING) {
+        if (!isPlaying()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 

--- a/src/main/java/com/fivefy/domain/playback/entity/Playback.java
+++ b/src/main/java/com/fivefy/domain/playback/entity/Playback.java
@@ -51,9 +51,14 @@ public class Playback {
     private LocalDateTime endedAt;
 
     public static Playback create(Long trackId, Long userId, String sessionId, String deviceId) {
+        return create(trackId, userId, sessionId, deviceId, LocalDateTime.now());
+    }
+
+    public static Playback create(Long trackId, Long userId, String sessionId, String deviceId, LocalDateTime now) {
         ValidationUtils.validateNonNull(trackId, "trackId");
         ValidationUtils.validateNonNull(userId, "userId");
         ValidationUtils.validateNonNull(sessionId, "sessionId");
+        ValidationUtils.validateNonNull(now, "now");
 
         Playback playback = new Playback();
         playback.trackId = trackId;
@@ -62,7 +67,6 @@ public class Playback {
         playback.deviceId = deviceId;
         playback.status = PlaybackStatus.PLAYING;
         playback.playedDuration = 0;
-        LocalDateTime now = LocalDateTime.now();
         playback.startedAt = now;
         playback.lastPlayedAt = now;
 
@@ -88,67 +92,95 @@ public class Playback {
     }
 
     public void resume() {
+        resume(LocalDateTime.now());
+    }
+
+    public void resume(LocalDateTime now) {
+        ValidationUtils.validateNonNull(now, "now");
+
         if (this.status != PlaybackStatus.PAUSED) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
         this.status = PlaybackStatus.PLAYING;
-        this.lastPlayedAt = LocalDateTime.now();
+        this.lastPlayedAt = now;
     }
 
     public void pause() {
-        if (this.status != PlaybackStatus.PLAYING) {
-            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
-        }
+        pause(LocalDateTime.now());
+    }
 
-        accumulatePlayedDuration();
+    public void pause(LocalDateTime now) {
+        validatePlayingState();
+        accumulatePlayedDuration(now);
         this.status = PlaybackStatus.PAUSED;
     }
 
     public void skip() {
-        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
-            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
-        }
+        skip(LocalDateTime.now());
+    }
+
+    public void skip(LocalDateTime now) {
+        validateSkippableState();
 
         if (this.status == PlaybackStatus.PLAYING) {
-            accumulatePlayedDuration();
+            accumulatePlayedDuration(now);
         }
 
         this.status = PlaybackStatus.SKIPPED;
-        this.endedAt = LocalDateTime.now();
+        this.endedAt = now;
     }
 
     public void stop() {
-        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
-            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
-        }
+        stop(LocalDateTime.now());
+    }
+
+    public void stop(LocalDateTime now) {
+        validateSkippableState();
 
         if (this.status == PlaybackStatus.PLAYING) {
-            accumulatePlayedDuration();
+            accumulatePlayedDuration(now);
         }
 
         this.status = PlaybackStatus.STOPPED;
-        this.endedAt = LocalDateTime.now();
+        this.endedAt = now;
     }
 
     public void complete() {
+        complete(LocalDateTime.now());
+    }
+
+    public void complete(LocalDateTime now) {
+        ValidationUtils.validateNonNull(now, "now");
+
         if (this.status != PlaybackStatus.PLAYING) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
-        accumulatePlayedDuration();
+        accumulatePlayedDuration(now);
         this.status = PlaybackStatus.COMPLETED;
-        this.endedAt = LocalDateTime.now();
+        this.endedAt = now;
     }
 
-    private void accumulatePlayedDuration() {
-        LocalDateTime now = LocalDateTime.now();
-        long seconds = Duration.between(this.lastPlayedAt, now).getSeconds();
+    private void validatePlayingState() {
+        if (this.status != PlaybackStatus.PLAYING) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+    }
 
+    private void validateSkippableState() {
+        if (this.status != PlaybackStatus.PLAYING && this.status != PlaybackStatus.PAUSED) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+    }
+
+    private void accumulatePlayedDuration(LocalDateTime now) {
+        ValidationUtils.validateNonNull(now, "now");
+
+        long seconds = Duration.between(this.lastPlayedAt, now).getSeconds();
         if (seconds > 0) {
             this.playedDuration += (int) seconds;
         }
-
         this.lastPlayedAt = now;
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
@@ -12,8 +12,7 @@ public enum PlaybackErrorCode implements ErrorCode {
     PLAYBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "재생 기록을 찾을 수 없습니다"),
     PLAYBACK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 재생 기록에 접근할 수 없습니다"),
     CURRENT_PLAYBACK_NOT_FOUND(HttpStatus.CONFLICT, "현재 재생 중인 음악이 없습니다"),
-    INVALID_PLAYBACK_STATE(HttpStatus.CONFLICT, "현재 재생 상태에서는 요청을 수행할 수 없습니다"),
-    NEXT_TRACK_NOT_FOUND(HttpStatus.CONFLICT, "다음 곡이 존재하지 않습니다");
+    INVALID_PLAYBACK_STATE(HttpStatus.CONFLICT, "현재 재생 상태에서는 요청을 수행할 수 없습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
@@ -12,7 +12,9 @@ public enum PlaybackErrorCode implements ErrorCode {
     PLAYBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "재생 기록을 찾을 수 없습니다"),
     PLAYBACK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 재생 기록에 접근할 수 없습니다"),
     CURRENT_PLAYBACK_NOT_FOUND(HttpStatus.CONFLICT, "현재 재생 중인 음악이 없습니다"),
-    INVALID_PLAYBACK_STATE(HttpStatus.CONFLICT, "현재 재생 상태에서는 요청을 수행할 수 없습니다");
+    INVALID_PLAYBACK_STATE(HttpStatus.CONFLICT, "현재 재생 상태에서는 요청을 수행할 수 없습니다"),
+    PLAYLIST_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트 트랙 정보를 찾을 수 없습니다"),
+    PLAYBACK_TRACK_MISMATCH(HttpStatus.CONFLICT, "현재 재생 정보와 플레이리스트 트랙 순서가 일치하지 않습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
@@ -1,0 +1,20 @@
+package com.fivefy.domain.playback.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PlaybackErrorCode implements ErrorCode {
+
+    PLAYBACK_NOT_FOUND(HttpStatus.NOT_FOUND, "재생 기록을 찾을 수 없습니다"),
+    PLAYBACK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 재생 기록에 접근할 수 없습니다"),
+    CURRENT_PLAYBACK_NOT_FOUND(HttpStatus.CONFLICT, "현재 재생 중인 음악이 없습니다"),
+    INVALID_PLAYBACK_STATE(HttpStatus.CONFLICT, "현재 재생 상태에서는 요청을 수행할 수 없습니다"),
+    NEXT_TRACK_NOT_FOUND(HttpStatus.CONFLICT, "다음 곡이 존재하지 않습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playback/enums/PlaybackErrorCode.java
@@ -14,7 +14,8 @@ public enum PlaybackErrorCode implements ErrorCode {
     CURRENT_PLAYBACK_NOT_FOUND(HttpStatus.CONFLICT, "현재 재생 중인 음악이 없습니다"),
     INVALID_PLAYBACK_STATE(HttpStatus.CONFLICT, "현재 재생 상태에서는 요청을 수행할 수 없습니다"),
     PLAYLIST_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "플레이리스트 트랙 정보를 찾을 수 없습니다"),
-    PLAYBACK_TRACK_MISMATCH(HttpStatus.CONFLICT, "현재 재생 정보와 플레이리스트 트랙 순서가 일치하지 않습니다");
+    PLAYBACK_TRACK_MISMATCH(HttpStatus.CONFLICT, "현재 재생 정보와 플레이리스트 트랙 순서가 일치하지 않습니다"),
+    PLAYLIST_TRACK_NOT_INCLUDED(HttpStatus.BAD_REQUEST, "플레이리스트에 포함되지 않은 트랙입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/playback/enums/PlaybackStatus.java
+++ b/src/main/java/com/fivefy/domain/playback/enums/PlaybackStatus.java
@@ -2,9 +2,9 @@ package com.fivefy.domain.playback.enums;
 
 public enum PlaybackStatus {
 
-    START,    // 재생
-    PAUSE,    // 일시 정지
-    COMPLETE, // 완료
-    STOP,     // 중단
-    SKIP      // 건너뛰기
+    PLAYING,    // 현재 재생 중
+    PAUSED,     // 일시정지 상태
+    STOPPED,    // 사용자가 재생을 중단한 상태
+    SKIPPED,    // 다음 곡으로 넘어가 종료된 상태
+    COMPLETED   // 곡이 끝까지 재생된 상태
 }

--- a/src/main/java/com/fivefy/domain/playback/repository/PlaybackRepository.java
+++ b/src/main/java/com/fivefy/domain/playback/repository/PlaybackRepository.java
@@ -11,5 +11,6 @@ public interface PlaybackRepository extends JpaRepository<Playback, Long> {
 
     Optional<Playback> findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(Long userId, Long playlistId, Long trackId, String sessionId);
     Optional<Playback> findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(Long userId, String sessionId, PlaybackStatus status);
+    Optional<Playback> findByIdAndUserId(Long playbackId, Long userId);
     List<Playback> findAllByUserIdOrderByIdDesc(Long userId);
 }

--- a/src/main/java/com/fivefy/domain/playback/repository/PlaybackRepository.java
+++ b/src/main/java/com/fivefy/domain/playback/repository/PlaybackRepository.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.playback.repository;
 
 import com.fivefy.domain.playback.entity.Playback;
+import com.fivefy.domain.playback.enums.PlaybackStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,5 +10,6 @@ import java.util.Optional;
 public interface PlaybackRepository extends JpaRepository<Playback, Long> {
 
     Optional<Playback> findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(Long userId, Long playlistId, Long trackId, String sessionId);
+    Optional<Playback> findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(Long userId, String sessionId, PlaybackStatus status);
     List<Playback> findAllByUserIdOrderByIdDesc(Long userId);
 }

--- a/src/main/java/com/fivefy/domain/playback/repository/PlaybackRepository.java
+++ b/src/main/java/com/fivefy/domain/playback/repository/PlaybackRepository.java
@@ -1,0 +1,13 @@
+package com.fivefy.domain.playback.repository;
+
+import com.fivefy.domain.playback.entity.Playback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PlaybackRepository extends JpaRepository<Playback, Long> {
+
+    Optional<Playback> findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(Long userId, Long playlistId, Long trackId, String sessionId);
+    List<Playback> findAllByUserIdOrderByIdDesc(Long userId);
+}

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -27,6 +27,8 @@ public class PlaybackService {
 
     @Transactional
     public PlaybackResponse play(Long userId, PlaybackPlayRequest request) {
+        validatePlaylistTrackRelation(request.playlistId(), request.trackId());
+
         Playback playback = playbackRepository
                 .findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
                         userId,
@@ -151,5 +153,11 @@ public class PlaybackService {
         }
 
         throw new BusinessException(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH);
+    }
+
+    private void validatePlaylistTrackRelation(Long playlistId, Long trackId) {
+        if (!playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, trackId)) {
+            throw new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED);
+        }
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -8,6 +8,7 @@ import com.fivefy.domain.playback.dto.request.PlaybackStopRequest;
 import com.fivefy.domain.playback.dto.response.PlaybackResponse;
 import com.fivefy.domain.playback.entity.Playback;
 import com.fivefy.domain.playback.enums.PlaybackErrorCode;
+import com.fivefy.domain.playback.enums.PlaybackStatus;
 import com.fivefy.domain.playback.repository.PlaybackRepository;
 import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
 import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
@@ -29,6 +30,25 @@ public class PlaybackService {
     public PlaybackResponse play(Long userId, PlaybackPlayRequest request) {
         validatePlaylistTrackRelation(request.playlistId(), request.trackId());
 
+        Playback currentPlayback = playbackRepository
+                .findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                        userId,
+                        request.sessionId(),
+                        PlaybackStatus.PLAYING
+                )
+                .orElse(null);
+
+        if (currentPlayback != null) {
+            if (currentPlayback.getPlaylistId().equals(request.playlistId())
+                    && currentPlayback.getTrackId().equals(request.trackId())) {
+                Playback handledPlayback = handlePlay(currentPlayback, request);
+                Playback savedPlayback = playbackRepository.save(handledPlayback);
+                return PlaybackResponse.from(savedPlayback);
+            }
+
+            currentPlayback.stop();
+        }
+
         Playback playback = playbackRepository
                 .findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
                         userId,
@@ -36,6 +56,7 @@ public class PlaybackService {
                         request.trackId(),
                         request.sessionId()
                 )
+                .filter(existing -> !existing.isPlaying())
                 .map(existing -> handlePlay(existing, request))
                 .orElseGet(() -> Playback.create(
                         request.playlistId(),

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -28,8 +28,10 @@ public class PlaybackService {
 
     @Transactional
     public PlaybackResponse play(Long userId, PlaybackPlayRequest request) {
+        // 플레이리스트에 포함된 트랙인지 검증
         validatePlaylistTrackRelation(request.playlistId(), request.trackId());
 
+        // 현재 세션에서 재생 중인 playback 조회 (중복 재생 방지)
         Playback currentPlayback = playbackRepository
                 .findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
                         userId,
@@ -39,6 +41,7 @@ public class PlaybackService {
                 .orElse(null);
 
         if (currentPlayback != null) {
+            // 같은 곡이면 기존 상태 흐름 처리
             if (currentPlayback.getPlaylistId().equals(request.playlistId())
                     && currentPlayback.getTrackId().equals(request.trackId())) {
                 Playback handledPlayback = handlePlay(currentPlayback, request);
@@ -46,9 +49,11 @@ public class PlaybackService {
                 return PlaybackResponse.from(savedPlayback);
             }
 
+            // 다른 곡이면 기존 재생 종료
             currentPlayback.stop();
         }
 
+        // 기존 이력 재사용 또는 새로운 playback 생성
         Playback playback = playbackRepository
                 .findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
                         userId,
@@ -74,6 +79,7 @@ public class PlaybackService {
     public PlaybackResponse pause(Long userId, PlaybackPauseRequest request) {
         Playback playback = getOwnedPlayback(userId, request.id());
 
+        // 재생 중이 아닐 경우 예외
         if (!playback.isPlaying()) {
             throw new BusinessException(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND);
         }
@@ -86,6 +92,7 @@ public class PlaybackService {
     public PlaybackResponse stop(Long userId, PlaybackStopRequest request) {
         Playback playback = getOwnedPlayback(userId, request.id());
 
+        // 재생/일시정지 상태가 아니면 예외
         if (!playback.isPlaying() && !playback.isPaused()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
@@ -98,10 +105,12 @@ public class PlaybackService {
     public PlaybackResponse skip(Long userId, PlaybackSkipRequest request) {
         Playback currentPlayback = getOwnedPlayback(userId, request.id());
 
+        // 재생/일시정지 상태가 아니면 예외
         if (!currentPlayback.isPlaying() && !currentPlayback.isPaused()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
+        // 플레이리스트 트랙 목록 조회
         List<PlaylistTrack> playlistTracks =
                 playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(currentPlayback.getPlaylistId());
 
@@ -109,10 +118,13 @@ public class PlaybackService {
             throw new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND);
         }
 
+        // 다음 트랙 계산
         Long nextTrackId = resolveNextTrackId(playlistTracks, currentPlayback.getTrackId());
 
+        // 현재 곡 skip 처리
         currentPlayback.skip();
 
+        // 다음 곡 자동 재생
         Playback nextPlayback = Playback.create(
                 currentPlayback.getPlaylistId(),
                 nextTrackId,
@@ -132,15 +144,18 @@ public class PlaybackService {
     }
 
     private Playback handlePlay(Playback playback, PlaybackPlayRequest request) {
+        // 이미 재생 중이면 예외
         if (playback.isPlaying()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
+        // 일시정지 상태 후 재개
         if (playback.isPaused()) {
             playback.resume();
             return playback;
         }
 
+        // 종료/완료/스킵 상태 후 새 playback 생성
         if (playback.isStopped() || playback.isCompleted() || playback.isSkipped()) {
             return Playback.create(
                     request.playlistId(),
@@ -155,11 +170,13 @@ public class PlaybackService {
     }
 
     private Playback getOwnedPlayback(Long userId, Long playbackId) {
+        // 내 playback만 조회 (존재/권한 구분 없이 NOT_FOUND 처리)
         return playbackRepository.findByIdAndUserId(playbackId, userId)
                 .orElseThrow(() -> new BusinessException(PlaybackErrorCode.PLAYBACK_NOT_FOUND));
     }
 
     private Long resolveNextTrackId(List<PlaylistTrack> playlistTracks, Long currentTrackId) {
+        // 현재 트랙 기준으로 다음 트랙 반환 (마지막이면 처음으로 순환)
         for (int i = 0; i < playlistTracks.size(); i++) {
             if (playlistTracks.get(i).getTrackId().equals(currentTrackId)) {
                 int nextIndex = (i + 1) % playlistTracks.size();
@@ -171,6 +188,7 @@ public class PlaybackService {
     }
 
     private void validatePlaylistTrackRelation(Long playlistId, Long trackId) {
+        // 플레이리스트에 포함되지 않은 트랙 요청 방지
         if (!playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, trackId)) {
             throw new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED);
         }

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -1,0 +1,155 @@
+package com.fivefy.domain.playback.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playback.dto.request.PlaybackPauseRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackPlayRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackSkipRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackStopRequest;
+import com.fivefy.domain.playback.dto.response.PlaybackResponse;
+import com.fivefy.domain.playback.entity.Playback;
+import com.fivefy.domain.playback.enums.PlaybackErrorCode;
+import com.fivefy.domain.playback.repository.PlaybackRepository;
+import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
+import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaybackService {
+
+    private final PlaybackRepository playbackRepository;
+    private final PlaylistTrackRepository playlistTrackRepository;
+
+    @Transactional
+    public PlaybackResponse play(Long userId, PlaybackPlayRequest request) {
+        Playback playback = playbackRepository
+                .findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                        userId,
+                        request.playlistId(),
+                        request.trackId(),
+                        request.sessionId()
+                )
+                .map(existing -> handlePlay(existing, request))
+                .orElseGet(() -> Playback.create(
+                        request.playlistId(),
+                        request.trackId(),
+                        userId,
+                        request.sessionId(),
+                        request.deviceId()
+                ));
+
+        Playback savedPlayback = playbackRepository.save(playback);
+        return PlaybackResponse.from(savedPlayback);
+    }
+
+    @Transactional
+    public PlaybackResponse pause(Long userId, PlaybackPauseRequest request) {
+        Playback playback = getOwnedPlayback(userId, request.id());
+
+        if (!playback.isPlaying()) {
+            throw new BusinessException(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND);
+        }
+
+        playback.pause();
+        return PlaybackResponse.from(playback);
+    }
+
+    @Transactional
+    public PlaybackResponse stop(Long userId, PlaybackStopRequest request) {
+        Playback playback = getOwnedPlayback(userId, request.id());
+
+        if (!playback.isPlaying() && !playback.isPaused()) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        playback.stop();
+        return PlaybackResponse.from(playback);
+    }
+
+    @Transactional
+    public PlaybackResponse skip(Long userId, PlaybackSkipRequest request) {
+        Playback currentPlayback = getOwnedPlayback(userId, request.id());
+
+        if (!currentPlayback.isPlaying() && !currentPlayback.isPaused()) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        List<PlaylistTrack> playlistTracks =
+                playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(currentPlayback.getPlaylistId());
+
+        if (playlistTracks.isEmpty()) {
+            throw new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND);
+        }
+
+        Long nextTrackId = resolveNextTrackId(playlistTracks, currentPlayback.getTrackId());
+
+        currentPlayback.skip();
+
+        Playback nextPlayback = Playback.create(
+                currentPlayback.getPlaylistId(),
+                nextTrackId,
+                userId,
+                currentPlayback.getSessionId(),
+                currentPlayback.getDeviceId()
+        );
+
+        Playback savedNextPlayback = playbackRepository.save(nextPlayback);
+        return PlaybackResponse.from(savedNextPlayback);
+    }
+
+    public List<PlaybackResponse> getPlaybackHistory(Long userId) {
+        return playbackRepository.findAllByUserIdOrderByIdDesc(userId).stream()
+                .map(PlaybackResponse::from)
+                .toList();
+    }
+
+    private Playback handlePlay(Playback playback, PlaybackPlayRequest request) {
+        if (playback.isPlaying()) {
+            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+        }
+
+        if (playback.isPaused()) {
+            playback.resume();
+            return playback;
+        }
+
+        if (playback.isStopped() || playback.isCompleted()) {
+            return Playback.create(
+                    request.playlistId(),
+                    request.trackId(),
+                    playback.getUserId(),
+                    request.sessionId(),
+                    request.deviceId()
+            );
+        }
+
+        throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
+    }
+
+    private Playback getOwnedPlayback(Long userId, Long playbackId) {
+        Playback playback = playbackRepository.findById(playbackId)
+                .orElseThrow(() -> new BusinessException(PlaybackErrorCode.PLAYBACK_NOT_FOUND));
+
+        if (!playback.isOwner(userId)) {
+            throw new BusinessException(PlaybackErrorCode.PLAYBACK_ACCESS_DENIED);
+        }
+
+        return playback;
+    }
+
+    private Long resolveNextTrackId(List<PlaylistTrack> playlistTracks, Long currentTrackId) {
+        for (int i = 0; i < playlistTracks.size(); i++) {
+            if (playlistTracks.get(i).getTrackId().equals(currentTrackId)) {
+                int nextIndex = (i + 1) % playlistTracks.size();
+                return playlistTracks.get(nextIndex).getTrackId();
+            }
+        }
+
+        throw new BusinessException(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH);
+    }
+}

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -155,14 +155,8 @@ public class PlaybackService {
     }
 
     private Playback getOwnedPlayback(Long userId, Long playbackId) {
-        Playback playback = playbackRepository.findById(playbackId)
+        return playbackRepository.findByIdAndUserId(playbackId, userId)
                 .orElseThrow(() -> new BusinessException(PlaybackErrorCode.PLAYBACK_NOT_FOUND));
-
-        if (!playback.isOwner(userId)) {
-            throw new BusinessException(PlaybackErrorCode.PLAYBACK_ACCESS_DENIED);
-        }
-
-        return playback;
     }
 
     private Long resolveNextTrackId(List<PlaylistTrack> playlistTracks, Long currentTrackId) {

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -118,7 +118,7 @@ public class PlaybackService {
             return playback;
         }
 
-        if (playback.isStopped() || playback.isCompleted()) {
+        if (playback.isStopped() || playback.isCompleted() || playback.isSkipped()) {
             return Playback.create(
                     request.playlistId(),
                     request.trackId(),


### PR DESCRIPTION
## 개요

> Playback 도메인의 재생 흐름(시작, 일시정지, 재개, 중단, 건너뛰기) 기반 상태 관리 및 재생 시간 누적 로직을 구현했습니다.

## 변경 사항

- Playback 엔티티 상태 기반 구조로 설계
- PlaybackStatus enum 재정의 (행동 → 상태 중심)

- Playback 도메인 로직 구현
  - 재생 시작 시 Playback 생성 및 상태 초기화
  - pause / stop / skip / complete 시점에 재생 시간 누적
  - resume 시 lastPlayedAt 기준 시각 갱신

- 시간 필드 역할 분리
  - startedAt : 최초 재생 시작 시각
  - lastPlayedAt : 마지막 재생 시작/재개 시각
  - endedAt : 재생 종료 시각

- PlaybackService 재생 흐름 로직 구현
  - 재생 시작 / 재개 (POST /api/playbacks/play)
  - 재생 일시정지 (POST /api/playbacks/pause)
  - 재생 중단 (POST /api/playbacks/stop)
  - 곡 건너뛰기 (POST /api/playbacks/skip)
  - 재생 기록 조회 (GET /api/me/playback-history)

- PlaybackErrorCode 정의 및 상태 기반 예외 처리 적용

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> Playback 재생 흐름을 순차적으로 호출하여 상태 변화 및 재생 시간 누적을 확인합니다.

### 1. 재생 시작
> POST /api/playbacks/play 호출 후 status = PLAYING 확인

### 2. 재생 일시정지
> POST /api/playbacks/pause 호출 후 status = PAUSED 및 playedDuration 증가 확인

### 3. 재생 재개
> POST /api/playbacks/play 호출 후 status = PLAYING 및 lastPlayedAt 갱신 확인

### 4. 재생 중단
> POST /api/playbacks/stop 호출 후 status = STOPPED 및 playedDuration 최종 누적 확인

### 5. 곡 건너뛰기
> POST /api/playbacks/skip 호출 후 status = SKIPPED 및 endedAt 기록 확인

### 6. 재생 기록 조회
> GET /api/me/playback-history 호출 후 최신순 정렬 및 상태 흐름 확인

## 스크린샷

- 재생 시작 응답 body
<img width="1274" height="1057" alt="image" src="https://github.com/user-attachments/assets/99fd2528-07bb-45a7-bac4-cefd4a2b6946" />

- 재생 일시정지 응답 body
<img width="1277" height="968" alt="image" src="https://github.com/user-attachments/assets/8a938baf-379f-465e-8c51-405ed3a02341" />

- 재생 재개 응답 body
<img width="1274" height="1085" alt="image" src="https://github.com/user-attachments/assets/6df8bf52-2e1b-4935-befb-d30115ec59e5" />

- 재생 중단 응답 body
<img width="1272" height="990" alt="image" src="https://github.com/user-attachments/assets/73e6cbb9-26cb-40a8-9366-4ba305ec209c" />

- 곡 건너뛰기 응답 body 
<img width="1275" height="1017" alt="image" src="https://github.com/user-attachments/assets/ef58196c-1953-452b-a2f0-81aaf1cf1884" />

- 재생 기록 조회 응답 body
<img width="1273" height="1175" alt="image" src="https://github.com/user-attachments/assets/8999ad69-c1ce-403e-87f6-8b96701efbbd" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 재생, 일시정지, 중지, 건너뛰기 제어용 API 엔드포인트 추가
  * 사용자별 재생 이력 조회 API 추가
  * 플레이리스트·트랙·세션·디바이스 기반 재생 세션 및 다중기기 흐름 개선
  * 재생 상태 전이(재생·일시정지·중지·건너뛰기·완료) 및 재생시간 누적 기록 기능 추가
  * 입력 검증 강화 및 재생 관련 상황에 대한 명확한 오류 응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->