### PR TITLE
feat: 앨범 등록 요청 생성/조회 API 및 publishDelayDays 정책 반영

### DIFF
--- a/src/main/java/com/fivefy/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/fivefy/domain/album/controller/AlbumController.java
@@ -2,6 +2,7 @@ package com.fivefy.domain.album.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
 import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestDetailResponse;
 import com.fivefy.domain.album.dto.response.AlbumReleaseRequestResponse;
 import com.fivefy.domain.album.service.AlbumService;
 import jakarta.validation.Valid;
@@ -51,6 +52,22 @@ public class AlbumController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "내 앨범 등록 요청 목록 조회 성공", response)
+        );
+    }
+
+    /**
+     * 앨범 등록 요청 상세 조회 API
+     */
+    @GetMapping("/album-release-requests/{requestId}")
+    public ResponseEntity<BaseResponse<AlbumReleaseRequestDetailResponse>> getAlbumReleaseRequest(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long requestId
+    ) {
+        AlbumReleaseRequestDetailResponse response =
+                albumService.getAlbumReleaseRequest(userId, requestId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "앨범 등록 요청 상세 조회 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/fivefy/domain/album/controller/AlbumController.java
@@ -1,0 +1,39 @@
+package com.fivefy.domain.album.controller;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestCreateResponse;
+import com.fivefy.domain.album.service.AlbumService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 앨범 도메인 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AlbumController {
+
+    private final AlbumService albumService;
+
+    /**
+     * 앨범 등록 요청 생성 API
+     */
+    @PostMapping("/album-release-requests")
+    public ResponseEntity<BaseResponse<AlbumReleaseRequestCreateResponse>> createAlbumReleaseRequest(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody AlbumReleaseRequestCreateRequest request
+    ) {
+        AlbumReleaseRequestCreateResponse response =
+                albumService.createAlbumReleaseRequest(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                BaseResponse.success(HttpStatus.CREATED, "앨범 등록 요청 성공", response)
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/controller/AlbumController.java
+++ b/src/main/java/com/fivefy/domain/album/controller/AlbumController.java
@@ -2,7 +2,7 @@ package com.fivefy.domain.album.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
 import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
-import com.fivefy.domain.album.dto.response.AlbumReleaseRequestCreateResponse;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestResponse;
 import com.fivefy.domain.album.service.AlbumService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 앨범 도메인 컨트롤러
@@ -25,15 +27,30 @@ public class AlbumController {
      * 앨범 등록 요청 생성 API
      */
     @PostMapping("/album-release-requests")
-    public ResponseEntity<BaseResponse<AlbumReleaseRequestCreateResponse>> createAlbumReleaseRequest(
+    public ResponseEntity<BaseResponse<AlbumReleaseRequestResponse>> createAlbumReleaseRequest(
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody AlbumReleaseRequestCreateRequest request
     ) {
-        AlbumReleaseRequestCreateResponse response =
+        AlbumReleaseRequestResponse response =
                 albumService.createAlbumReleaseRequest(userId, request);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 BaseResponse.success(HttpStatus.CREATED, "앨범 등록 요청 성공", response)
+        );
+    }
+
+    /**
+     * 내 앨범 등록 요청 목록 조회 API
+     */
+    @GetMapping("/album-release-requests/me")
+    public ResponseEntity<BaseResponse<List<AlbumReleaseRequestResponse>>> getMyAlbumReleaseRequests(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<AlbumReleaseRequestResponse> response =
+                albumService.getMyAlbumReleaseRequests(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "내 앨범 등록 요청 목록 조회 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/album/dto/request/AlbumReleaseRequestCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/album/dto/request/AlbumReleaseRequestCreateRequest.java
@@ -1,10 +1,6 @@
 package com.fivefy.domain.album.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 /**
  * 앨범 등록 요청 생성 요청 DTO

--- a/src/main/java/com/fivefy/domain/album/dto/request/AlbumReleaseRequestCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/album/dto/request/AlbumReleaseRequestCreateRequest.java
@@ -1,0 +1,32 @@
+package com.fivefy.domain.album.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 앨범 등록 요청 생성 요청 DTO
+ */
+public record AlbumReleaseRequestCreateRequest(
+
+        @NotNull(message = "아티스트 ID는 필수입니다.")
+        Long artistId,
+
+        @NotBlank(message = "앨범 제목은 필수입니다.")
+        @Size(max = 150, message = "앨범 제목은 150자 이하여야 합니다.")
+        String title,
+
+        String description,
+
+        @Size(max = 255, message = "커버 이미지 URL은 255자 이하여야 합니다.")
+        String coverImageUrl,
+
+        @NotNull(message = "공개 예약 옵션은 필수입니다.")
+        @Min(value = 0, message = "공개 예약 옵션은 0 이상이어야 합니다.")
+        @Max(value = 7, message = "공개 예약 옵션은 7 이하여야 합니다.")
+        Integer publishDelayDays
+
+) {
+}

--- a/src/main/java/com/fivefy/domain/album/dto/response/AlbumReleaseRequestCreateResponse.java
+++ b/src/main/java/com/fivefy/domain/album/dto/response/AlbumReleaseRequestCreateResponse.java
@@ -1,0 +1,29 @@
+package com.fivefy.domain.album.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.album.entity.AlbumReleaseRequest;
+
+import java.time.LocalDateTime;
+
+/**
+ * 앨범 등록 요청 생성 응답 DTO
+ */
+public record AlbumReleaseRequestCreateResponse(
+
+        Long requestId,
+        Long artistId,
+        String title,
+        ApplicationStatus status,
+        LocalDateTime createdAt
+
+) {
+    public static AlbumReleaseRequestCreateResponse from(AlbumReleaseRequest albumReleaseRequest) {
+        return new AlbumReleaseRequestCreateResponse(
+                albumReleaseRequest.getId(),
+                albumReleaseRequest.getArtistId(),
+                albumReleaseRequest.getTitle(),
+                albumReleaseRequest.getStatus(),
+                albumReleaseRequest.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/dto/response/AlbumReleaseRequestDetailResponse.java
+++ b/src/main/java/com/fivefy/domain/album/dto/response/AlbumReleaseRequestDetailResponse.java
@@ -1,0 +1,43 @@
+package com.fivefy.domain.album.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.album.entity.AlbumReleaseRequest;
+
+import java.time.LocalDateTime;
+
+/**
+ * 앨범 등록 요청 상세 응답 DTO
+ */
+public record AlbumReleaseRequestDetailResponse(
+        Long requestId,
+        Long requesterUserId,
+        Long artistId,
+        String title,
+        String description,
+        String coverImageUrl,
+        Integer publishDelayDays,
+        ApplicationStatus status,
+        Long reviewedByAdminId,
+        LocalDateTime reviewedAt,
+        String rejectionReason,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static AlbumReleaseRequestDetailResponse from(AlbumReleaseRequest request) {
+        return new AlbumReleaseRequestDetailResponse(
+                request.getId(),
+                request.getRequesterUserId(),
+                request.getArtistId(),
+                request.getTitle(),
+                request.getDescription(),
+                request.getCoverImageUrl(),
+                request.getPublishDelayDays(),
+                request.getStatus(),
+                request.getReviewedByAdminId(),
+                request.getReviewedAt(),
+                request.getRejectionReason(),
+                request.getCreatedAt(),
+                request.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/dto/response/AlbumReleaseRequestResponse.java
+++ b/src/main/java/com/fivefy/domain/album/dto/response/AlbumReleaseRequestResponse.java
@@ -6,9 +6,9 @@ import com.fivefy.domain.album.entity.AlbumReleaseRequest;
 import java.time.LocalDateTime;
 
 /**
- * 앨범 등록 요청 생성 응답 DTO
+ * 앨범 등록 요청 생성 응답 및 내 앨범 등록 요청 목록 응답 DTO
  */
-public record AlbumReleaseRequestCreateResponse(
+public record AlbumReleaseRequestResponse(
 
         Long requestId,
         Long artistId,
@@ -17,8 +17,8 @@ public record AlbumReleaseRequestCreateResponse(
         LocalDateTime createdAt
 
 ) {
-    public static AlbumReleaseRequestCreateResponse from(AlbumReleaseRequest albumReleaseRequest) {
-        return new AlbumReleaseRequestCreateResponse(
+    public static AlbumReleaseRequestResponse from(AlbumReleaseRequest albumReleaseRequest) {
+        return new AlbumReleaseRequestResponse(
                 albumReleaseRequest.getId(),
                 albumReleaseRequest.getArtistId(),
                 albumReleaseRequest.getTitle(),

--- a/src/main/java/com/fivefy/domain/album/entity/Album.java
+++ b/src/main/java/com/fivefy/domain/album/entity/Album.java
@@ -42,9 +42,6 @@ public class Album extends BaseEntity {
     @Column(name = "cover_image_url", length = 255)
     private String coverImageUrl;
 
-    @Column(name = "release_at", nullable = false)
-    private LocalDateTime releaseAt;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
     private AlbumStatus status;
@@ -73,12 +70,10 @@ public class Album extends BaseEntity {
             String title,
             String description,
             String coverImageUrl,
-            LocalDateTime releaseAt,
             LocalDateTime scheduledPublishAt
     ) {
         validateNonNull(artistId, "artistId");
         validateNonNull(title, "title");
-        validateNonNull(releaseAt, "releaseAt");
 
         Album album = new Album();
 
@@ -86,7 +81,6 @@ public class Album extends BaseEntity {
         album.title = title;
         album.description = description;
         album.coverImageUrl = coverImageUrl;
-        album.releaseAt = releaseAt;
         album.scheduledPublishAt = scheduledPublishAt;
         album.status = AlbumStatus.UNPUBLISHED;
         album.trackCount = 0L;

--- a/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
+++ b/src/main/java/com/fivefy/domain/album/entity/AlbumReleaseRequest.java
@@ -46,11 +46,8 @@ public class AlbumReleaseRequest extends BaseEntity {
     @Column(name = "cover_image_url", length = 255)
     private String coverImageUrl;
 
-    @Column(name = "release_at", nullable = false)
-    private LocalDateTime releaseAt;
-
-    @Column(name = "scheduled_publish_at")
-    private LocalDateTime scheduledPublishAt;
+    @Column(name = "publish_delay_days", nullable = false)
+    private Integer publishDelayDays;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
@@ -75,13 +72,12 @@ public class AlbumReleaseRequest extends BaseEntity {
             String title,
             String description,
             String coverImageUrl,
-            LocalDateTime releaseAt,
-            LocalDateTime scheduledPublishAt
+            Integer publishDelayDays
     ) {
         validateNonNull(requesterUserId, "requesterUserId");
         validateNonNull(artistId, "artistId");
         validateNonNull(title, "title");
-        validateNonNull(releaseAt, "releaseAt");
+        validateNonNull(publishDelayDays, "publishDelayDays");
 
         AlbumReleaseRequest request = new AlbumReleaseRequest();
 
@@ -90,8 +86,7 @@ public class AlbumReleaseRequest extends BaseEntity {
         request.title = title;
         request.description = description;
         request.coverImageUrl = coverImageUrl;
-        request.releaseAt = releaseAt;
-        request.scheduledPublishAt = scheduledPublishAt;
+        request.publishDelayDays = publishDelayDays;
         request.status = ApplicationStatus.PENDING;
 
         return request;

--- a/src/main/java/com/fivefy/domain/album/enums/AlbumReleaseErrorCode.java
+++ b/src/main/java/com/fivefy/domain/album/enums/AlbumReleaseErrorCode.java
@@ -10,7 +10,8 @@ public enum AlbumReleaseErrorCode implements ErrorCode {
     ERR_ALBUM_RELEASE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 앨범 등록 요청입니다"),
     ERR_ALBUM_RELEASE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리중인 동일한 앨범 등록 요청입니다"),
     ERR_INVALID_PUBLISH_DELAY_DAYS(HttpStatus.BAD_REQUEST, "공개 예약일은 즉시 공개(0일) 또는 1일 후부터 7일 후까지만 선택할 수 있습니다"),
-    ERR_INACTIVE_ARTIST_CANNOT_REQUEST_ALBUM_RELEASE(HttpStatus.BAD_REQUEST, "비활성화된 아티스트로는 앨범 등록 요청을 할 수 없습니다");
+    ERR_INACTIVE_ARTIST_CANNOT_REQUEST_ALBUM_RELEASE(HttpStatus.BAD_REQUEST, "비활성화된 아티스트로는 앨범 등록 요청을 할 수 없습니다"),
+    ERR_ALBUM_RELEASE_DETAIL_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 또는 관리자만 앨범 등록 요청 상세 정보를 조회할 수 있습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/album/enums/AlbumReleaseErrorCode.java
+++ b/src/main/java/com/fivefy/domain/album/enums/AlbumReleaseErrorCode.java
@@ -6,8 +6,11 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum AlbumReleaseErrorCode implements ErrorCode {
-    ERR_ALBUM_RELEASE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 앨범 등록 요청입니다");
-
+    ERR_ALBUM_RELEASE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 앨범 등록 요청입니다"),
+    ERR_ALBUM_RELEASE_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 앨범 등록 요청입니다"),
+    ERR_ALBUM_RELEASE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리중인 동일한 앨범 등록 요청입니다"),
+    ERR_INVALID_PUBLISH_DELAY_DAYS(HttpStatus.BAD_REQUEST, "공개 예약일은 즉시 공개(0일) 또는 1일 후부터 7일 후까지만 선택할 수 있습니다"),
+    ERR_INACTIVE_ARTIST_CANNOT_REQUEST_ALBUM_RELEASE(HttpStatus.BAD_REQUEST, "비활성화된 아티스트로는 앨범 등록 요청을 할 수 없습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepository.java
@@ -1,0 +1,10 @@
+package com.fivefy.domain.album.repository;
+
+/**
+ * AlbumReleaseRequest Querydsl 전용 Repository
+ */
+public interface AlbumReleaseRequestQueryRepository {
+
+    // 동일 유저, 동일 아티스트, 동일 제목으로 진행 중(PENDING) 요청 존재 여부
+    boolean existsPendingRequest(Long requesterUserId, Long artistId, String title);
+}

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepository.java
@@ -1,10 +1,15 @@
 package com.fivefy.domain.album.repository;
 
+import com.fivefy.domain.album.entity.AlbumReleaseRequest;
+
+import java.util.List;
+
 /**
  * AlbumReleaseRequest Querydsl 전용 Repository
  */
 public interface AlbumReleaseRequestQueryRepository {
 
-    // 동일 유저, 동일 아티스트, 동일 제목으로 진행 중(PENDING) 요청 존재 여부
     boolean existsPendingRequest(Long requesterUserId, Long artistId, String title);
+
+    List<AlbumReleaseRequest> searchMyAlbumReleaseRequests(Long requesterUserId);
 }

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.fivefy.domain.album.repository;
 
 import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.album.entity.AlbumReleaseRequest;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 import static com.fivefy.domain.album.entity.QAlbumReleaseRequest.albumReleaseRequest;
 
@@ -25,5 +28,14 @@ public class AlbumReleaseRequestQueryRepositoryImpl implements AlbumReleaseReque
                 .fetchFirst();
 
         return result != null;
+    }
+
+    @Override
+    public List<AlbumReleaseRequest> searchMyAlbumReleaseRequests(Long requesterUserId) {
+        return queryFactory
+                .selectFrom(albumReleaseRequest)
+                .where(albumReleaseRequest.requesterUserId.eq(requesterUserId))
+                .orderBy(albumReleaseRequest.createdAt.desc())
+                .fetch();
     }
 }

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestQueryRepositoryImpl.java
@@ -1,0 +1,29 @@
+package com.fivefy.domain.album.repository;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.fivefy.domain.album.entity.QAlbumReleaseRequest.albumReleaseRequest;
+
+@RequiredArgsConstructor
+public class AlbumReleaseRequestQueryRepositoryImpl implements AlbumReleaseRequestQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsPendingRequest(Long requesterUserId, Long artistId, String title) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(albumReleaseRequest)
+                .where(
+                        albumReleaseRequest.requesterUserId.eq(requesterUserId),
+                        albumReleaseRequest.artistId.eq(artistId),
+                        albumReleaseRequest.title.eq(title),
+                        albumReleaseRequest.status.eq(ApplicationStatus.PENDING)
+                )
+                .fetchFirst();
+
+        return result != null;
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestRepository.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumReleaseRequestRepository.java
@@ -3,5 +3,5 @@ package com.fivefy.domain.album.repository;
 import com.fivefy.domain.album.entity.AlbumReleaseRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AlbumReleaseRequestRepository extends JpaRepository<AlbumReleaseRequest, Long> {
+public interface AlbumReleaseRequestRepository extends JpaRepository<AlbumReleaseRequest, Long>, AlbumReleaseRequestQueryRepository {
 }

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -2,7 +2,7 @@ package com.fivefy.domain.album.service;
 
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
-import com.fivefy.domain.album.dto.response.AlbumReleaseRequestCreateResponse;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestResponse;
 import com.fivefy.domain.album.entity.AlbumReleaseRequest;
 import com.fivefy.domain.album.enums.AlbumReleaseErrorCode;
 import com.fivefy.domain.album.repository.AlbumReleaseRequestRepository;
@@ -16,6 +16,8 @@ import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 앨범 도메인 서비스
@@ -40,7 +42,7 @@ public class AlbumService {
      * 6. 동일 조건의 진행 중 요청 중복 검증
      */
     @Transactional
-    public AlbumReleaseRequestCreateResponse createAlbumReleaseRequest(
+    public AlbumReleaseRequestResponse createAlbumReleaseRequest(
             Long userId,
             AlbumReleaseRequestCreateRequest request
     ) {
@@ -73,7 +75,20 @@ public class AlbumService {
 
         AlbumReleaseRequest saved = albumReleaseRequestRepository.save(albumReleaseRequest);
 
-        return AlbumReleaseRequestCreateResponse.from(saved);
+        return AlbumReleaseRequestResponse.from(saved);
+    }
+
+    /**
+     * 내 앨범 등록 요청 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<AlbumReleaseRequestResponse> getMyAlbumReleaseRequests(Long userId) {
+        findUser(userId);
+
+        return albumReleaseRequestRepository.searchMyAlbumReleaseRequests(userId)
+                .stream()
+                .map(AlbumReleaseRequestResponse::from)
+                .toList();
     }
 
     // 유저 존재 여부를 검증

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -1,0 +1,151 @@
+package com.fivefy.domain.album.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestCreateResponse;
+import com.fivefy.domain.album.entity.AlbumReleaseRequest;
+import com.fivefy.domain.album.enums.AlbumReleaseErrorCode;
+import com.fivefy.domain.album.repository.AlbumReleaseRequestRepository;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
+import com.fivefy.domain.artist.enums.ArtistStatus;
+import com.fivefy.domain.artist.repository.ArtistRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 앨범 도메인 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class AlbumService {
+
+    private final AlbumReleaseRequestRepository albumReleaseRequestRepository;
+    private final ArtistRepository artistRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 앨범 등록 요청을 생성한다.
+     *
+     * 검증 흐름:
+     * 1. 요청 유저 존재 여부 확인
+     * 2. 삭제되지 않은 아티스트 조회
+     * 3. 아티스트 소유자 검증
+     * 4. 아티스트 상태 검증
+     * 5. 공개 예약 옵션 검증
+     * 6. 동일 조건의 진행 중 요청 중복 검증
+     */
+    @Transactional
+    public AlbumReleaseRequestCreateResponse createAlbumReleaseRequest(
+            Long userId,
+            AlbumReleaseRequestCreateRequest request
+    ) {
+        // 존재하지 않는 유저 요청을 초기에 차단
+        findUser(userId);
+
+        // 삭제된 아티스트는 존재하지 않는 것처럼 처리
+        Artist artist = findNotDeletedArtist(request.artistId());
+
+        // 본인이 소유한 아티스트만 앨범 등록 요청 가능
+        validateArtistOwner(userId, artist);
+
+        // 비활성화된 아티스트는 앨범 등록 요청 불가
+        validateArtistActive(artist);
+
+        // 정책상 허용된 공개 옵션인지 검증
+        validatePublishDelayDays(request.publishDelayDays());
+
+        // 동일 조건(PENDING)의 중복 요청 방지
+        validateDuplicatePendingRequest(userId, request.artistId(), request.title());
+
+        AlbumReleaseRequest albumReleaseRequest = AlbumReleaseRequest.create(
+                userId,
+                request.artistId(),
+                request.title(),
+                request.description(),
+                request.coverImageUrl(),
+                request.publishDelayDays()
+        );
+
+        AlbumReleaseRequest saved = albumReleaseRequestRepository.save(albumReleaseRequest);
+
+        return AlbumReleaseRequestCreateResponse.from(saved);
+    }
+
+    // 유저 존재 여부를 검증
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
+    }
+
+    // 아티스트 조회
+    private Artist findArtist(Long artistId) {
+        return artistRepository.findById(artistId)
+                .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND));
+    }
+
+    /**
+     * 삭제되지 않은 아티스트 조회
+     *
+     * 삭제된 아티스트는 외부에서 접근할 수 없도록 NOT_FOUND 처리
+     */
+    private Artist findNotDeletedArtist(Long artistId) {
+        Artist artist = findArtist(artistId);
+
+        if (artist.isDeleted()) {
+            throw new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND);
+        }
+
+        return artist;
+    }
+
+    // 아티스트 소유자 검증
+    private void validateArtistOwner(Long userId, Artist artist) {
+        if (!artist.isOwnedBy(userId)) {
+            throw new BusinessException(ArtistErrorCode.ERR_FORBIDDEN_ARTIST_ACCESS);
+        }
+    }
+
+    // 앨범 등록 요청 가능한 아티스트 상태 검증
+    private void validateArtistActive(Artist artist) {
+        if (artist.getStatus() != ArtistStatus.ACTIVE) {
+            throw new BusinessException(
+                    AlbumReleaseErrorCode.ERR_INACTIVE_ARTIST_CANNOT_REQUEST_ALBUM_RELEASE
+            );
+        }
+    }
+
+    /**
+     * 공개 예약 옵션 검증
+     *
+     * 정책:
+     * 0 = 즉시 공개
+     * 1~7 = 승인 시점 기준 N일 후 공개
+     */
+    private void validatePublishDelayDays(Integer publishDelayDays) {
+        if (publishDelayDays == null || publishDelayDays < 0 || publishDelayDays > 7) {
+            throw new BusinessException(
+                    AlbumReleaseErrorCode.ERR_INVALID_PUBLISH_DELAY_DAYS
+            );
+        }
+    }
+
+    // 동일 조건의 진행 중 요청(PENDING) 중복 방지
+    private void validateDuplicatePendingRequest(Long userId, Long artistId, String title) {
+        boolean exists = albumReleaseRequestRepository.existsPendingRequest(
+                userId,
+                artistId,
+                title
+        );
+
+        if (exists) {
+            throw new BusinessException(
+                    AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_ALREADY_EXISTS
+            );
+        }
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -2,6 +2,7 @@ package com.fivefy.domain.album.service;
 
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestDetailResponse;
 import com.fivefy.domain.album.dto.response.AlbumReleaseRequestResponse;
 import com.fivefy.domain.album.entity.AlbumReleaseRequest;
 import com.fivefy.domain.album.enums.AlbumReleaseErrorCode;
@@ -12,6 +13,7 @@ import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -91,6 +93,19 @@ public class AlbumService {
                 .toList();
     }
 
+    /**
+     * 앨범 등록 요청 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public AlbumReleaseRequestDetailResponse getAlbumReleaseRequest(Long userId, Long requestId) {
+        AlbumReleaseRequest request = findAlbumReleaseRequest(requestId);
+        User user = findUser(userId);
+
+        validateAlbumReleaseRequestDetailAccess(userId, user, request);
+
+        return AlbumReleaseRequestDetailResponse.from(request);
+    }
+
     // 유저 존재 여부를 검증
     private User findUser(Long userId) {
         return userRepository.findById(userId)
@@ -160,6 +175,30 @@ public class AlbumService {
         if (exists) {
             throw new BusinessException(
                     AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_ALREADY_EXISTS
+            );
+        }
+    }
+
+    // 앨범 등록 요청 조회
+    private AlbumReleaseRequest findAlbumReleaseRequest(Long requestId) {
+        return albumReleaseRequestRepository.findById(requestId)
+                .orElseThrow(() -> new BusinessException(
+                        AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_REQUEST_NOT_FOUND
+                ));
+    }
+
+    // 앨범 등록 요청 상세 조회 권한 검증
+    private void validateAlbumReleaseRequestDetailAccess(
+            Long userId,
+            User user,
+            AlbumReleaseRequest request
+    ) {
+        boolean isRequester = request.getRequesterUserId().equals(userId);
+        boolean isAdmin = user.getRole() == UserRole.ADMIN;
+
+        if (!isRequester && !isAdmin) {
+            throw new BusinessException(
+                    AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_DETAIL_FORBIDDEN
             );
         }
     }

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -1,0 +1,410 @@
+package com.fivefy.domain.album.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestCreateResponse;
+import com.fivefy.domain.album.entity.AlbumReleaseRequest;
+import com.fivefy.domain.album.enums.AlbumReleaseErrorCode;
+import com.fivefy.domain.album.repository.AlbumReleaseRequestRepository;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
+import com.fivefy.domain.artist.enums.ArtistType;
+import com.fivefy.domain.artist.repository.ArtistRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static com.fivefy.common.enums.ApplicationStatus.PENDING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * AlbumService의 비즈니스 로직을 검증하는 단위 테스트
+ *
+ * 앨범 등록 요청 생성 기능을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AlbumServiceTest {
+
+    @Mock
+    private AlbumReleaseRequestRepository albumReleaseRequestRepository;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AlbumService albumService;
+
+    @Nested
+    @DisplayName("앨범 등록 요청 생성")
+    class CreateAlbumReleaseRequest {
+
+        @Test
+        @DisplayName("앨범 등록 요청 생성에 성공한다")
+        void createAlbumReleaseRequest_success() {
+            // given
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    3
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId))
+                    .thenReturn(java.util.Optional.of(artist));
+
+            when(albumReleaseRequestRepository.existsPendingRequest(
+                    userId,
+                    artistId,
+                    request.title()
+            )).thenReturn(false);
+
+            AlbumReleaseRequest savedRequest = AlbumReleaseRequest.create(
+                    userId,
+                    artistId,
+                    request.title(),
+                    request.description(),
+                    request.coverImageUrl(),
+                    request.publishDelayDays()
+            );
+
+            ReflectionTestUtils.setField(savedRequest, "id", 1L);
+            ReflectionTestUtils.setField(
+                    savedRequest,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 16, 16, 0, 0)
+            );
+
+            when(albumReleaseRequestRepository.save(any(AlbumReleaseRequest.class)))
+                    .thenReturn(savedRequest);
+
+            // when
+            AlbumReleaseRequestCreateResponse response =
+                    albumService.createAlbumReleaseRequest(userId, request);
+
+            // then
+            assertThat(response.requestId()).isEqualTo(1L);
+            assertThat(response.artistId()).isEqualTo(artistId);
+            assertThat(response.title()).isEqualTo("Love poem");
+            assertThat(response.status()).isEqualTo(PENDING);
+            assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 16, 16, 0, 0));
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, times(1)).findById(artistId);
+            verify(albumReleaseRequestRepository, times(1))
+                    .existsPendingRequest(userId, artistId, request.title());
+            verify(albumReleaseRequestRepository, times(1))
+                    .save(any(AlbumReleaseRequest.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 앨범 등록 요청 생성에 실패한다")
+        void createAlbumReleaseRequest_fail_whenUserNotFound() {
+            // given
+            Long userId = 1L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    10L,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, never()).findById(any());
+            verify(albumReleaseRequestRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 아티스트면 앨범 등록 요청 생성에 실패한다")
+        void createAlbumReleaseRequest_fail_whenArtistNotFound() {
+            // given
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.of(user));
+
+            when(artistRepository.findById(artistId))
+                    .thenReturn(java.util.Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, times(1)).findById(artistId);
+            verify(albumReleaseRequestRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("삭제된 아티스트면 앨범 등록 요청 생성에 실패한다")
+        void createAlbumReleaseRequest_fail_whenArtistDeleted() {
+            // given
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+            ReflectionTestUtils.setField(
+                    artist,
+                    "deletedAt",
+                    LocalDateTime.of(2026, 4, 16, 12, 0, 0)
+            );
+
+            when(artistRepository.findById(artistId))
+                    .thenReturn(java.util.Optional.of(artist));
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, times(1)).findById(artistId);
+            verify(albumReleaseRequestRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("아티스트 소유자가 아니면 앨범 등록 요청 생성에 실패한다")
+        void createAlbumReleaseRequest_fail_whenNotOwner() {
+            // given
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.of(user));
+
+            Artist artist = Artist.create(
+                    2L,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId))
+                    .thenReturn(java.util.Optional.of(artist));
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistErrorCode.ERR_FORBIDDEN_ARTIST_ACCESS.getMessage());
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, times(1)).findById(artistId);
+            verify(albumReleaseRequestRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("비활성화된 아티스트면 앨범 등록 요청 생성에 실패한다")
+        void createAlbumReleaseRequest_fail_whenArtistInactive() {
+            // given
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+            artist.deactivate();
+
+            when(artistRepository.findById(artistId))
+                    .thenReturn(java.util.Optional.of(artist));
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumReleaseErrorCode.ERR_INACTIVE_ARTIST_CANNOT_REQUEST_ALBUM_RELEASE.getMessage());
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, times(1)).findById(artistId);
+            verify(albumReleaseRequestRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("공개 예약 옵션이 범위를 벗어나면 앨범 등록 요청 생성에 실패한다")
+        void createAlbumReleaseRequest_fail_whenInvalidPublishDelayDays() {
+            // given
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    8
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId))
+                    .thenReturn(java.util.Optional.of(artist));
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumReleaseErrorCode.ERR_INVALID_PUBLISH_DELAY_DAYS.getMessage());
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, times(1)).findById(artistId);
+            verify(albumReleaseRequestRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("동일한 진행 중 요청이 이미 있으면 앨범 등록 요청 생성에 실패한다")
+        void createAlbumReleaseRequest_fail_whenAlreadyExists() {
+            // given
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId))
+                    .thenReturn(java.util.Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId))
+                    .thenReturn(java.util.Optional.of(artist));
+
+            when(albumReleaseRequestRepository.existsPendingRequest(
+                    userId,
+                    artistId,
+                    request.title()
+            )).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_ALREADY_EXISTS.getMessage());
+
+            verify(userRepository, times(1)).findById(userId);
+            verify(artistRepository, times(1)).findById(artistId);
+            verify(albumReleaseRequestRepository, times(1))
+                    .existsPendingRequest(userId, artistId, request.title());
+            verify(albumReleaseRequestRepository, never()).save(any());
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -1,8 +1,9 @@
 package com.fivefy.domain.album.service;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
-import com.fivefy.domain.album.dto.response.AlbumReleaseRequestCreateResponse;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestResponse;
 import com.fivefy.domain.album.entity.AlbumReleaseRequest;
 import com.fivefy.domain.album.enums.AlbumReleaseErrorCode;
 import com.fivefy.domain.album.repository.AlbumReleaseRequestRepository;
@@ -23,17 +24,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
-import static com.fivefy.common.enums.ApplicationStatus.PENDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * AlbumService의 비즈니스 로직을 검증하는 단위 테스트
  *
  * 앨범 등록 요청 생성 기능을 검증한다.
+ * 내 앨범 등록 요청 목록 조회 기능을 검증한다.
+ * 내 앨범 등록 요청 목록 빈 결과 조회 기능을 검증한다.
  */
 @ExtendWith(MockitoExtension.class)
 class AlbumServiceTest {
@@ -55,9 +60,8 @@ class AlbumServiceTest {
     class CreateAlbumReleaseRequest {
 
         @Test
-        @DisplayName("앨범 등록 요청 생성에 성공한다")
+        @DisplayName("앨범 등록 요청 생성 성공")
         void createAlbumReleaseRequest_success() {
-            // given
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -70,8 +74,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -82,14 +85,9 @@ class AlbumServiceTest {
             );
             ReflectionTestUtils.setField(artist, "id", artistId);
 
-            when(artistRepository.findById(artistId))
-                    .thenReturn(java.util.Optional.of(artist));
-
-            when(albumReleaseRequestRepository.existsPendingRequest(
-                    userId,
-                    artistId,
-                    request.title()
-            )).thenReturn(false);
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumReleaseRequestRepository.existsPendingRequest(userId, artistId, request.title()))
+                    .thenReturn(false);
 
             AlbumReleaseRequest savedRequest = AlbumReleaseRequest.create(
                     userId,
@@ -99,40 +97,25 @@ class AlbumServiceTest {
                     request.coverImageUrl(),
                     request.publishDelayDays()
             );
-
             ReflectionTestUtils.setField(savedRequest, "id", 1L);
-            ReflectionTestUtils.setField(
-                    savedRequest,
-                    "createdAt",
-                    LocalDateTime.of(2026, 4, 16, 16, 0, 0)
-            );
+            ReflectionTestUtils.setField(savedRequest, "createdAt", LocalDateTime.of(2026, 4, 16, 16, 0, 0));
 
             when(albumReleaseRequestRepository.save(any(AlbumReleaseRequest.class)))
                     .thenReturn(savedRequest);
 
-            // when
-            AlbumReleaseRequestCreateResponse response =
+            AlbumReleaseRequestResponse response =
                     albumService.createAlbumReleaseRequest(userId, request);
 
-            // then
             assertThat(response.requestId()).isEqualTo(1L);
             assertThat(response.artistId()).isEqualTo(artistId);
             assertThat(response.title()).isEqualTo("Love poem");
-            assertThat(response.status()).isEqualTo(PENDING);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
             assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 16, 16, 0, 0));
-
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, times(1)).findById(artistId);
-            verify(albumReleaseRequestRepository, times(1))
-                    .existsPendingRequest(userId, artistId, request.title());
-            verify(albumReleaseRequestRepository, times(1))
-                    .save(any(AlbumReleaseRequest.class));
         }
 
         @Test
-        @DisplayName("존재하지 않는 유저면 앨범 등록 요청 생성에 실패한다")
+        @DisplayName("존재하지 않는 유저면 앨범 등록 요청 생성 실패")
         void createAlbumReleaseRequest_fail_whenUserNotFound() {
-            // given
             Long userId = 1L;
 
             AlbumReleaseRequestCreateRequest request = new AlbumReleaseRequestCreateRequest(
@@ -143,23 +126,16 @@ class AlbumServiceTest {
                     0
             );
 
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.empty());
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-            // when & then
             assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
-
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, never()).findById(any());
-            verify(albumReleaseRequestRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("존재하지 않는 아티스트면 앨범 등록 요청 생성에 실패한다")
+        @DisplayName("존재하지 않는 아티스트면 앨범 등록 요청 생성 실패")
         void createAlbumReleaseRequest_fail_whenArtistNotFound() {
-            // given
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -172,26 +148,17 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.empty());
 
-            when(artistRepository.findById(artistId))
-                    .thenReturn(java.util.Optional.empty());
-
-            // when & then
             assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
-
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, times(1)).findById(artistId);
-            verify(albumReleaseRequestRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("삭제된 아티스트면 앨범 등록 요청 생성에 실패한다")
+        @DisplayName("삭제된 아티스트면 앨범 등록 요청 생성 실패")
         void createAlbumReleaseRequest_fail_whenArtistDeleted() {
-            // given
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -204,8 +171,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -215,29 +181,18 @@ class AlbumServiceTest {
                     "https://example.com/artist.jpg"
             );
             ReflectionTestUtils.setField(artist, "id", artistId);
-            ReflectionTestUtils.setField(
-                    artist,
-                    "deletedAt",
-                    LocalDateTime.of(2026, 4, 16, 12, 0, 0)
-            );
+            ReflectionTestUtils.setField(artist, "deletedAt", LocalDateTime.of(2026, 4, 16, 16, 0, 0));
 
-            when(artistRepository.findById(artistId))
-                    .thenReturn(java.util.Optional.of(artist));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
 
-            // when & then
             assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
-
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, times(1)).findById(artistId);
-            verify(albumReleaseRequestRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("아티스트 소유자가 아니면 앨범 등록 요청 생성에 실패한다")
-        void createAlbumReleaseRequest_fail_whenNotOwner() {
-            // given
+        @DisplayName("아티스트 소유자가 아니면 앨범 등록 요청 생성 실패")
+        void createAlbumReleaseRequest_fail_whenForbiddenArtistAccess() {
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -250,8 +205,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     2L,
@@ -262,23 +216,16 @@ class AlbumServiceTest {
             );
             ReflectionTestUtils.setField(artist, "id", artistId);
 
-            when(artistRepository.findById(artistId))
-                    .thenReturn(java.util.Optional.of(artist));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
 
-            // when & then
             assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(ArtistErrorCode.ERR_FORBIDDEN_ARTIST_ACCESS.getMessage());
-
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, times(1)).findById(artistId);
-            verify(albumReleaseRequestRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("비활성화된 아티스트면 앨범 등록 요청 생성에 실패한다")
+        @DisplayName("비활성화된 아티스트면 앨범 등록 요청 생성 실패")
         void createAlbumReleaseRequest_fail_whenArtistInactive() {
-            // given
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -291,8 +238,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -304,23 +250,16 @@ class AlbumServiceTest {
             ReflectionTestUtils.setField(artist, "id", artistId);
             artist.deactivate();
 
-            when(artistRepository.findById(artistId))
-                    .thenReturn(java.util.Optional.of(artist));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
 
-            // when & then
             assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(AlbumReleaseErrorCode.ERR_INACTIVE_ARTIST_CANNOT_REQUEST_ALBUM_RELEASE.getMessage());
-
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, times(1)).findById(artistId);
-            verify(albumReleaseRequestRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("공개 예약 옵션이 범위를 벗어나면 앨범 등록 요청 생성에 실패한다")
+        @DisplayName("공개 예약 옵션이 범위를 벗어나면 앨범 등록 요청 생성 실패")
         void createAlbumReleaseRequest_fail_whenInvalidPublishDelayDays() {
-            // given
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -333,8 +272,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -345,23 +283,16 @@ class AlbumServiceTest {
             );
             ReflectionTestUtils.setField(artist, "id", artistId);
 
-            when(artistRepository.findById(artistId))
-                    .thenReturn(java.util.Optional.of(artist));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
 
-            // when & then
             assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(AlbumReleaseErrorCode.ERR_INVALID_PUBLISH_DELAY_DAYS.getMessage());
-
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, times(1)).findById(artistId);
-            verify(albumReleaseRequestRepository, never()).save(any());
         }
 
         @Test
-        @DisplayName("동일한 진행 중 요청이 이미 있으면 앨범 등록 요청 생성에 실패한다")
+        @DisplayName("동일한 진행 중 요청이 이미 있으면 앨범 등록 요청 생성 실패")
         void createAlbumReleaseRequest_fail_whenAlreadyExists() {
-            // given
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -374,8 +305,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
-                    .thenReturn(java.util.Optional.of(user));
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -386,25 +316,90 @@ class AlbumServiceTest {
             );
             ReflectionTestUtils.setField(artist, "id", artistId);
 
-            when(artistRepository.findById(artistId))
-                    .thenReturn(java.util.Optional.of(artist));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumReleaseRequestRepository.existsPendingRequest(userId, artistId, request.title()))
+                    .thenReturn(true);
 
-            when(albumReleaseRequestRepository.existsPendingRequest(
-                    userId,
-                    artistId,
-                    request.title()
-            )).thenReturn(true);
-
-            // when & then
             assertThatThrownBy(() -> albumService.createAlbumReleaseRequest(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_ALREADY_EXISTS.getMessage());
+        }
+    }
 
-            verify(userRepository, times(1)).findById(userId);
-            verify(artistRepository, times(1)).findById(artistId);
-            verify(albumReleaseRequestRepository, times(1))
-                    .existsPendingRequest(userId, artistId, request.title());
-            verify(albumReleaseRequestRepository, never()).save(any());
+    @Nested
+    @DisplayName("내 앨범 등록 요청 목록 조회")
+    class GetMyAlbumReleaseRequests {
+
+        @Test
+        @DisplayName("최신순으로 목록 조회 성공")
+        void getMyAlbumReleaseRequests_success() {
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            AlbumReleaseRequest request1 = AlbumReleaseRequest.create(
+                    userId,
+                    artistId,
+                    "두 번째 요청",
+                    "설명2",
+                    "https://example.com/cover2.jpg",
+                    2
+            );
+            ReflectionTestUtils.setField(request1, "id", 2L);
+            ReflectionTestUtils.setField(request1, "createdAt", LocalDateTime.of(2026, 4, 16, 16, 0, 0));
+
+            AlbumReleaseRequest request2 = AlbumReleaseRequest.create(
+                    userId,
+                    artistId,
+                    "첫 번째 요청",
+                    "설명1",
+                    "https://example.com/cover1.jpg",
+                    0
+            );
+            ReflectionTestUtils.setField(request2, "id", 1L);
+            ReflectionTestUtils.setField(request2, "createdAt", LocalDateTime.of(2026, 4, 15, 16, 0, 0));
+
+            when(albumReleaseRequestRepository.searchMyAlbumReleaseRequests(userId))
+                    .thenReturn(List.of(request1, request2));
+
+            List<AlbumReleaseRequestResponse> response =
+                    albumService.getMyAlbumReleaseRequests(userId);
+
+            assertThat(response).hasSize(2);
+            assertThat(response.get(0).requestId()).isEqualTo(2L);
+            assertThat(response.get(0).title()).isEqualTo("두 번째 요청");
+            assertThat(response.get(1).requestId()).isEqualTo(1L);
+            assertThat(response.get(1).title()).isEqualTo("첫 번째 요청");
+        }
+
+        @Test
+        @DisplayName("내 앨범 등록 요청이 없으면 빈 목록 조회 성공")
+        void getMyAlbumReleaseRequests_success_whenEmpty() {
+            Long userId = 1L;
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(albumReleaseRequestRepository.searchMyAlbumReleaseRequests(userId))
+                    .thenReturn(List.of());
+
+            List<AlbumReleaseRequestResponse> response =
+                    albumService.getMyAlbumReleaseRequests(userId);
+
+            assertThat(response).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 목록 조회 실패")
+        void getMyAlbumReleaseRequests_fail_whenUserNotFound() {
+            Long userId = 1L;
+
+            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> albumService.getMyAlbumReleaseRequests(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.album.service;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.dto.request.AlbumReleaseRequestCreateRequest;
+import com.fivefy.domain.album.dto.response.AlbumReleaseRequestDetailResponse;
 import com.fivefy.domain.album.dto.response.AlbumReleaseRequestResponse;
 import com.fivefy.domain.album.entity.AlbumReleaseRequest;
 import com.fivefy.domain.album.enums.AlbumReleaseErrorCode;
@@ -13,6 +14,7 @@ import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,6 +41,7 @@ import static org.mockito.Mockito.when;
  * 앨범 등록 요청 생성 기능을 검증한다.
  * 내 앨범 등록 요청 목록 조회 기능을 검증한다.
  * 내 앨범 등록 요청 목록 빈 결과 조회 기능을 검증한다.
+ * 앨범 등록 요청 상세 조회 기능을 검증한다.
  */
 @ExtendWith(MockitoExtension.class)
 class AlbumServiceTest {
@@ -400,6 +403,121 @@ class AlbumServiceTest {
             assertThatThrownBy(() -> albumService.getMyAlbumReleaseRequests(userId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("앨범 등록 요청 상세 조회")
+    class GetAlbumReleaseRequest {
+
+        @Test
+        @DisplayName("요청자 본인이면 상세 조회 성공")
+        void getAlbumReleaseRequest_success_whenRequester() {
+            Long userId = 1L;
+            Long requestId = 100L;
+            Long artistId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            AlbumReleaseRequest request = AlbumReleaseRequest.create(
+                    userId,
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/album.jpg",
+                    0
+            );
+            ReflectionTestUtils.setField(request, "id", requestId);
+            ReflectionTestUtils.setField(request, "createdAt", LocalDateTime.of(2026, 4, 14, 15, 0, 0));
+            ReflectionTestUtils.setField(request, "updatedAt", LocalDateTime.of(2026, 4, 14, 15, 0, 0));
+
+            when(albumReleaseRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+            AlbumReleaseRequestDetailResponse response =
+                    albumService.getAlbumReleaseRequest(userId, requestId);
+
+            assertThat(response.requestId()).isEqualTo(requestId);
+            assertThat(response.requesterUserId()).isEqualTo(userId);
+            assertThat(response.artistId()).isEqualTo(artistId);
+            assertThat(response.title()).isEqualTo("Palette");
+            assertThat(response.publishDelayDays()).isEqualTo(0);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("관리자면 상세 조회 성공")
+        void getAlbumReleaseRequest_success_whenAdmin() {
+            Long userId = 99L;
+            Long requestId = 100L;
+            Long requesterUserId = 1L;
+            Long artistId = 10L;
+
+            User admin = mock(User.class);
+            when(admin.getRole()).thenReturn(UserRole.ADMIN);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(admin));
+
+            AlbumReleaseRequest request = AlbumReleaseRequest.create(
+                    requesterUserId,
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/album.jpg",
+                    0
+            );
+            ReflectionTestUtils.setField(request, "id", requestId);
+            ReflectionTestUtils.setField(request, "createdAt", LocalDateTime.of(2026, 4, 14, 15, 0, 0));
+            ReflectionTestUtils.setField(request, "updatedAt", LocalDateTime.of(2026, 4, 14, 15, 0, 0));
+
+            when(albumReleaseRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+            AlbumReleaseRequestDetailResponse response =
+                    albumService.getAlbumReleaseRequest(userId, requestId);
+
+            assertThat(response.requestId()).isEqualTo(requestId);
+            assertThat(response.requesterUserId()).isEqualTo(requesterUserId);
+        }
+
+        @Test
+        @DisplayName("본인도 관리자도 아니면 상세 조회 실패")
+        void getAlbumReleaseRequest_fail_whenForbidden() {
+            Long userId = 2L;
+            Long requestId = 100L;
+            Long requesterUserId = 1L;
+            Long artistId = 10L;
+
+            User user = mock(User.class);
+            when(user.getRole()).thenReturn(UserRole.USER);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+            AlbumReleaseRequest request = AlbumReleaseRequest.create(
+                    requesterUserId,
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/album.jpg",
+                    0
+            );
+            ReflectionTestUtils.setField(request, "id", requestId);
+
+            when(albumReleaseRequestRepository.findById(requestId)).thenReturn(Optional.of(request));
+
+            assertThatThrownBy(() -> albumService.getAlbumReleaseRequest(userId, requestId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_DETAIL_FORBIDDEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 요청이면 상세 조회 실패")
+        void getAlbumReleaseRequest_fail_whenNotFound() {
+            Long userId = 1L;
+            Long requestId = 100L;
+
+            when(albumReleaseRequestRepository.findById(requestId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> albumService.getAlbumReleaseRequest(userId, requestId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumReleaseErrorCode.ERR_ALBUM_RELEASE_REQUEST_NOT_FOUND.getMessage());
         }
     }
 }


### PR DESCRIPTION
## 개요
앨범 등록 요청(AlbumReleaseRequest)의 생성, 목록 조회, 상세 조회 API를 구현하고,
등록 시점 정책을 publishDelayDays 기반으로 리팩토링

## 변경 사항
#### 등록 요청 정책 정리
- 등록 시점을 publishDelayDays 기반으로 통일
- releaseAt, scheduledPublishAt 필드 제거
- 관련 생성 파라미터 및 검증 로직 정리

#### 앨범 등록 요청 생성
- 앨범 등록 요청 생성 API 추가
- 요청/응답 DTO 구현
- 아티스트 소유권 및 상태 검증
- 공개 예약 옵션(publishDelayDays) 검증
- 동일 조건(PENDING) 중복 요청 검증

#### 조회 기능
- 내 앨범 등록 요청 목록 조회 API 추가
- Querydsl 기반 조회
- 생성/목록 응답 DTO 통합
- 앨범 등록 요청 상세 조회 API 추가
- 본인 또는 관리자만 조회 가능
- 권한 검증 및 예외 처리 적용

#### 테스트
- 생성/목록/상세 조회 서비스 단위 테스트 추가
- 유저 없음, 빈 결과, 권한 없음 등 예외 케이스 검증

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법
```
1. 앨범 등록 요청 생성 → publishDelayDays 검증 및 중복 요청 확인
2. 내 요청 목록 조회 → 정상/빈 결과 확인
3. 요청 상세 조회 → 본인/관리자 접근 허용 및 권한 검증 확인
```

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앨범 등록 요청 제출 기능 추가
  * 내 앨범 등록 요청 목록 조회 기능 추가
  * 앨범 등록 요청 상세 정보 조회 기능 추가
  * 공개 예약일을 즉시 공개(0일) 또는 1~7일 후로 선택 가능하도록 개선
  * 앨범 등록 요청 상태 추적 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->