### PR TITLE
test: 재생 도메인 테스트 코드 작성

### DIFF
--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -41,16 +41,15 @@ public class PlaybackService {
                 .orElse(null);
 
         if (currentPlayback != null) {
-            // 같은 곡이면 기존 상태 흐름 처리
+            // 같은 곡이면 중복 재생 요청
             if (currentPlayback.getPlaylistId().equals(request.playlistId())
                     && currentPlayback.getTrackId().equals(request.trackId())) {
-                Playback handledPlayback = handlePlay(currentPlayback, request);
-                Playback savedPlayback = playbackRepository.save(handledPlayback);
-                return PlaybackResponse.from(savedPlayback);
+                throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
             }
 
             // 다른 곡이면 기존 재생 종료
             currentPlayback.stop();
+            playbackRepository.save(currentPlayback);
         }
 
         // 기존 이력 재사용 또는 새로운 playback 생성
@@ -123,6 +122,7 @@ public class PlaybackService {
 
         // 현재 곡 skip 처리
         currentPlayback.skip();
+        playbackRepository.save(currentPlayback);
 
         // 다음 곡 자동 재생
         Playback nextPlayback = Playback.create(
@@ -144,11 +144,6 @@ public class PlaybackService {
     }
 
     private Playback handlePlay(Playback playback, PlaybackPlayRequest request) {
-        // 이미 재생 중이면 예외
-        if (playback.isPlaying()) {
-            throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
-        }
-
         // 일시정지 상태 후 재개
         if (playback.isPaused()) {
             playback.resume();

--- a/src/test/java/com/fivefy/domain/playback/controller/PlaybackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playback/controller/PlaybackControllerTest.java
@@ -1,0 +1,520 @@
+package com.fivefy.domain.playback.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playback.dto.request.PlaybackPauseRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackPlayRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackSkipRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackStopRequest;
+import com.fivefy.domain.playback.dto.response.PlaybackResponse;
+import com.fivefy.domain.playback.enums.PlaybackErrorCode;
+import com.fivefy.domain.playback.enums.PlaybackStatus;
+import com.fivefy.domain.playback.service.PlaybackService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import tools.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PlaybackController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlaybackControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PlaybackService playbackService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @Nested
+    @DisplayName("재생 시작")
+    class Play {
+
+        @Test
+        @DisplayName("재생 시작 성공 시 200 반환")
+        void playSuccess() throws Exception {
+            // given
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+            PlaybackResponse response = new PlaybackResponse(
+                    1L,
+                    1L,
+                    10L,
+                    100L,
+                    "session-1",
+                    "device-1",
+                    PlaybackStatus.PLAYING,
+                    0,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    null
+            );
+
+            given(playbackService.play(any(), any(PlaybackPlayRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/play")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("재생 시작 성공"))
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andExpect(jsonPath("$.data.playlistId").value(1L))
+                    .andExpect(jsonPath("$.data.trackId").value(10L))
+                    .andExpect(jsonPath("$.data.status").value("PLAYING"));
+        }
+
+        @Test
+        @DisplayName("playlistId 없이 재생 시작 요청 시 400 반환")
+        void playWithoutPlaylistId() throws Exception {
+            // given
+            String request = """
+                    {
+                      "trackId": 10,
+                      "sessionId": "session-1",
+                      "deviceId": "device-1"
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/play")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("trackId 없이 재생 시작 요청 시 400 반환")
+        void playWithoutTrackId() throws Exception {
+            // given
+            String request = """
+                    {
+                      "playlistId": 1,
+                      "sessionId": "session-1",
+                      "deviceId": "device-1"
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/play")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("sessionId 없이 재생 시작 요청 시 400 반환")
+        void playWithoutSessionId() throws Exception {
+            // given
+            String request = """
+                    {
+                      "playlistId": 1,
+                      "trackId": 10,
+                      "sessionId": "",
+                      "deviceId": "device-1"
+                    }
+                    """;
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/play")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("이미 재생 중인 곡을 다시 재생 요청하면 409 반환")
+        void playInvalidState() throws Exception {
+            // given
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            given(playbackService.play(any(), any(PlaybackPlayRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/play")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()));
+        }
+
+        @Test
+        @DisplayName("플레이리스트에 포함되지 않은 트랙 재생 요청 시 400 반환")
+        void playPlaylistTrackNotIncluded() throws Exception {
+            // given
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            given(playbackService.play(any(), any(PlaybackPlayRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/play")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("재생 일시정지")
+    class Pause {
+
+        @Test
+        @DisplayName("재생 일시정지 성공 시 200 반환")
+        void pauseSuccess() throws Exception {
+            // given
+            PlaybackPauseRequest request = new PlaybackPauseRequest(1L);
+            PlaybackResponse response = new PlaybackResponse(
+                    1L,
+                    1L,
+                    10L,
+                    100L,
+                    "session-1",
+                    "device-1",
+                    PlaybackStatus.PAUSED,
+                    30,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    null
+            );
+
+            given(playbackService.pause(any(), any(PlaybackPauseRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/pause")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("재생 일시정지 성공"))
+                    .andExpect(jsonPath("$.data.status").value("PAUSED"));
+        }
+
+        @Test
+        @DisplayName("id 없이 일시정지 요청 시 400 반환")
+        void pauseWithoutId() throws Exception {
+            // given
+            String request = "{}";
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/pause")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재생 기록 일시정지 시 404 반환")
+        void pauseNotFound() throws Exception {
+            // given
+            PlaybackPauseRequest request = new PlaybackPauseRequest(1L);
+
+            given(playbackService.pause(any(), any(PlaybackPauseRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.PLAYBACK_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/pause")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("현재 재생 중이 아닌 경우 일시정지 시 409 반환")
+        void pauseCurrentPlaybackNotFound() throws Exception {
+            // given
+            PlaybackPauseRequest request = new PlaybackPauseRequest(1L);
+
+            given(playbackService.pause(any(), any(PlaybackPauseRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/pause")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("곡 건너뛰기")
+    class Skip {
+
+        @Test
+        @DisplayName("곡 건너뛰기 성공 시 200 반환")
+        void skipSuccess() throws Exception {
+            // given
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+            PlaybackResponse response = new PlaybackResponse(
+                    2L,
+                    1L,
+                    20L,
+                    100L,
+                    "session-1",
+                    "device-1",
+                    PlaybackStatus.PLAYING,
+                    0,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    null
+            );
+
+            given(playbackService.skip(any(), any(PlaybackSkipRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/skip")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("곡 건너뛰기 성공"))
+                    .andExpect(jsonPath("$.data.id").value(2L))
+                    .andExpect(jsonPath("$.data.trackId").value(20L))
+                    .andExpect(jsonPath("$.data.status").value("PLAYING"));
+        }
+
+        @Test
+        @DisplayName("id 없이 곡 건너뛰기 요청 시 400 반환")
+        void skipWithoutId() throws Exception {
+            // given
+            String request = "{}";
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/skip")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재생 기록 건너뛰기 시 404 반환")
+        void skipNotFound() throws Exception {
+            // given
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            given(playbackService.skip(any(), any(PlaybackSkipRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.PLAYBACK_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/skip")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("현재 재생 상태에서 건너뛸 수 없으면 409 반환")
+        void skipInvalidState() throws Exception {
+            // given
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            given(playbackService.skip(any(), any(PlaybackSkipRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/skip")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()));
+        }
+
+        @Test
+        @DisplayName("플레이리스트 트랙 정보가 없으면 404 반환")
+        void skipPlaylistTrackNotFound() throws Exception {
+            // given
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            given(playbackService.skip(any(), any(PlaybackSkipRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/skip")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("현재 재생 트랙 정보와 플레이리스트 트랙 순서가 일치하지 않으면 409 반환")
+        void skipTrackMismatch() throws Exception {
+            // given
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            given(playbackService.skip(any(), any(PlaybackSkipRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/skip")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("곡 정지")
+    class Stop {
+
+        @Test
+        @DisplayName("곡 정지 성공 시 200 반환")
+        void stopSuccess() throws Exception {
+            // given
+            PlaybackStopRequest request = new PlaybackStopRequest(1L);
+            PlaybackResponse response = new PlaybackResponse(
+                    1L,
+                    1L,
+                    10L,
+                    100L,
+                    "session-1",
+                    "device-1",
+                    PlaybackStatus.STOPPED,
+                    40,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    LocalDateTime.now()
+            );
+
+            given(playbackService.stop(any(), any(PlaybackStopRequest.class)))
+                    .willReturn(response);
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/stop")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("곡 정지 성공"))
+                    .andExpect(jsonPath("$.data.status").value("STOPPED"));
+        }
+
+        @Test
+        @DisplayName("id 없이 곡 정지 요청 시 400 반환")
+        void stopWithoutId() throws Exception {
+            // given
+            String request = "{}";
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/stop")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(request))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재생 기록 정지 시 404 반환")
+        void stopNotFound() throws Exception {
+            // given
+            PlaybackStopRequest request = new PlaybackStopRequest(1L);
+
+            given(playbackService.stop(any(), any(PlaybackStopRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.PLAYBACK_NOT_FOUND));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/stop")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("현재 재생 상태에서 정지할 수 없으면 409 반환")
+        void stopInvalidState() throws Exception {
+            // given
+            PlaybackStopRequest request = new PlaybackStopRequest(1L);
+
+            given(playbackService.stop(any(), any(PlaybackStopRequest.class)))
+                    .willThrow(new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE));
+
+            // when & then
+            mockMvc.perform(post("/api/playbacks/stop")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("재생 기록 조회")
+    class GetPlaybackHistory {
+
+        @Test
+        @DisplayName("재생 기록 조회 성공 시 200 반환")
+        void getPlaybackHistorySuccess() throws Exception {
+            // given
+            PlaybackResponse response1 = new PlaybackResponse(
+                    2L,
+                    1L,
+                    20L,
+                    100L,
+                    "session-1",
+                    "device-1",
+                    PlaybackStatus.SKIPPED,
+                    25,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    LocalDateTime.now()
+            );
+            PlaybackResponse response2 = new PlaybackResponse(
+                    1L,
+                    1L,
+                    10L,
+                    100L,
+                    "session-1",
+                    "device-1",
+                    PlaybackStatus.COMPLETED,
+                    180,
+                    LocalDateTime.now(),
+                    LocalDateTime.now(),
+                    LocalDateTime.now()
+            );
+
+            given(playbackService.getPlaybackHistory(any()))
+                    .willReturn(List.of(response1, response2));
+
+            // when & then
+            mockMvc.perform(get("/api/me/playback-history"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("재생 기록 조회 성공"))
+                    .andExpect(jsonPath("$.data.length()").value(2))
+                    .andExpect(jsonPath("$.data[0].id").value(2L))
+                    .andExpect(jsonPath("$.data[0].status").value("SKIPPED"))
+                    .andExpect(jsonPath("$.data[1].id").value(1L))
+                    .andExpect(jsonPath("$.data[1].status").value("COMPLETED"));
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/playback/entity/PlaybackTest.java
+++ b/src/test/java/com/fivefy/domain/playback/entity/PlaybackTest.java
@@ -1,0 +1,338 @@
+package com.fivefy.domain.playback.entity;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playback.enums.PlaybackErrorCode;
+import com.fivefy.domain.playback.enums.PlaybackStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PlaybackTest {
+
+    @Test
+    @DisplayName("재생 생성 성공")
+    void create_success() {
+        // given
+        Long playlistId = 1L;
+        Long trackId = 10L;
+        Long userId = 100L;
+        String sessionId = "session-1";
+        String deviceId = "device-1";
+
+        // when
+        Playback playback = Playback.create(playlistId, trackId, userId, sessionId, deviceId);
+
+        // then
+        assertThat(playback.getPlaylistId()).isEqualTo(playlistId);
+        assertThat(playback.getTrackId()).isEqualTo(trackId);
+        assertThat(playback.getUserId()).isEqualTo(userId);
+        assertThat(playback.getSessionId()).isEqualTo(sessionId);
+        assertThat(playback.getDeviceId()).isEqualTo(deviceId);
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.PLAYING);
+        assertThat(playback.getPlayedDuration()).isEqualTo(0);
+        assertThat(playback.getStartedAt()).isNotNull();
+        assertThat(playback.getLastPlayedAt()).isNotNull();
+        assertThat(playback.getEndedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("재생 생성 시 playlistId가 null이면 예외 발생")
+    void create_invalid_playlistId_null() {
+        // given & when & then
+        assertThatThrownBy(() ->
+                Playback.create(null, 10L, 1L, "session-1", "device-1")
+        ).isInstanceOf(NullPointerException.class)
+                .hasMessage("playlistId(은)는 필수입니다");
+    }
+
+    @Test
+    @DisplayName("재생 생성 시 trackId가 null이면 예외 발생")
+    void create_invalid_trackId_null() {
+        // given & when & then
+        assertThatThrownBy(() ->
+                Playback.create(1L, null, 1L, "session-1", "device-1")
+        ).isInstanceOf(NullPointerException.class)
+                .hasMessage("trackId(은)는 필수입니다");
+    }
+
+    @Test
+    @DisplayName("재생 생성 시 userId가 null이면 예외 발생")
+    void create_invalid_userId_null() {
+        // given & when & then
+        assertThatThrownBy(() ->
+                Playback.create(1L, 10L, null, "session-1", "device-1")
+        ).isInstanceOf(NullPointerException.class)
+                .hasMessage("userId(은)는 필수입니다");
+    }
+
+    @Test
+    @DisplayName("재생 생성 시 sessionId가 null이면 예외 발생")
+    void create_invalid_sessionId_null() {
+        // given & when & then
+        assertThatThrownBy(() ->
+                Playback.create(1L, 10L, 1L, null, "device-1")
+        ).isInstanceOf(NullPointerException.class)
+                .hasMessage("sessionId(은)는 필수입니다");
+    }
+
+    @Test
+    @DisplayName("본인 재생 기록이면 true 반환")
+    void isOwner_true() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+
+        // when
+        boolean result = playback.isOwner(1L);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("본인 재생 기록이 아니면 false 반환")
+    void isOwner_false() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+
+        // when
+        boolean result = playback.isOwner(2L);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("재생 중 상태 확인")
+    void isPlaying_true() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+
+        // when & then
+        assertThat(playback.isPlaying()).isTrue();
+        assertThat(playback.isPaused()).isFalse();
+        assertThat(playback.isStopped()).isFalse();
+        assertThat(playback.isSkipped()).isFalse();
+        assertThat(playback.isCompleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("일시정지 상태 확인")
+    void isPaused_true() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+        // when & then
+        assertThat(playback.isPaused()).isTrue();
+        assertThat(playback.isPlaying()).isFalse();
+    }
+
+    @Test
+    @DisplayName("정지 상태 확인")
+    void isStopped_true() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.STOPPED);
+
+        // when & then
+        assertThat(playback.isStopped()).isTrue();
+    }
+
+    @Test
+    @DisplayName("건너뛴 상태 확인")
+    void isSkipped_true() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.SKIPPED);
+
+        // when & then
+        assertThat(playback.isSkipped()).isTrue();
+    }
+
+    @Test
+    @DisplayName("재생 완료 상태 확인")
+    void isCompleted_true() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.COMPLETED);
+
+        // when & then
+        assertThat(playback.isCompleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("일시정지 상태에서 재개 성공")
+    void resume_success() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+        // when
+        playback.resume();
+
+        // then
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.PLAYING);
+    }
+
+    @Test
+    @DisplayName("일시정지 상태가 아니면 재개 시 예외 발생")
+    void resume_invalid_state() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+
+        // when & then
+        assertThatThrownBy(playback::resume)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("재생 중인 곡 일시정지 성공")
+    void pause_success() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "lastPlayedAt", LocalDateTime.now().minusSeconds(5));
+
+        // when
+        playback.pause();
+
+        // then
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.PAUSED);
+        assertThat(playback.getPlayedDuration()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("재생 중이 아니면 일시정지 시 예외 발생")
+    void pause_invalid_state() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+        // when & then
+        assertThatThrownBy(playback::pause)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("재생 중인 곡 정지 성공")
+    void stop_playing_success() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "lastPlayedAt", LocalDateTime.now().minusSeconds(5));
+
+        // when
+        playback.stop();
+
+        // then
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.STOPPED);
+        assertThat(playback.getEndedAt()).isNotNull();
+        assertThat(playback.getPlayedDuration()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("일시정지 상태의 곡 정지 성공")
+    void stop_paused_success() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+        // when
+        playback.stop();
+
+        // then
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.STOPPED);
+        assertThat(playback.getEndedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("정지할 수 없는 상태면 예외 발생")
+    void stop_invalid_state() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.STOPPED);
+
+        // when & then
+        assertThatThrownBy(playback::stop)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("재생 중인 곡 건너뛰기 성공")
+    void skip_playing_success() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "lastPlayedAt", LocalDateTime.now().minusSeconds(5));
+
+        // when
+        playback.skip();
+
+        // then
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.SKIPPED);
+        assertThat(playback.getEndedAt()).isNotNull();
+        assertThat(playback.getPlayedDuration()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("일시정지 상태의 곡 건너뛰기 성공")
+    void skip_paused_success() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+        // when
+        playback.skip();
+
+        // then
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.SKIPPED);
+        assertThat(playback.getEndedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("건너뛸 수 없는 상태면 예외 발생")
+    void skip_invalid_state() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.STOPPED);
+
+        // when & then
+        assertThatThrownBy(playback::skip)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("재생 완료 성공")
+    void complete_success() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "lastPlayedAt", LocalDateTime.now().minusSeconds(5));
+
+        // when
+        playback.complete();
+
+        // then
+        assertThat(playback.getStatus()).isEqualTo(PlaybackStatus.COMPLETED);
+        assertThat(playback.getEndedAt()).isNotNull();
+        assertThat(playback.getPlayedDuration()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("재생 중이 아니면 완료 처리 시 예외 발생")
+    void complete_invalid_state() {
+        // given
+        Playback playback = Playback.create(1L, 10L, 1L, "session-1", "device-1");
+        ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+        // when & then
+        assertThatThrownBy(playback::complete)
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+    }
+}

--- a/src/test/java/com/fivefy/domain/playback/service/PlaybackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playback/service/PlaybackServiceTest.java
@@ -1,0 +1,685 @@
+package com.fivefy.domain.playback.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.playback.dto.request.PlaybackPauseRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackPlayRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackSkipRequest;
+import com.fivefy.domain.playback.dto.request.PlaybackStopRequest;
+import com.fivefy.domain.playback.dto.response.PlaybackResponse;
+import com.fivefy.domain.playback.entity.Playback;
+import com.fivefy.domain.playback.enums.PlaybackErrorCode;
+import com.fivefy.domain.playback.enums.PlaybackStatus;
+import com.fivefy.domain.playback.repository.PlaybackRepository;
+import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
+import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class PlaybackServiceTest {
+
+    @InjectMocks private PlaybackService playbackService;
+
+    @Mock private PlaybackRepository playbackRepository;
+    @Mock private PlaylistTrackRepository playlistTrackRepository;
+
+    @Nested
+    @DisplayName("재생 시작")
+    class Play {
+
+        @Test
+        @DisplayName("새로운 재생 시작 성공")
+        void playSuccessNewPlayback() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback playback = Playback.create(
+                    request.playlistId(),
+                    request.trackId(),
+                    userId,
+                    request.sessionId(),
+                    request.deviceId()
+            );
+            ReflectionTestUtils.setField(playback, "id", 1L);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.empty());
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId, 1L, 10L, "session-1"
+            )).willReturn(Optional.empty());
+            given(playbackRepository.save(any(Playback.class))).willReturn(playback);
+
+            // when
+            PlaybackResponse result = playbackService.play(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.playlistId()).isEqualTo(1L);
+            assertThat(result.trackId()).isEqualTo(10L);
+            assertThat(result.userId()).isEqualTo(userId);
+            assertThat(result.sessionId()).isEqualTo("session-1");
+            assertThat(result.deviceId()).isEqualTo("device-1");
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("플레이리스트에 포함되지 않은 트랙이면 예외 발생")
+        void playPlaylistTrackNotIncluded() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.play(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED.getMessage());
+        }
+
+        @Test
+        @DisplayName("일시정지 상태의 재생 기록이면 재개 성공")
+        void playResumeSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback playback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(playback, "id", 1L);
+            ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.empty());
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId, 1L, 10L, "session-1"
+            )).willReturn(Optional.of(playback));
+            given(playbackRepository.save(any(Playback.class))).willReturn(playback);
+
+            // when
+            PlaybackResponse result = playbackService.play(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("정지 상태의 재생 기록이면 새 재생 기록 생성 성공")
+        void playStoppedPlaybackCreateNewSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback stoppedPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(stoppedPlayback, "id", 1L);
+            ReflectionTestUtils.setField(stoppedPlayback, "status", PlaybackStatus.STOPPED);
+
+            Playback newPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(newPlayback, "id", 2L);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.empty());
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId, 1L, 10L, "session-1"
+            )).willReturn(Optional.of(stoppedPlayback));
+            given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.play(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("완료 상태의 재생 기록이면 새 재생 기록 생성 성공")
+        void playCompletedPlaybackCreateNewSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback completedPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(completedPlayback, "id", 1L);
+            ReflectionTestUtils.setField(completedPlayback, "status", PlaybackStatus.COMPLETED);
+
+            Playback newPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(newPlayback, "id", 2L);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.empty());
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId, 1L, 10L, "session-1"
+            )).willReturn(Optional.of(completedPlayback));
+            given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.play(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("건너뛴 상태의 재생 기록이면 새 재생 기록 생성 성공")
+        void playSkippedPlaybackCreateNewSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback skippedPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(skippedPlayback, "id", 1L);
+            ReflectionTestUtils.setField(skippedPlayback, "status", PlaybackStatus.SKIPPED);
+
+            Playback newPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(newPlayback, "id", 2L);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.empty());
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId, 1L, 10L, "session-1"
+            )).willReturn(Optional.of(skippedPlayback));
+            given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.play(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("이미 같은 세션에서 같은 곡이 재생 중이면 예외 발생")
+        void playAlreadyPlayingSameTrack() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback currentPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.of(currentPlayback));
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.play(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+        }
+
+        @Test
+        @DisplayName("같은 세션에서 다른 곡이 재생 중이면 기존 곡 정지 후 새 곡 재생 성공")
+        void playDifferentTrackWhilePlaying() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 20L, "session-1", "device-1");
+
+            Playback currentPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+
+            Playback newPlayback = Playback.create(1L, 20L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(newPlayback, "id", 2L);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 20L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.of(currentPlayback));
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId, 1L, 20L, "session-1"
+            )).willReturn(Optional.empty());
+            given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.play(userId, request);
+
+            // then
+            assertThat(currentPlayback.getStatus()).isEqualTo(PlaybackStatus.STOPPED);
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.trackId()).isEqualTo(20L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("기존 이력이 재생 중 상태면 새 재생 기록 생성")
+        void playExistingHistoryPlayingCreateNewPlayback() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback existingPlayingPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(existingPlayingPlayback, "id", 1L);
+
+            Playback newPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(newPlayback, "id", 2L);
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.empty());
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId, 1L, 10L, "session-1"
+            )).willReturn(Optional.of(existingPlayingPlayback));
+            given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.play(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("같은 세션에서 같은 곡 재생 중이면 예외 발생")
+        void playSameTrackWhilePlaying() {
+            // given
+            Long userId = 1L;
+            PlaybackPlayRequest request = new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            Playback currentPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+            // create() 기본 상태 = PLAYING
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L)).willReturn(true);
+
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId, "session-1", PlaybackStatus.PLAYING
+            )).willReturn(Optional.of(currentPlayback));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    playbackService.play(userId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("재생 일시정지")
+    class Pause {
+
+        @Test
+        @DisplayName("재생 일시정지 성공")
+        void pauseSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackPauseRequest request = new PlaybackPauseRequest(1L);
+
+            Playback playback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(playback, "id", 1L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(playback));
+
+            // when
+            PlaybackResponse result = playbackService.pause(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PAUSED);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재생 기록이면 예외 발생")
+        void pausePlaybackNotFound() {
+            // given
+            Long userId = 1L;
+            PlaybackPauseRequest request = new PlaybackPauseRequest(1L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.pause(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("현재 재생 중인 음악이 아니면 예외 발생")
+        void pauseCurrentPlaybackNotFound() {
+            // given
+            Long userId = 1L;
+            PlaybackPauseRequest request = new PlaybackPauseRequest(1L);
+
+            Playback playback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(playback, "id", 1L);
+            ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(playback));
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.pause(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("곡 정지")
+    class Stop {
+
+        @Test
+        @DisplayName("재생 중인 곡 정지 성공")
+        void stopPlayingSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackStopRequest request = new PlaybackStopRequest(1L);
+
+            Playback playback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(playback, "id", 1L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(playback));
+
+            // when
+            PlaybackResponse result = playbackService.stop(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.STOPPED);
+            assertThat(result.endedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("일시정지 상태의 곡 정지 성공")
+        void stopPausedSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackStopRequest request = new PlaybackStopRequest(1L);
+
+            Playback playback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(playback, "id", 1L);
+            ReflectionTestUtils.setField(playback, "status", PlaybackStatus.PAUSED);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(playback));
+
+            // when
+            PlaybackResponse result = playbackService.stop(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.STOPPED);
+            assertThat(result.endedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재생 기록이면 예외 발생")
+        void stopPlaybackNotFound() {
+            // given
+            Long userId = 1L;
+            PlaybackStopRequest request = new PlaybackStopRequest(1L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.stop(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("정지할 수 없는 상태면 예외 발생")
+        void stopInvalidState() {
+            // given
+            Long userId = 1L;
+            PlaybackStopRequest request = new PlaybackStopRequest(1L);
+
+            Playback playback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(playback, "id", 1L);
+            ReflectionTestUtils.setField(playback, "status", PlaybackStatus.STOPPED);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(playback));
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.stop(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("곡 건너뛰기")
+    class Skip {
+
+        @Test
+        @DisplayName("곡 건너뛰기 성공")
+        void skipSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            Playback currentPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+
+            PlaylistTrack currentTrack = mock(PlaylistTrack.class);
+            PlaylistTrack nextTrack = mock(PlaylistTrack.class);
+
+            given(currentTrack.getTrackId()).willReturn(10L);
+            given(nextTrack.getTrackId()).willReturn(20L);
+
+            Playback nextPlayback = Playback.create(1L, 20L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(nextPlayback, "id", 2L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(currentPlayback));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
+                    .willReturn(List.of(currentTrack, nextTrack));
+            given(playbackRepository.save(any(Playback.class))).willReturn(nextPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.skip(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.trackId()).isEqualTo(20L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("마지막 곡에서 건너뛰면 처음 곡으로 순환")
+        void skipWrapAroundSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            Playback currentPlayback = Playback.create(1L, 20L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+
+            PlaylistTrack firstTrack = mock(PlaylistTrack.class);
+            PlaylistTrack lastTrack = mock(PlaylistTrack.class);
+
+            given(firstTrack.getTrackId()).willReturn(10L);
+            given(lastTrack.getTrackId()).willReturn(20L);
+
+            Playback nextPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(nextPlayback, "id", 2L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(currentPlayback));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
+                    .willReturn(List.of(firstTrack, lastTrack));
+            given(playbackRepository.save(any(Playback.class))).willReturn(nextPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.skip(userId, request);
+
+            // then
+            assertThat(result.trackId()).isEqualTo(10L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 재생 기록이면 예외 발생")
+        void skipPlaybackNotFound() {
+            // given
+            Long userId = 1L;
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.skip(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("건너뛸 수 없는 상태면 예외 발생")
+        void skipInvalidState() {
+            // given
+            Long userId = 1L;
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            Playback currentPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+            ReflectionTestUtils.setField(currentPlayback, "status", PlaybackStatus.STOPPED);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(currentPlayback));
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.skip(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+        }
+
+        @Test
+        @DisplayName("플레이리스트 트랙 정보가 없으면 예외 발생")
+        void skipPlaylistTrackNotFound() {
+            // given
+            Long userId = 1L;
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            Playback currentPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(currentPlayback));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
+                    .willReturn(List.of());
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.skip(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("현재 트랙이 플레이리스트 트랙 순서와 일치하지 않으면 예외 발생")
+        void skipTrackMismatch() {
+            // given
+            Long userId = 1L;
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            Playback currentPlayback = Playback.create(1L, 999L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+
+            PlaylistTrack track1 = mock(PlaylistTrack.class);
+            PlaylistTrack track2 = mock(PlaylistTrack.class);
+
+            given(track1.getTrackId()).willReturn(10L);
+            given(track2.getTrackId()).willReturn(20L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(currentPlayback));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
+                    .willReturn(List.of(track1, track2));
+
+            // when & then
+            assertThatThrownBy(() -> playbackService.skip(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH.getMessage());
+        }
+
+        @Test
+        @DisplayName("일시정지 상태에서 곡 건너뛰기 성공")
+        void skipPausedSuccess() {
+            // given
+            Long userId = 1L;
+            PlaybackSkipRequest request = new PlaybackSkipRequest(1L);
+
+            Playback currentPlayback = Playback.create(1L, 10L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(currentPlayback, "id", 1L);
+            ReflectionTestUtils.setField(currentPlayback, "status", PlaybackStatus.PAUSED);
+
+            PlaylistTrack currentTrack = mock(PlaylistTrack.class);
+            PlaylistTrack nextTrack = mock(PlaylistTrack.class);
+
+            given(currentTrack.getTrackId()).willReturn(10L);
+            given(nextTrack.getTrackId()).willReturn(20L);
+
+            Playback nextPlayback = Playback.create(1L, 20L, userId, "session-1", "device-1");
+            ReflectionTestUtils.setField(nextPlayback, "id", 2L);
+
+            given(playbackRepository.findByIdAndUserId(1L, userId)).willReturn(Optional.of(currentPlayback));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
+                    .willReturn(List.of(currentTrack, nextTrack));
+            given(playbackRepository.save(any(Playback.class))).willReturn(nextPlayback);
+
+            // when
+            PlaybackResponse result = playbackService.skip(userId, request);
+
+            // then
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.trackId()).isEqualTo(20L);
+            assertThat(result.status()).isEqualTo(PlaybackStatus.PLAYING);
+        }
+    }
+
+    @Nested
+    @DisplayName("재생 기록 조회")
+    class GetPlaybackHistory {
+
+        @Test
+        @DisplayName("재생 기록 조회 성공")
+        void getPlaybackHistorySuccess() {
+            // given
+            Long userId = 1L;
+
+            Playback playback1 = Playback.create(1L, 20L, userId, "session-1", "device-1");
+            Playback playback2 = Playback.create(1L, 10L, userId, "session-1", "device-1");
+
+            ReflectionTestUtils.setField(playback1, "id", 2L);
+            ReflectionTestUtils.setField(playback2, "id", 1L);
+            ReflectionTestUtils.setField(playback1, "status", PlaybackStatus.SKIPPED);
+            ReflectionTestUtils.setField(playback2, "status", PlaybackStatus.COMPLETED);
+
+            given(playbackRepository.findAllByUserIdOrderByIdDesc(userId))
+                    .willReturn(List.of(playback1, playback2));
+
+            // when
+            List<PlaybackResponse> result = playbackService.getPlaybackHistory(userId);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).id()).isEqualTo(2L);
+            assertThat(result.get(0).status()).isEqualTo(PlaybackStatus.SKIPPED);
+            assertThat(result.get(1).id()).isEqualTo(1L);
+            assertThat(result.get(1).status()).isEqualTo(PlaybackStatus.COMPLETED);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

> Playback 도메인 재생 흐름(play, pause, stop, skip, resume)에 대한  
컨트롤러, 서비스, 엔티티 테스트를 추가하여 전체 흐름을 검증하였습니다.

## 변경 사항

- Playback 컨트롤러 테스트 코드 작성
  - 재생 / 일시정지 / 정지 / 건너뛰기 / 조회 API 검증

- Playback 서비스 테스트 코드 작성
  - 재생 흐름(play → pause → resume → stop → skip) 상태 전이 검증
  - 동일 곡 중복 재생 방지 로직 검증

- Playback 엔티티 테스트 코드 작성
  - 상태 전이 로직 (resume, pause, stop, skip, complete) 검증
  - 예외 처리 및 유효성 검증 테스트 추가

- API 예외 케이스 테스트 보강
  - 400 (잘못된 요청)
  - 404 (재생 기록 없음)
  - 409 (잘못된 상태 전이)

- 테스트 작성 과정에서 발견된 로직 개선
  - 동일 곡 재생 시 예외 처리로 흐름 명확화
  - 상태 변경 시 명시적 save() 적용

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 스크린샷

- Playback 도메인 테스트 커버리지
<img width="1735" height="389" alt="image" src="https://github.com/user-attachments/assets/ff9f523a-fcc6-495f-b067-58e3b8f39f5a" />

- 테스트 설계 및 커버리지 판단 과정 (도달 불가능 분기 및 방어 코드 분석)
<https://sudaruuu.tistory.com/139>

## 체크리스트

- [ ] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 재생 상태 관리 로직 개선으로 중복 재생 요청 방지 및 상태 전환 안정성 강화

* **테스트**
  * 재생 기능에 대한 포괄적인 테스트 스위트 추가로 코드 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->