### PR TITLE
feature: 토큰 재발급과 로그아웃 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 
+    // digestUtils
+    implementation 'commons-codec:commons-codec'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -110,6 +110,39 @@ include::{snippets}/user-login-fail/response-fields.adoc[]
 
 ---
 
+=== 토큰 재발급
+
+include::{snippets}/user-reissue/http-request.adoc[]
+include::{snippets}/user-reissue/request-cookies.adoc[]
+include::{snippets}/user-reissue/http-response.adoc[]
+include::{snippets}/user-reissue/response-headers.adoc[]
+include::{snippets}/user-reissue/response-cookies.adoc[]
+include::{snippets}/user-reissue/response-fields.adoc[]
+
+==== 에러 케이스 - RT 쿠키 누락
+
+include::{snippets}/user-reissue-missing-rt/http-request.adoc[]
+include::{snippets}/user-reissue-missing-rt/http-response.adoc[]
+include::{snippets}/user-reissue-missing-rt/response-fields.adoc[]
+
+==== 에러 케이스 - 유효하지 않은 RT
+
+include::{snippets}/user-reissue-invalid-rt/http-request.adoc[]
+include::{snippets}/user-reissue-invalid-rt/request-cookies.adoc[]
+include::{snippets}/user-reissue-invalid-rt/http-response.adoc[]
+include::{snippets}/user-reissue-invalid-rt/response-fields.adoc[]
+
+---
+
+=== 로그아웃
+
+include::{snippets}/user-logout/http-request.adoc[]
+include::{snippets}/user-logout/http-response.adoc[]
+include::{snippets}/user-logout/response-cookies.adoc[]
+include::{snippets}/user-logout/response-fields.adoc[]
+
+---
+
 == 도메인 API
 
 === 기능

--- a/src/main/java/com/fivefy/common/config/security/JwtUtil.java
+++ b/src/main/java/com/fivefy/common/config/security/JwtUtil.java
@@ -39,9 +39,10 @@ public class JwtUtil {
     }
 
     // refresh token 생성
-    public String createRefreshToken() {
+    public String createRefreshToken(Long userId) {
         Date now = new Date();
         return Jwts.builder()
+                .subject(String.valueOf(userId))
                 .issuedAt(now)
                 .expiration(new Date(now.getTime() + jwtProperties.refreshExpiration()))
                 .signWith(getSigningKey())

--- a/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/users/signup",
-                                "/api/users/login"
+                                "/api/users/login",
+                                "/api/users/reissue"
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())

--- a/src/main/java/com/fivefy/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fivefy/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -19,7 +20,7 @@ public class GlobalExceptionHandler {
     // 여러 도메인 에러들을 관리하는 BusinessException 처리
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<BaseResponse<Void>> handleBusinessException(BusinessException e) {
-        log.error("비즈니스 에러 발생 : {}, 에러 상세 내용 : ", e.getMessage(), e);
+        log.warn("비즈니스 에러 발생 : {}, 에러 상세 내용 : ", e.getMessage(), e);
         return ResponseEntity.status(e.getHttpStatus()).body(
                 BaseResponse.fail(e.getHttpStatus(), e.getMessage())
         );
@@ -28,7 +29,7 @@ public class GlobalExceptionHandler {
     // validation 예외 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse<List<FieldErrorResponse>>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        log.error("요청 검증 에러 발생 : ", e);
+        log.warn("요청 검증 에러 발생 : ", e);
         List<FieldErrorResponse> errors = e.getBindingResult().getFieldErrors()
                 .stream()
                 .map(error -> new FieldErrorResponse(error.getField(), error.getDefaultMessage()))
@@ -43,6 +44,15 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<Void>> handleNoResourceFoundException(NoResourceFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
                 BaseResponse.fail(HttpStatus.NOT_FOUND, "잘못된 접근입니다")
+        );
+    }
+
+    // Cookie에 Refresh Token이 없을 경우 발생하는 예외 처리
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<BaseResponse<Void>> handleMissingRequestCookieException(MissingRequestCookieException e) {
+        log.warn("인증 쿠키 누락 : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                BaseResponse.fail(HttpStatus.UNAUTHORIZED, "인증 정보가 유효하지 않습니다")
         );
     }
 

--- a/src/main/java/com/fivefy/domain/user/controller/UserController.java
+++ b/src/main/java/com/fivefy/domain/user/controller/UserController.java
@@ -13,10 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
 
@@ -37,18 +34,34 @@ public class UserController {
     @PostMapping("/users/login")
     public ResponseEntity<BaseResponse<UserLoginResponse>> loginUser(@Valid @RequestBody UserLoginRequest request) {
         UserLoginResponse result = userService.loginUser(request);
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", result.refreshToken())
-                .httpOnly(true)
-                .secure(true)
-                .path("/api/users/refresh")
-                .maxAge(Duration.ofDays(7))
-                .sameSite("Strict")
-                .build();
+        ResponseCookie cookie = buildRefreshTokenCookie(result.refreshToken());
 
         return ResponseEntity.status(HttpStatus.OK)
                 .header(HttpHeaders.CACHE_CONTROL, "no-store")
                 .header(HttpHeaders.PRAGMA, "no-cache")
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(BaseResponse.success(HttpStatus.OK, "로그인 성공", UserLoginResponse.from(result.accessToken())));
+    }
+
+    @PostMapping("/users/reissue")
+    public ResponseEntity<BaseResponse<UserLoginResponse>> reissueToken(@CookieValue(name = "refreshToken") String refreshToken) {
+        UserLoginResponse result = userService.reissueToken(refreshToken);
+        ResponseCookie cookie = buildRefreshTokenCookie(result.refreshToken());
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .header(HttpHeaders.PRAGMA, "no-cache")
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .body(BaseResponse.success(HttpStatus.OK, "토큰 재발급 성공", UserLoginResponse.from(result.accessToken())));
+    }
+
+    private ResponseCookie buildRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/users/reissue")
+                .maxAge(Duration.ofDays(7))
+                .sameSite("Strict")
+                .build();
     }
 }

--- a/src/main/java/com/fivefy/domain/user/controller/UserController.java
+++ b/src/main/java/com/fivefy/domain/user/controller/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Duration;
@@ -53,6 +54,23 @@ public class UserController {
                 .header(HttpHeaders.PRAGMA, "no-cache")
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .body(BaseResponse.success(HttpStatus.OK, "토큰 재발급 성공", UserLoginResponse.from(result.accessToken())));
+    }
+
+    @PostMapping("/users/logout")
+    public ResponseEntity<BaseResponse<Void>> logoutUser(@AuthenticationPrincipal Long userId) {
+        userService.logoutUser(userId);
+
+        ResponseCookie expiredCookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/users/reissue")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
+                .body(BaseResponse.success(HttpStatus.OK, "로그아웃 성공", null));
     }
 
     private ResponseCookie buildRefreshTokenCookie(String refreshToken) {

--- a/src/main/java/com/fivefy/domain/user/enums/UserErrorCode.java
+++ b/src/main/java/com/fivefy/domain/user/enums/UserErrorCode.java
@@ -11,7 +11,10 @@ public enum UserErrorCode implements ErrorCode {
 
     ERR_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다"),
     ERR_USER_DUPLICATED_EMAIL(HttpStatus.CONFLICT, "중복된 이메일이 존재합니다"),
-    ERR_USER_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다");
+    ERR_USER_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 올바르지 않습니다"),
+    ERR_USER_INVALID_RT(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다"),
+    ERR_USER_EXPIRED_RT(HttpStatus.UNAUTHORIZED, "만료된 Refresh Token입니다"),
+    ERR_USER_NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/user/service/UserService.java
+++ b/src/main/java/com/fivefy/domain/user/service/UserService.java
@@ -189,4 +189,9 @@ public class UserService {
 
         return UserLoginResponse.of(newAccessToken, newRefreshToken);
     }
+
+    public void logoutUser(Long userId) {
+        redisTemplate.delete(RT_PREFIX + userId);
+        redisTemplate.delete(PREV_RT_PREFIX + userId);
+    }
 }

--- a/src/main/java/com/fivefy/domain/user/service/UserService.java
+++ b/src/main/java/com/fivefy/domain/user/service/UserService.java
@@ -94,7 +94,7 @@ public class UserService {
         }
 
         String accessToken = jwtUtil.createAccessToken(user.getId(), user.getRole());
-        String refreshToken = jwtUtil.createRefreshToken();
+        String refreshToken = jwtUtil.createRefreshToken(user.getId());
 
         redisTemplate.opsForValue().set(
                 RT_PREFIX + user.getId(),
@@ -163,7 +163,7 @@ public class UserService {
 
         // 새로운 AT, RT 발급
         String newAccessToken = jwtUtil.createAccessToken(user.getId(), user.getRole());
-        String newRefreshToken = jwtUtil.createRefreshToken();
+        String newRefreshToken = jwtUtil.createRefreshToken(user.getId());
 
         // Redis 업데이트 (트랜잭션)
         redisTemplate.execute(new SessionCallback<List<Object>>() {

--- a/src/main/java/com/fivefy/domain/user/service/UserService.java
+++ b/src/main/java/com/fivefy/domain/user/service/UserService.java
@@ -10,17 +10,28 @@ import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.repository.UserRepository;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.repository.WalletRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.apache.commons.codec.digest.DigestUtils;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.fivefy.domain.user.enums.UserErrorCode.*;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -32,6 +43,9 @@ public class UserService {
     private final StringRedisTemplate redisTemplate;
 
     private static final String DUMMY_HASH = "$2a$10$7EqJtq98hPqEX7fNZaFWoOHiS8GdKx2UY8ailqXF/w3vGN9VOGQ0y";
+    private static final String RT_PREFIX = "RT:";
+    private static final String PREV_RT_PREFIX = "PREV_RT:";
+    private static final long PREV_RT_GRACE_PERIOD_SECONDS = 30L;
 
     /**
      회원가입
@@ -83,11 +97,96 @@ public class UserService {
         String refreshToken = jwtUtil.createRefreshToken();
 
         redisTemplate.opsForValue().set(
-                "RT:" + user.getId(),
+                RT_PREFIX + user.getId(),
                 refreshToken,
                 Duration.ofDays(7)
         );
 
         return UserLoginResponse.of(accessToken, refreshToken);
+    }
+
+    /**
+     토큰 재발급
+     1. RT 쿠키 검증
+     2. Redis에 저장된 RT와 일치 여부 확인
+     3. 새로운 AT, RT 발급
+     4. Redis에 RT 갱신
+     */
+    public UserLoginResponse reissueToken(String refreshToken) {
+        Claims claims;
+        try {
+            // 전달받은 RT의 서명/만료 검증
+            claims = jwtUtil.validateToken(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ERR_USER_EXPIRED_RT);
+        } catch (Exception e) {
+            throw new BusinessException(ERR_USER_INVALID_RT);
+        }
+
+        long userId = Long.parseLong(claims.getSubject());
+
+        // Redis에 저장된 현재 RT와 유예 RT를 조회
+        String storedRt = redisTemplate.opsForValue().get(RT_PREFIX + userId);
+        String prevRt = redisTemplate.opsForValue().get(PREV_RT_PREFIX + userId);
+
+        // 로그아웃 상태 체크
+        if (storedRt == null) {
+            throw new BusinessException(ERR_USER_NOT_LOGGED_IN);
+        }
+
+        // 두 토큰 중 어느 것과도 일치하지 않으면 탈취로 간주하고 모든 토큰 삭제 (로그아웃)
+        if (!refreshToken.equals(storedRt) && !refreshToken.equals(prevRt)) {
+            String tokenHash = DigestUtils.sha256Hex(refreshToken).substring(0, 16);
+            log.warn("토큰 탈취 의심 - 사용자: {}, 토큰해시: {}", userId, tokenHash);
+            redisTemplate.delete(RT_PREFIX + userId);
+            redisTemplate.delete(PREV_RT_PREFIX + userId);
+            throw new BusinessException(ERR_USER_INVALID_RT);
+        }
+
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new BusinessException(ERR_USER_NOT_FOUND)
+        );
+        // 유예 기간 RT로 요청이 오면 AT는 새로 발급, RT는 현재 최신 정보 반환 (동시성)
+        if (refreshToken.equals(prevRt)) {
+            log.info("유예 기간 내 토큰 재발급 요청 허용 - 사용자: {}", userId);
+            return UserLoginResponse.of(
+                    jwtUtil.createAccessToken(user.getId(), user.getRole()),
+                    storedRt
+            );
+        }
+
+        // 로그인 무한 동기화를 방지하기 위해 기존 RT의 남은 수명을 새로운 RT에 적용
+        Long remainingTtl = redisTemplate.getExpire(RT_PREFIX + userId, TimeUnit.SECONDS);
+        if (remainingTtl == null || remainingTtl <= 0) {
+            throw new BusinessException(ERR_USER_EXPIRED_RT);
+        }
+
+        // 새로운 AT, RT 발급
+        String newAccessToken = jwtUtil.createAccessToken(user.getId(), user.getRole());
+        String newRefreshToken = jwtUtil.createRefreshToken();
+
+        // Redis 업데이트 (트랜잭션)
+        redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public List<Object> execute(@NonNull RedisOperations operations) throws DataAccessException {
+                operations.multi();
+                // 재발급 이전 기존 RT를 유예 기간(30초) 동안 임시 저장하여 동시 요청 대비
+                operations.opsForValue().set(
+                        PREV_RT_PREFIX + userId,
+                        storedRt,
+                        Duration.ofSeconds(PREV_RT_GRACE_PERIOD_SECONDS)
+                );
+                // 새로운 RT를 Redis에 저장
+                operations.opsForValue().set(
+                        RT_PREFIX + userId,
+                        newRefreshToken,
+                        Duration.ofSeconds(remainingTtl)
+                );
+                return operations.exec();
+            }
+        });
+
+        return UserLoginResponse.of(newAccessToken, newRefreshToken);
     }
 }

--- a/src/test/java/com/fivefy/common/config/security/JwtUtilTest.java
+++ b/src/test/java/com/fivefy/common/config/security/JwtUtilTest.java
@@ -53,12 +53,12 @@ class JwtUtilTest {
     }
 
     @Test
-    @DisplayName("RefreshToken은 subject와 role 클레임 없이 생성")
-    void createRefreshTokenWithoutSubjectAndRole() {
-        String token = jwtUtil.createRefreshToken();
+    @DisplayName("RefreshToken을 생성하고 검증")
+    void createAndValidateRT() {
+        String token = jwtUtil.createRefreshToken(1L);
         Claims claims = jwtUtil.validateToken(token);
 
-        assertThat(claims.getSubject()).isNull();
+        assertThat(Long.parseLong(claims.getSubject())).isEqualTo(1L);
         assertThat(claims.get("role")).isNull();
     }
 

--- a/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
@@ -8,6 +8,7 @@ import com.fivefy.domain.user.dto.request.UserSignupRequest;
 import com.fivefy.domain.user.dto.response.UserLoginResponse;
 import com.fivefy.domain.user.dto.response.UserSignupResponse;
 import com.fivefy.domain.user.service.UserService;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,10 +20,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 
-import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_DUPLICATED_EMAIL;
-import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_LOGIN_FAIL;
+import static com.fivefy.domain.user.enums.UserErrorCode.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -298,6 +299,72 @@ class UserControllerTest extends RestDocsSupport {
                                     fieldWithPath("message").type(STRING).description("에러 메시지")
                             )
                     ));
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급")
+    class Reissue {
+
+        @Test
+        @DisplayName("재발급 성공 — 200, 새 AT 바디 반환, 새 RT 쿠키 설정")
+        void reissueSuccess() throws Exception {
+            // given
+            UserLoginResponse result = UserLoginResponse.of("new.access.token", "new.refresh.token");
+            given(userService.reissueToken(any())).willReturn(result);
+
+            // when & then
+            mockMvc.perform(post("/api/users/reissue")
+                            .with(csrf())
+                            .cookie(new Cookie("refreshToken", "valid.refresh.token")))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.accessToken").value("new.access.token"))
+                    .andExpect(jsonPath("$.data.refreshToken").doesNotExist())
+                    .andExpect(cookie().value("refreshToken", "new.refresh.token"))
+                    .andExpect(cookie().httpOnly("refreshToken", true))
+                    .andExpect(cookie().secure("refreshToken", true))
+                    .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
+                    .andExpect(header().string(HttpHeaders.PRAGMA, "no-cache"));
+        }
+
+        @Test
+        @DisplayName("RT 쿠키 없이 재발급 요청 시 401 반환")
+        void reissueWithoutCookie() throws Exception {
+            mockMvc.perform(post("/api/users/reissue")
+                            .with(csrf()))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").value("인증 정보가 유효하지 않습니다"));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 RT로 재발급 시 401 반환")
+        void reissueWithInvalidToken() throws Exception {
+            // given
+            given(userService.reissueToken(any()))
+                    .willThrow(new BusinessException(ERR_USER_INVALID_RT));
+
+            // when & then
+            mockMvc.perform(post("/api/users/reissue")
+                            .with(csrf())
+                            .cookie(new Cookie("refreshToken", "invalid.refresh.token")))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").value(ERR_USER_INVALID_RT.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 API")
+    class Logout {
+
+        @Test
+        @DisplayName("로그아웃 성공 — 200, RT 쿠키 만료 처리")
+        void logoutSuccess() throws Exception {
+            mockMvc.perform(post("/api/users/logout")
+                            .with(csrf())
+                            .requestAttr("userId", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("로그아웃 성공"))
+                    .andExpect(cookie().maxAge("refreshToken", 0));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/fivefy/domain/user/controller/UserControllerTest.java
@@ -24,10 +24,8 @@ import static com.fivefy.domain.user.enums.UserErrorCode.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
-import static org.springframework.restdocs.cookies.CookieDocumentation.responseCookies;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.cookies.CookieDocumentation.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -203,7 +201,7 @@ class UserControllerTest extends RestDocsSupport {
                             ),
                             responseHeaders(
                                     headerWithName(HttpHeaders.CACHE_CONTROL).description("캐시 방지 헤더 (HTTP/1.1)"),
-                                    headerWithName(HttpHeaders.PRAGMA).description("캐시 방지 헤더 (HTTP/1.0 하위 호환용)")
+                                    headerWithName(HttpHeaders.PRAGMA).description("캐시 방지 헤더 (HTTP/1.0 호환)")
                             )
                     ));
         }
@@ -315,7 +313,7 @@ class UserControllerTest extends RestDocsSupport {
 
             // when & then
             mockMvc.perform(post("/api/users/reissue")
-                            .with(csrf())
+                            .with(csrf().asHeader())
                             .cookie(new Cookie("refreshToken", "valid.refresh.token")))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.accessToken").value("new.access.token"))
@@ -324,16 +322,41 @@ class UserControllerTest extends RestDocsSupport {
                     .andExpect(cookie().httpOnly("refreshToken", true))
                     .andExpect(cookie().secure("refreshToken", true))
                     .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-store"))
-                    .andExpect(header().string(HttpHeaders.PRAGMA, "no-cache"));
+                    .andExpect(header().string(HttpHeaders.PRAGMA, "no-cache"))
+                    .andDo(document("user-reissue",
+                            requestCookies(
+                                    cookieWithName("refreshToken").description("기존 리프레시 토큰 (HttpOnly, Secure)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.accessToken").type(STRING).description("새로운 액세스 토큰")
+                            ),
+                            responseCookies(
+                                    cookieWithName("refreshToken").description("새로운 리프레시 토큰 (HttpOnly, Secure)")
+                            ),
+                            responseHeaders(
+                                    headerWithName(HttpHeaders.CACHE_CONTROL).description("캐시 방지 헤더 (HTTP/1.1)"),
+                                    headerWithName(HttpHeaders.PRAGMA).description("캐시 방지 헤더 (HTTP/1.0 호환)")
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("RT 쿠키 없이 재발급 요청 시 401 반환")
         void reissueWithoutCookie() throws Exception {
             mockMvc.perform(post("/api/users/reissue")
-                            .with(csrf()))
+                            .with(csrf().asHeader()))
                     .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.message").value("인증 정보가 유효하지 않습니다"));
+                    .andExpect(jsonPath("$.message").value("인증 정보가 유효하지 않습니다"))
+                    .andDo(document("user-reissue-missing-rt",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -345,10 +368,20 @@ class UserControllerTest extends RestDocsSupport {
 
             // when & then
             mockMvc.perform(post("/api/users/reissue")
-                            .with(csrf())
+                            .with(csrf().asHeader())
                             .cookie(new Cookie("refreshToken", "invalid.refresh.token")))
                     .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.message").value(ERR_USER_INVALID_RT.getMessage()));
+                    .andExpect(jsonPath("$.message").value(ERR_USER_INVALID_RT.getMessage()))
+                    .andDo(document("user-reissue-invalid-rt",
+                            requestCookies(
+                                    cookieWithName("refreshToken").description("유효하지 않은 리프레시 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -360,11 +393,21 @@ class UserControllerTest extends RestDocsSupport {
         @DisplayName("로그아웃 성공 — 200, RT 쿠키 만료 처리")
         void logoutSuccess() throws Exception {
             mockMvc.perform(post("/api/users/logout")
-                            .with(csrf())
+                            .with(csrf().asHeader())
                             .requestAttr("userId", 1L))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value("로그아웃 성공"))
-                    .andExpect(cookie().maxAge("refreshToken", 0));
+                    .andExpect(cookie().maxAge("refreshToken", 0))
+                    .andDo(document("user-logout",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지")
+                            ),
+                            responseCookies(
+                                    cookieWithName("refreshToken").description("만료된 리프레시 토큰 (maxAge=0)")
+                            )
+                    ));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
@@ -153,7 +153,7 @@ class UserServiceTest {
             given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
             given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(true);
             given(jwtUtil.createAccessToken(any(), any())).willReturn("accessToken");
-            given(jwtUtil.createRefreshToken()).willReturn("refreshToken");
+            given(jwtUtil.createRefreshToken(any())).willReturn("refreshToken");
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
             // when
@@ -171,7 +171,7 @@ class UserServiceTest {
             given(userRepository.findByEmail(request.email())).willReturn(Optional.of(user));
             given(passwordEncoder.matches(request.password(), user.getPassword())).willReturn(true);
             given(jwtUtil.createAccessToken(any(), any())).willReturn("accessToken");
-            given(jwtUtil.createRefreshToken()).willReturn("refreshToken");
+            given(jwtUtil.createRefreshToken(any())).willReturn("refreshToken");
             given(redisTemplate.opsForValue()).willReturn(valueOperations);
 
             // when

--- a/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/fivefy/domain/user/service/UserServiceTest.java
@@ -7,28 +7,37 @@ import com.fivefy.domain.user.dto.request.UserSignupRequest;
 import com.fivefy.domain.user.dto.response.UserLoginResponse;
 import com.fivefy.domain.user.dto.response.UserSignupResponse;
 import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.repository.WalletRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
-import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_DUPLICATED_EMAIL;
-import static com.fivefy.domain.user.enums.UserErrorCode.ERR_USER_LOGIN_FAIL;
+import static com.fivefy.domain.user.enums.UserErrorCode.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -228,6 +237,228 @@ class UserServiceTest {
 
             // then — 이메일이 없어도 passwordEncoder.matches()가 반드시 1회 호출됨
             verify(passwordEncoder, times(1)).matches(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급")
+    class Reissue {
+
+        private User user;
+        private Claims claims;
+
+        private static final String VALID_RT    = "valid.refresh.token";
+        private static final String PREV_RT     = "prev.refresh.token";
+        private static final String NEW_AT      = "new.access.token";
+        private static final String NEW_RT      = "new.refresh.token";
+        private static final String RT_KEY      = "RT:1";
+        private static final String PREV_RT_KEY = "PREV_RT:1";
+        private static final long   REMAINING_TTL = 600L;
+
+        @BeforeEach
+        void setUp() {
+            user = User.create("test@test.com", "encodedPassword", "테스트");
+            ReflectionTestUtils.setField(user, "id", 1L);
+            ReflectionTestUtils.setField(user, "role", UserRole.USER);
+
+            claims = mock(Claims.class);
+        }
+
+        @Test
+        @DisplayName("재발급 성공 - 새 AT/RT 발급 및 Redis 갱신")
+        void reissueSuccess() {
+            // given
+            given(claims.getSubject()).willReturn("1");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtUtil.validateToken(VALID_RT)).willReturn(claims);
+            given(valueOperations.get(RT_KEY)).willReturn(VALID_RT);
+            given(valueOperations.get(PREV_RT_KEY)).willReturn(null);
+            given(redisTemplate.getExpire(RT_KEY, TimeUnit.SECONDS)).willReturn(REMAINING_TTL);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(jwtUtil.createAccessToken(any(), any())).willReturn(NEW_AT);
+            given(jwtUtil.createRefreshToken(1L)).willReturn(NEW_RT);
+            given(redisTemplate.execute(ArgumentMatchers.<SessionCallback<List<Object>>>any())).willReturn(null);
+
+            // when
+            UserLoginResponse response = userService.reissueToken(VALID_RT);
+
+            // then
+            assertThat(response.accessToken()).isEqualTo(NEW_AT);
+            assertThat(response.refreshToken()).isEqualTo(NEW_RT);
+            verify(redisTemplate).execute(ArgumentMatchers.<SessionCallback<List<Object>>>any());
+        }
+
+        @Test
+        @DisplayName("만료된 RT — ERR_USER_EXPIRED_RT 예외")
+        void reissueWithExpiredToken() {
+            // given
+            given(jwtUtil.validateToken(any()))
+                    .willThrow(mock(ExpiredJwtException.class));
+
+            // when & then
+            assertThatThrownBy(() -> userService.reissueToken(VALID_RT))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_EXPIRED_RT.getMessage());
+        }
+
+        @Test
+        @DisplayName("서명 오류 등 유효하지 않은 RT — ERR_USER_INVALID_RT 예외")
+        void reissueWithInvalidToken() {
+            // given
+            given(jwtUtil.validateToken(any()))
+                    .willThrow(new RuntimeException("invalid"));
+
+            // when & then
+            assertThatThrownBy(() -> userService.reissueToken(VALID_RT))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_INVALID_RT.getMessage());
+        }
+
+        @Test
+        @DisplayName("로그아웃 상태(Redis RT 없음) — ERR_USER_NOT_LOGGED_IN 예외")
+        void reissueWhenLoggedOut() {
+            // given
+            given(claims.getSubject()).willReturn("1");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtUtil.validateToken(VALID_RT)).willReturn(claims);
+            given(valueOperations.get(RT_KEY)).willReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> userService.reissueToken(VALID_RT))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_NOT_LOGGED_IN.getMessage());
+        }
+
+        @Test
+        @DisplayName("RT 탈취 감지 — storedRt/prevRt 불일치 시 RT + PREV_RT 삭제 후 예외")
+        void reissueDetectsTokenTheft() {
+            // given — 이미 Rotation된 RT로 재시도하는 탈취 시나리오
+            given(claims.getSubject()).willReturn("1");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtUtil.validateToken(VALID_RT)).willReturn(claims);
+            given(valueOperations.get(RT_KEY)).willReturn("already.rotated.token");
+            given(valueOperations.get(PREV_RT_KEY)).willReturn("also.different.token");
+
+            // when & then
+            assertThatThrownBy(() -> userService.reissueToken(VALID_RT))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_INVALID_RT.getMessage());
+
+            verify(redisTemplate).delete(RT_KEY);
+            verify(redisTemplate).delete(PREV_RT_KEY);
+        }
+
+        @Test
+        @DisplayName("유예 RT로 재발급 — 새 AT + 현재 storedRt 반환 (동시 요청 대응)")
+        void reissueWithPrevRt() {
+            // given — 동시 요청으로 인해 이전 RT(PREV_RT)로 재시도하는 시나리오
+            given(claims.getSubject()).willReturn("1");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtUtil.validateToken(PREV_RT)).willReturn(claims);
+            given(valueOperations.get(RT_KEY)).willReturn(VALID_RT);
+            given(valueOperations.get(PREV_RT_KEY)).willReturn(PREV_RT);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(jwtUtil.createAccessToken(any(), any())).willReturn(NEW_AT);
+
+            // when
+            UserLoginResponse response = userService.reissueToken(PREV_RT);
+
+            // then — AT는 새로 발급, RT는 현재 storedRt 반환
+            assertThat(response.accessToken()).isEqualTo(NEW_AT);
+            assertThat(response.refreshToken()).isEqualTo(VALID_RT);
+
+            // 유예 RT 처리 시 새 RT 발급하지 않음
+            verify(jwtUtil, never()).createRefreshToken(anyLong());
+        }
+
+        @Test
+        @DisplayName("Redis TTL 0 이하 — ERR_USER_EXPIRED_RT 예외")
+        void reissueWhenTtlExpired() {
+            // given
+            given(claims.getSubject()).willReturn("1");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtUtil.validateToken(VALID_RT)).willReturn(claims);
+            given(valueOperations.get(RT_KEY)).willReturn(VALID_RT);
+            given(valueOperations.get(PREV_RT_KEY)).willReturn(null);
+            given(redisTemplate.getExpire(RT_KEY, TimeUnit.SECONDS)).willReturn(0L);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> userService.reissueToken(VALID_RT))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_EXPIRED_RT.getMessage());
+        }
+
+        @Test
+        @DisplayName("유저 탈퇴/삭제 상태 — ERR_USER_NOT_FOUND 예외")
+        void reissueWithDeletedUser() {
+            // given
+            given(claims.getSubject()).willReturn("1");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtUtil.validateToken(VALID_RT)).willReturn(claims);
+            given(valueOperations.get(RT_KEY)).willReturn(VALID_RT);
+            given(valueOperations.get(PREV_RT_KEY)).willReturn(null);
+            given(userRepository.findById(1L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userService.reissueToken(VALID_RT))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ERR_USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("재발급 성공 시 새 RT가 기존 RT와 다르다 (Rotation 검증)")
+        void reissueRotatesRefreshToken() {
+            // given
+            given(claims.getSubject()).willReturn("1");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(jwtUtil.validateToken(VALID_RT)).willReturn(claims);
+            given(valueOperations.get(RT_KEY)).willReturn(VALID_RT);
+            given(valueOperations.get(PREV_RT_KEY)).willReturn(null);
+            given(redisTemplate.getExpire(RT_KEY, TimeUnit.SECONDS)).willReturn(REMAINING_TTL);
+            given(userRepository.findById(1L)).willReturn(Optional.of(user));
+            given(jwtUtil.createAccessToken(any(), any())).willReturn(NEW_AT);
+            given(jwtUtil.createRefreshToken(1L)).willReturn(NEW_RT);
+            given(redisTemplate.execute(ArgumentMatchers.<SessionCallback<List<Object>>>any())).willReturn(null);
+
+            // when
+            UserLoginResponse response = userService.reissueToken(VALID_RT);
+
+            // then
+            assertThat(response.refreshToken()).isNotEqualTo(VALID_RT);
+            assertThat(response.refreshToken()).isEqualTo(NEW_RT);
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃")
+    class Logout {
+
+        private static final String RT_KEY      = "RT:1";
+        private static final String PREV_RT_KEY = "PREV_RT:1";
+
+        @Test
+        @DisplayName("로그아웃 성공 — RT + PREV_RT 모두 삭제")
+        void logoutSuccess() {
+            // when
+            userService.logoutUser(1L);
+
+            // then
+            verify(redisTemplate).delete(RT_KEY);
+            verify(redisTemplate).delete(PREV_RT_KEY);
+        }
+
+        @Test
+        @DisplayName("이미 로그아웃된 상태에서 재시도 — 예외 없이 처리")
+        void logoutAlreadyLoggedOut() {
+            // given
+            given(redisTemplate.delete(RT_KEY)).willReturn(false);
+            given(redisTemplate.delete(PREV_RT_KEY)).willReturn(false);
+
+            // when & then
+            userService.logoutUser(1L);
+            verify(redisTemplate).delete(RT_KEY);
+            verify(redisTemplate).delete(PREV_RT_KEY);
         }
     }
 }


### PR DESCRIPTION
## 개요

> JWT 기반 인증 시스템의 토큰 재발급 및 로그아웃 기능을 구현하고, Refresh Token 탈취 방지를 위한 보안 강화 로직을 추가했습니다.

## 변경 사항

- 토큰 재발급 API 구현
  - **POST /api/users/reissue** 엔드포인트 추가
  - HttpOnly, Secure 쿠키를 통한 Refresh Token 전달
  - 새로운 Access Token 및 Refresh Token 발급
  - Cache-Control, Pragma 헤더를 통한 캐싱 방지
- 보안 강화
  - Refresh Token 탈취 감지
    - Redis 이중 검증 로직 구현 (RT, PREV_RT)
    - 불일치 감지 시 모든 토큰 즉시 삭제
    - SHA-256 해싱을 통한 보안 로깅
  - Refresh Token Rotation
    - 재발급 시 새로운 RT 발급 및 기존 RT를 PREV_RT로 보관
    - 30초 유예 기간 내 이전 토큰으로 재발급 가능 (동시 요청 대응)
  - 무한 연장 방지
    - TTL 승계 로직 구현 (기존 RT의 남은 TTL 승계)
    - TTL 만료 시 재발급 불가
  - 원자성 보장
    - Redis 트랜잭션(SessionCallback)을 통한 RT, PREV_RT 원자적 업데이트
- 로그아웃 API 구현
  - **POST /api/users/logout** 엔드포인트 추가
  - Redis에서 RT 및 PREV_RT 삭제
  - Refresh Token 쿠키 만료 처리 (maxAge=0)
- Refresh Token 개선
  - RT에 userId subject 추가 (기존: subject 없음)
  - Redis 키 접두사 상수화 (`RT:`, `PREV_RT:`)
- 예외 처리 개선
  - 토큰 상태별 구체적 예외 분리
    - `ERR_USER_EXPIRED_RT`: 만료된 토큰
    - `ERR_USER_INVALID_RT`: 유효하지 않은 토큰 (탈취 감지 포함)
    - `ERR_USER_NOT_LOGGED_IN`: 로그아웃 상태
  - `MissingRequestCookieException` 핸들러 추가
  - 예상 가능한 에러 로그 레벨 error → warn 변경
- 코드 품질 개선
  - 쿠키 생성 로직을 `buildRefreshTokenCookie()` 메서드로 분리
  - 쿠키 경로를 `/api/users/reissue`로 명시적 지정
  - 테스트 커버리지 확대 (토큰 재발급, 로그아웃)

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [x] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> /api/users/reissue 호출 후 응답 및 redis 확인
> /api/users/logout 호출 후 redis rt key 삭제 확인

## 스크린샷

- 재발급 성공
<img width="850" height="417" alt="재발급 성공" src="https://github.com/user-attachments/assets/840af2c0-e9ff-4b0d-8b73-3e6588600330" />
<img width="131" height="33" alt="재발급 시 유예 RT 저장" src="https://github.com/user-attachments/assets/e9201620-7b72-4bf7-a8fe-669bbc5e44ac" />

- 유효하지 않은 RT로 재발급 요청
<img width="853" height="335" alt="Redis에 저장되지 않은 RT 사용" src="https://github.com/user-attachments/assets/86055f9e-164c-447a-bfd0-efce0b9120d6" />
<img width="1294" height="55" alt="토큰 탈취 의심 로그" src="https://github.com/user-attachments/assets/4fceac73-b260-4e66-b4f6-7659ce0d9882" />

- 유예기간 RT로 재발급 요청 (동시 요청 대응)
<img width="1135" height="32" alt="유예 기간 RT 사용해서 재발급" src="https://github.com/user-attachments/assets/f2444fff-df2a-4f6d-88dc-4a338f6ff410" />

- 로그아웃 성공
<img width="850" height="408" alt="로그아웃" src="https://github.com/user-attachments/assets/dc0c760d-7173-4c47-9fc1-d96723b29538" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 토큰 재발급 엔드포인트 추가: 만료된 접근 토큰을 새로운 토큰으로 재발급
  * 로그아웃 기능 추가: 사용자의 토큰을 무효화하고 세션 종료
  * 새로운 토큰 유효성 검증 및 오류 처리 메커니즘 구현

* **Documentation**
  * API 문서에 토큰 재발급 및 로그아웃 엔드포인트 가이드 추가

* **Tests**
  * 토큰 재발급 및 로그아웃 기능에 대한 단위 테스트 및 통합 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->