### PR TITLE
test: Playlist/Playback/PopularChart REST Docs 테스트 및 문서화 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -197,6 +197,396 @@ include::{snippets}/user-delete-mismatch-password/response-fields.adoc[]
 
 ---
 
+== Playlist API
+
+=== 플레이리스트 생성
+
+include::{snippets}/playlist-create/http-request.adoc[]
+include::{snippets}/playlist-create/request-fields.adoc[]
+include::{snippets}/playlist-create/http-response.adoc[]
+include::{snippets}/playlist-create/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/playlist-create-invalid/http-request.adoc[]
+include::{snippets}/playlist-create-invalid/request-fields.adoc[]
+include::{snippets}/playlist-create-invalid/http-response.adoc[]
+include::{snippets}/playlist-create-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 중복 제목
+
+include::{snippets}/playlist-create-duplicate/http-request.adoc[]
+include::{snippets}/playlist-create-duplicate/request-fields.adoc[]
+include::{snippets}/playlist-create-duplicate/http-response.adoc[]
+include::{snippets}/playlist-create-duplicate/response-fields.adoc[]
+
+---
+
+=== 플레이리스트 목록 조회
+
+include::{snippets}/playlist-get-list/http-request.adoc[]
+include::{snippets}/playlist-get-list/http-response.adoc[]
+include::{snippets}/playlist-get-list/response-fields.adoc[]
+
+---
+
+=== 플레이리스트 단건 조회
+
+include::{snippets}/playlist-get/http-request.adoc[]
+include::{snippets}/playlist-get/http-response.adoc[]
+include::{snippets}/playlist-get/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 없음
+
+include::{snippets}/playlist-get-not-found/http-request.adoc[]
+include::{snippets}/playlist-get-not-found/http-response.adoc[]
+include::{snippets}/playlist-get-not-found/response-fields.adoc[]
+
+---
+
+=== 플레이리스트 수정
+
+include::{snippets}/playlist-update/http-request.adoc[]
+include::{snippets}/playlist-update/request-fields.adoc[]
+include::{snippets}/playlist-update/http-response.adoc[]
+include::{snippets}/playlist-update/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/playlist-update-invalid/http-request.adoc[]
+include::{snippets}/playlist-update-invalid/request-fields.adoc[]
+include::{snippets}/playlist-update-invalid/http-response.adoc[]
+include::{snippets}/playlist-update-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 수정 권한 없음
+
+include::{snippets}/playlist-update-forbidden/http-request.adoc[]
+include::{snippets}/playlist-update-forbidden/request-fields.adoc[]
+include::{snippets}/playlist-update-forbidden/http-response.adoc[]
+include::{snippets}/playlist-update-forbidden/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 없음
+
+include::{snippets}/playlist-update-not-found/http-request.adoc[]
+include::{snippets}/playlist-update-not-found/request-fields.adoc[]
+include::{snippets}/playlist-update-not-found/http-response.adoc[]
+include::{snippets}/playlist-update-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 중복 제목
+
+include::{snippets}/playlist-update-duplicate/http-request.adoc[]
+include::{snippets}/playlist-update-duplicate/request-fields.adoc[]
+include::{snippets}/playlist-update-duplicate/http-response.adoc[]
+include::{snippets}/playlist-update-duplicate/response-fields.adoc[]
+
+---
+
+=== 플레이리스트 삭제
+
+include::{snippets}/playlist-delete/http-request.adoc[]
+include::{snippets}/playlist-delete/http-response.adoc[]
+include::{snippets}/playlist-delete/response-fields.adoc[]
+
+==== 에러 케이스 - 삭제 권한 없음
+
+include::{snippets}/playlist-delete-forbidden/http-request.adoc[]
+include::{snippets}/playlist-delete-forbidden/http-response.adoc[]
+include::{snippets}/playlist-delete-forbidden/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 없음
+
+include::{snippets}/playlist-delete-not-found/http-request.adoc[]
+include::{snippets}/playlist-delete-not-found/http-response.adoc[]
+include::{snippets}/playlist-delete-not-found/response-fields.adoc[]
+
+---
+
+== PlaylistTrack API
+
+=== 플레이리스트 트랙 추가
+
+include::{snippets}/playlist-track-add/http-request.adoc[]
+include::{snippets}/playlist-track-add/request-fields.adoc[]
+include::{snippets}/playlist-track-add/http-response.adoc[]
+include::{snippets}/playlist-track-add/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/playlist-track-add-invalid/http-request.adoc[]
+include::{snippets}/playlist-track-add-invalid/http-response.adoc[]
+include::{snippets}/playlist-track-add-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 접근 권한 없음
+
+include::{snippets}/playlist-track-add-forbidden/http-request.adoc[]
+include::{snippets}/playlist-track-add-forbidden/request-fields.adoc[]
+include::{snippets}/playlist-track-add-forbidden/http-response.adoc[]
+include::{snippets}/playlist-track-add-forbidden/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 없음
+
+include::{snippets}/playlist-track-add-not-found/http-request.adoc[]
+include::{snippets}/playlist-track-add-not-found/request-fields.adoc[]
+include::{snippets}/playlist-track-add-not-found/http-response.adoc[]
+include::{snippets}/playlist-track-add-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 이미 추가된 트랙
+
+include::{snippets}/playlist-track-add-duplicate/http-request.adoc[]
+include::{snippets}/playlist-track-add-duplicate/request-fields.adoc[]
+include::{snippets}/playlist-track-add-duplicate/http-response.adoc[]
+include::{snippets}/playlist-track-add-duplicate/response-fields.adoc[]
+
+---
+
+=== 플레이리스트 트랙 목록 조회
+
+include::{snippets}/playlist-track-get-list/http-request.adoc[]
+include::{snippets}/playlist-track-get-list/http-response.adoc[]
+include::{snippets}/playlist-track-get-list/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 없음
+
+include::{snippets}/playlist-track-get-list-not-found/http-request.adoc[]
+include::{snippets}/playlist-track-get-list-not-found/http-response.adoc[]
+include::{snippets}/playlist-track-get-list-not-found/response-fields.adoc[]
+
+---
+
+=== 플레이리스트 트랙 순서 변경
+
+include::{snippets}/playlist-track-update-order/http-request.adoc[]
+include::{snippets}/playlist-track-update-order/request-fields.adoc[]
+include::{snippets}/playlist-track-update-order/http-response.adoc[]
+include::{snippets}/playlist-track-update-order/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/playlist-track-update-order-invalid/http-request.adoc[]
+include::{snippets}/playlist-track-update-order-invalid/request-fields.adoc[]
+include::{snippets}/playlist-track-update-order-invalid/http-response.adoc[]
+include::{snippets}/playlist-track-update-order-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 수정 권한 없음
+
+include::{snippets}/playlist-track-update-order-forbidden/http-request.adoc[]
+include::{snippets}/playlist-track-update-order-forbidden/request-fields.adoc[]
+include::{snippets}/playlist-track-update-order-forbidden/http-response.adoc[]
+include::{snippets}/playlist-track-update-order-forbidden/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 없음
+
+include::{snippets}/playlist-track-update-order-not-found/http-request.adoc[]
+include::{snippets}/playlist-track-update-order-not-found/request-fields.adoc[]
+include::{snippets}/playlist-track-update-order-not-found/http-response.adoc[]
+include::{snippets}/playlist-track-update-order-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 순서 충돌
+
+include::{snippets}/playlist-track-update-order-conflict/http-request.adoc[]
+include::{snippets}/playlist-track-update-order-conflict/request-fields.adoc[]
+include::{snippets}/playlist-track-update-order-conflict/http-response.adoc[]
+include::{snippets}/playlist-track-update-order-conflict/response-fields.adoc[]
+
+---
+
+=== 플레이리스트 트랙 삭제
+
+include::{snippets}/playlist-track-delete/http-request.adoc[]
+include::{snippets}/playlist-track-delete/http-response.adoc[]
+include::{snippets}/playlist-track-delete/response-fields.adoc[]
+
+==== 에러 케이스 - 삭제 권한 없음
+
+include::{snippets}/playlist-track-delete-forbidden/http-request.adoc[]
+include::{snippets}/playlist-track-delete-forbidden/http-response.adoc[]
+include::{snippets}/playlist-track-delete-forbidden/response-fields.adoc[]
+
+==== 에러 케이스 - 삭제할 트랙 없음
+
+include::{snippets}/playlist-track-delete-not-found/http-request.adoc[]
+include::{snippets}/playlist-track-delete-not-found/http-response.adoc[]
+include::{snippets}/playlist-track-delete-not-found/response-fields.adoc[]
+
+---
+
+== Playback API
+
+=== 재생 시작
+
+include::{snippets}/playback-play/http-request.adoc[]
+include::{snippets}/playback-play/request-fields.adoc[]
+include::{snippets}/playback-play/http-response.adoc[]
+include::{snippets}/playback-play/response-fields.adoc[]
+
+==== 에러 케이스 - playlistId 누락
+
+include::{snippets}/playback-play-invalid-playlist-id/http-request.adoc[]
+include::{snippets}/playback-play-invalid-playlist-id/http-response.adoc[]
+include::{snippets}/playback-play-invalid-playlist-id/response-fields.adoc[]
+
+==== 에러 케이스 - 잘못된 재생 상태
+
+include::{snippets}/playback-play-invalid-state/http-request.adoc[]
+include::{snippets}/playback-play-invalid-state/request-fields.adoc[]
+include::{snippets}/playback-play-invalid-state/http-response.adoc[]
+include::{snippets}/playback-play-invalid-state/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트에 포함되지 않은 트랙
+
+include::{snippets}/playback-play-track-not-included/http-request.adoc[]
+include::{snippets}/playback-play-track-not-included/request-fields.adoc[]
+include::{snippets}/playback-play-track-not-included/http-response.adoc[]
+include::{snippets}/playback-play-track-not-included/response-fields.adoc[]
+
+---
+
+=== 재생 일시정지
+
+include::{snippets}/playback-pause/http-request.adoc[]
+include::{snippets}/playback-pause/request-fields.adoc[]
+include::{snippets}/playback-pause/http-response.adoc[]
+include::{snippets}/playback-pause/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/playback-pause-invalid/http-request.adoc[]
+include::{snippets}/playback-pause-invalid/http-response.adoc[]
+include::{snippets}/playback-pause-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 재생 기록 없음
+
+include::{snippets}/playback-pause-not-found/http-request.adoc[]
+include::{snippets}/playback-pause-not-found/request-fields.adoc[]
+include::{snippets}/playback-pause-not-found/http-response.adoc[]
+include::{snippets}/playback-pause-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 현재 재생 중인 곡 없음
+
+include::{snippets}/playback-pause-current-not-found/http-request.adoc[]
+include::{snippets}/playback-pause-current-not-found/request-fields.adoc[]
+include::{snippets}/playback-pause-current-not-found/http-response.adoc[]
+include::{snippets}/playback-pause-current-not-found/response-fields.adoc[]
+
+---
+
+=== 곡 건너뛰기
+
+include::{snippets}/playback-skip/http-request.adoc[]
+include::{snippets}/playback-skip/request-fields.adoc[]
+include::{snippets}/playback-skip/http-response.adoc[]
+include::{snippets}/playback-skip/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/playback-skip-invalid/http-request.adoc[]
+include::{snippets}/playback-skip-invalid/http-response.adoc[]
+include::{snippets}/playback-skip-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 재생 기록 없음
+
+include::{snippets}/playback-skip-not-found/http-request.adoc[]
+include::{snippets}/playback-skip-not-found/request-fields.adoc[]
+include::{snippets}/playback-skip-not-found/http-response.adoc[]
+include::{snippets}/playback-skip-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 잘못된 재생 상태
+
+include::{snippets}/playback-skip-invalid-state/http-request.adoc[]
+include::{snippets}/playback-skip-invalid-state/request-fields.adoc[]
+include::{snippets}/playback-skip-invalid-state/http-response.adoc[]
+include::{snippets}/playback-skip-invalid-state/response-fields.adoc[]
+
+==== 에러 케이스 - 플레이리스트 트랙 정보 없음
+
+include::{snippets}/playback-skip-playlist-track-not-found/http-request.adoc[]
+include::{snippets}/playback-skip-playlist-track-not-found/request-fields.adoc[]
+include::{snippets}/playback-skip-playlist-track-not-found/http-response.adoc[]
+include::{snippets}/playback-skip-playlist-track-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 현재 재생 트랙 불일치
+
+include::{snippets}/playback-skip-track-mismatch/http-request.adoc[]
+include::{snippets}/playback-skip-track-mismatch/request-fields.adoc[]
+include::{snippets}/playback-skip-track-mismatch/http-response.adoc[]
+include::{snippets}/playback-skip-track-mismatch/response-fields.adoc[]
+
+---
+
+=== 곡 정지
+
+include::{snippets}/playback-stop/http-request.adoc[]
+include::{snippets}/playback-stop/request-fields.adoc[]
+include::{snippets}/playback-stop/http-response.adoc[]
+include::{snippets}/playback-stop/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/playback-stop-invalid/http-request.adoc[]
+include::{snippets}/playback-stop-invalid/http-response.adoc[]
+include::{snippets}/playback-stop-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 재생 기록 없음
+
+include::{snippets}/playback-stop-not-found/http-request.adoc[]
+include::{snippets}/playback-stop-not-found/request-fields.adoc[]
+include::{snippets}/playback-stop-not-found/http-response.adoc[]
+include::{snippets}/playback-stop-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 잘못된 재생 상태
+
+include::{snippets}/playback-stop-invalid-state/http-request.adoc[]
+include::{snippets}/playback-stop-invalid-state/request-fields.adoc[]
+include::{snippets}/playback-stop-invalid-state/http-response.adoc[]
+include::{snippets}/playback-stop-invalid-state/response-fields.adoc[]
+
+---
+
+=== 재생 기록 조회
+
+include::{snippets}/playback-history/http-request.adoc[]
+include::{snippets}/playback-history/http-response.adoc[]
+include::{snippets}/playback-history/response-fields.adoc[]
+
+---
+
+== PopularChart API
+
+=== 인기 차트 조회
+
+include::{snippets}/popular-chart-get-top100/http-request.adoc[]
+include::{snippets}/popular-chart-get-top100/http-response.adoc[]
+include::{snippets}/popular-chart-get-top100/response-fields.adoc[]
+
+=== snapshotDate로 인기 차트 조회
+
+include::{snippets}/popular-chart-get-top100-with-date/http-request.adoc[]
+include::{snippets}/popular-chart-get-top100-with-date/http-response.adoc[]
+include::{snippets}/popular-chart-get-top100-with-date/response-fields.adoc[]
+
+==== 에러 케이스 - 차트 데이터 없음
+
+include::{snippets}/popular-chart-get-top100-not-found/http-request.adoc[]
+include::{snippets}/popular-chart-get-top100-not-found/http-response.adoc[]
+include::{snippets}/popular-chart-get-top100-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 유효하지 않은 snapshotDate
+
+include::{snippets}/popular-chart-get-top100-invalid-date/http-request.adoc[]
+include::{snippets}/popular-chart-get-top100-invalid-date/http-response.adoc[]
+include::{snippets}/popular-chart-get-top100-invalid-date/response-fields.adoc[]
+
+---
+
+== PopularChart Test API
+
+=== 테스트용 인기 차트 생성
+
+include::{snippets}/popular-chart-test-generate/http-request.adoc[]
+include::{snippets}/popular-chart-test-generate/http-response.adoc[]
+
+---
+
 == 도메인 API
 
 === 기능

--- a/src/test/java/com/fivefy/domain/playback/controller/PlaybackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playback/controller/PlaybackControllerTest.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.playback.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.playback.dto.request.PlaybackPauseRequest;
 import com.fivefy.domain.playback.dto.request.PlaybackPlayRequest;
@@ -13,31 +14,29 @@ import com.fivefy.domain.playback.service.PlaybackService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser
 @WebMvcTest(PlaybackController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class PlaybackControllerTest {
-
-    @Autowired private MockMvc mockMvc;
-    @Autowired private ObjectMapper objectMapper;
+class PlaybackControllerTest extends RestDocsSupport {
 
     @MockitoBean private PlaybackService playbackService;
     @MockitoBean private JwtUtil jwtUtil;
@@ -73,6 +72,7 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/play")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -81,7 +81,31 @@ class PlaybackControllerTest {
                     .andExpect(jsonPath("$.data.id").value(1L))
                     .andExpect(jsonPath("$.data.playlistId").value(1L))
                     .andExpect(jsonPath("$.data.trackId").value(10L))
-                    .andExpect(jsonPath("$.data.status").value("PLAYING"));
+                    .andExpect(jsonPath("$.data.status").value("PLAYING"))
+                    .andDo(document("playback-play",
+                            requestFields(
+                                    fieldWithPath("playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("deviceId").type(STRING).description("디바이스 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("재생 기록 ID"),
+                                    fieldWithPath("data.playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("data.deviceId").type(STRING).description("디바이스 ID"),
+                                    fieldWithPath("data.status").type(STRING).description("재생 상태"),
+                                    fieldWithPath("data.playedDuration").type(NUMBER).description("누적 재생 시간(초)"),
+                                    fieldWithPath("data.startedAt").type(STRING).description("재생 시작 시각"),
+                                    fieldWithPath("data.lastPlayedAt").type(STRING).description("마지막 재생 시각"),
+                                    fieldWithPath("data.endedAt").type(NULL).description("재생 종료 시각")
+                            )
+                    ));
         }
 
         @Test
@@ -98,9 +122,20 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/play")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playback-play-invalid-playlist-id",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -117,6 +152,7 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/play")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request))
                     .andExpect(status().isBadRequest());
@@ -137,6 +173,7 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/play")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request))
                     .andExpect(status().isBadRequest());
@@ -153,10 +190,24 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/play")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()))
+                    .andDo(document("playback-play-invalid-state",
+                            requestFields(
+                                    fieldWithPath("playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("deviceId").type(STRING).description("디바이스 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -170,10 +221,24 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/play")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED.getMessage()))
+                    .andDo(document("playback-play-track-not-included",
+                            requestFields(
+                                    fieldWithPath("playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("deviceId").type(STRING).description("디바이스 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -205,12 +270,34 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/pause")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("재생 일시정지 성공"))
-                    .andExpect(jsonPath("$.data.status").value("PAUSED"));
+                    .andExpect(jsonPath("$.data.status").value("PAUSED"))
+                    .andDo(document("playback-pause",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("재생 기록 ID"),
+                                    fieldWithPath("data.playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("data.deviceId").type(STRING).description("디바이스 ID"),
+                                    fieldWithPath("data.status").type(STRING).description("재생 상태"),
+                                    fieldWithPath("data.playedDuration").type(NUMBER).description("누적 재생 시간(초)"),
+                                    fieldWithPath("data.startedAt").type(STRING).description("재생 시작 시각"),
+                                    fieldWithPath("data.lastPlayedAt").type(STRING).description("마지막 재생 시각"),
+                                    fieldWithPath("data.endedAt").type(NULL).description("재생 종료 시각")
+                            )
+                    ));
         }
 
         @Test
@@ -221,9 +308,20 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/pause")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playback-pause-invalid",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -237,10 +335,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/pause")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()))
+                    .andDo(document("playback-pause-not-found",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -254,10 +363,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/pause")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND.getMessage()))
+                    .andDo(document("playback-pause-current-not-found",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -289,6 +409,7 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/skip")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
@@ -296,7 +417,28 @@ class PlaybackControllerTest {
                     .andExpect(jsonPath("$.message").value("곡 건너뛰기 성공"))
                     .andExpect(jsonPath("$.data.id").value(2L))
                     .andExpect(jsonPath("$.data.trackId").value(20L))
-                    .andExpect(jsonPath("$.data.status").value("PLAYING"));
+                    .andExpect(jsonPath("$.data.status").value("PLAYING"))
+                    .andDo(document("playback-skip",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("재생 기록 ID"),
+                                    fieldWithPath("data.playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("data.deviceId").type(STRING).description("디바이스 ID"),
+                                    fieldWithPath("data.status").type(STRING).description("재생 상태"),
+                                    fieldWithPath("data.playedDuration").type(NUMBER).description("누적 재생 시간(초)"),
+                                    fieldWithPath("data.startedAt").type(STRING).description("재생 시작 시각"),
+                                    fieldWithPath("data.lastPlayedAt").type(STRING).description("마지막 재생 시각"),
+                                    fieldWithPath("data.endedAt").type(NULL).description("재생 종료 시각")
+                            )
+                    ));
         }
 
         @Test
@@ -307,9 +449,20 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/skip")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playback-skip-invalid",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -323,10 +476,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/skip")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()))
+                    .andDo(document("playback-skip-not-found",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -340,10 +504,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/skip")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()))
+                    .andDo(document("playback-skip-invalid-state",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -357,10 +532,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/skip")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage()))
+                    .andDo(document("playback-skip-playlist-track-not-found",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -374,10 +560,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/skip")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH.getMessage()))
+                    .andDo(document("playback-skip-track-mismatch",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -409,12 +606,34 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/stop")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("곡 정지 성공"))
-                    .andExpect(jsonPath("$.data.status").value("STOPPED"));
+                    .andExpect(jsonPath("$.data.status").value("STOPPED"))
+                    .andDo(document("playback-stop",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("재생 기록 ID"),
+                                    fieldWithPath("data.playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("data.deviceId").type(STRING).description("디바이스 ID"),
+                                    fieldWithPath("data.status").type(STRING).description("재생 상태"),
+                                    fieldWithPath("data.playedDuration").type(NUMBER).description("누적 재생 시간(초)"),
+                                    fieldWithPath("data.startedAt").type(STRING).description("재생 시작 시각"),
+                                    fieldWithPath("data.lastPlayedAt").type(STRING).description("마지막 재생 시각"),
+                                    fieldWithPath("data.endedAt").type(STRING).description("재생 종료 시각")
+                            )
+                    ));
         }
 
         @Test
@@ -425,9 +644,20 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/stop")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(request))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playback-stop-invalid",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -441,10 +671,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/stop")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.PLAYBACK_NOT_FOUND.getMessage()))
+                    .andDo(document("playback-stop-not-found",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -458,10 +699,21 @@ class PlaybackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playbacks/stop")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage()))
+                    .andDo(document("playback-stop-invalid-state",
+                            requestFields(
+                                    fieldWithPath("id").type(NUMBER).description("재생 기록 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -512,7 +764,26 @@ class PlaybackControllerTest {
                     .andExpect(jsonPath("$.data[0].id").value(2L))
                     .andExpect(jsonPath("$.data[0].status").value("SKIPPED"))
                     .andExpect(jsonPath("$.data[1].id").value(1L))
-                    .andExpect(jsonPath("$.data[1].status").value("COMPLETED"));
+                    .andExpect(jsonPath("$.data[1].status").value("COMPLETED"))
+                    .andDo(document("playback-history",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("재생 기록 목록"),
+                                    fieldWithPath("data[].id").type(NUMBER).description("재생 기록 ID"),
+                                    fieldWithPath("data[].playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data[].trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data[].userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data[].sessionId").type(STRING).description("세션 ID"),
+                                    fieldWithPath("data[].deviceId").type(STRING).description("디바이스 ID"),
+                                    fieldWithPath("data[].status").type(STRING).description("재생 상태"),
+                                    fieldWithPath("data[].playedDuration").type(NUMBER).description("누적 재생 시간(초)"),
+                                    fieldWithPath("data[].startedAt").type(STRING).description("재생 시작 시각"),
+                                    fieldWithPath("data[].lastPlayedAt").type(STRING).description("마지막 재생 시각"),
+                                    fieldWithPath("data[].endedAt").type(STRING).description("재생 종료 시각")
+                            )
+                    ));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.playlist.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.playlist.contoller.PlaylistController;
@@ -13,15 +14,12 @@ import com.fivefy.domain.playlist.service.PlaylistService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,16 +27,19 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@WithMockUser
 @WebMvcTest(PlaylistController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class PlaylistControllerTest {
-
-    @Autowired private MockMvc mockMvc;
-    @Autowired private ObjectMapper objectMapper;
+class PlaylistControllerTest extends RestDocsSupport {
 
     @MockitoBean private PlaylistService playlistService;
     @MockitoBean private JwtUtil jwtUtil;
@@ -68,6 +69,7 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists")
+                            .with(csrf().asHeader())
                             .param("userId", "1")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
@@ -76,7 +78,25 @@ class PlaylistControllerTest {
                     .andExpect(jsonPath("$.message").value("플레이리스트 생성 성공"))
                     .andExpect(jsonPath("$.data.id").value(1L))
                     .andExpect(jsonPath("$.data.title").value("운동할 때 듣는 노래"))
-                    .andExpect(jsonPath("$.data.description").value("신나는 음악 모음"));
+                    .andExpect(jsonPath("$.data.description").value("신나는 음악 모음"))
+                    .andDo(document("playlist-create",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("플레이리스트 제목"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.title").type(STRING).description("플레이리스트 제목"),
+                                    fieldWithPath("data.description").type(STRING).description("플레이리스트 설명"),
+                                    fieldWithPath("data.createdAt").type(STRING).description("생성 일시"),
+                                    fieldWithPath("data.updatedAt").type(STRING).description("수정 일시"),
+                                    fieldWithPath("data.deletedAt").type(NULL).description("삭제 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -87,9 +107,24 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playlist-create-invalid",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("플레이리스트 제목 (값 없음)"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -101,6 +136,7 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isBadRequest());
@@ -117,10 +153,22 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage()))
+                    .andDo(document("playlist-create-duplicate",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("중복된 플레이리스트 제목"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -163,7 +211,26 @@ class PlaylistControllerTest {
                     .andExpect(jsonPath("$.data.page").value(0))
                     .andExpect(jsonPath("$.data.size").value(20))
                     .andExpect(jsonPath("$.data.totalElements").value(2))
-                    .andExpect(jsonPath("$.data.totalPages").value(1));
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andDo(document("playlist-get-list",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.content").type(ARRAY).description("플레이리스트 목록"),
+                                    fieldWithPath("data.content[].id").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.content[].userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.content[].title").type(STRING).description("플레이리스트 제목"),
+                                    fieldWithPath("data.content[].description").type(STRING).description("플레이리스트 설명"),
+                                    fieldWithPath("data.content[].createdAt").type(STRING).description("생성 일시"),
+                                    fieldWithPath("data.content[].updatedAt").type(STRING).description("수정 일시"),
+                                    fieldWithPath("data.content[].deletedAt").type(NULL).description("삭제 일시"),
+                                    fieldWithPath("data.page").type(NUMBER).description("현재 페이지 번호"),
+                                    fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
+                                    fieldWithPath("data.totalElements").type(NUMBER).description("전체 데이터 수"),
+                                    fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수")
+                            )
+                    ));
         }
     }
 
@@ -193,7 +260,21 @@ class PlaylistControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 조회 성공"))
                     .andExpect(jsonPath("$.data.id").value(1L))
-                    .andExpect(jsonPath("$.data.title").value("내 플레이리스트"));
+                    .andExpect(jsonPath("$.data.title").value("내 플레이리스트"))
+                    .andDo(document("playlist-get",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.title").type(STRING).description("플레이리스트 제목"),
+                                    fieldWithPath("data.description").type(STRING).description("플레이리스트 설명"),
+                                    fieldWithPath("data.createdAt").type(STRING).description("생성 일시"),
+                                    fieldWithPath("data.updatedAt").type(STRING).description("수정 일시"),
+                                    fieldWithPath("data.deletedAt").type(NULL).description("삭제 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -206,7 +287,14 @@ class PlaylistControllerTest {
             // when & then
             mockMvc.perform(get("/api/playlists/1"))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()))
+                    .andDo(document("playlist-get-not-found",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -234,13 +322,32 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/1")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 수정 성공"))
                     .andExpect(jsonPath("$.data.title").value("수정된 제목"))
-                    .andExpect(jsonPath("$.data.description").value("수정된 설명"));
+                    .andExpect(jsonPath("$.data.description").value("수정된 설명"))
+                    .andDo(document("playlist-update",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("수정할 플레이리스트 제목"),
+                                    fieldWithPath("description").type(STRING).description("수정할 플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.userId").type(NUMBER).description("유저 ID"),
+                                    fieldWithPath("data.title").type(STRING).description("수정된 제목"),
+                                    fieldWithPath("data.description").type(STRING).description("수정된 설명"),
+                                    fieldWithPath("data.createdAt").type(STRING).description("생성 일시"),
+                                    fieldWithPath("data.updatedAt").type(STRING).description("수정 일시"),
+                                    fieldWithPath("data.deletedAt").type(NULL).description("삭제 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -251,9 +358,24 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/1")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playlist-update-invalid",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("플레이리스트 제목 (값 없음)"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -267,10 +389,22 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/1")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage()))
+                    .andDo(document("playlist-update-forbidden",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("수정할 플레이리스트 제목"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -284,10 +418,22 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/1")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()))
+                    .andDo(document("playlist-update-not-found",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("수정할 플레이리스트 제목"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -301,10 +447,22 @@ class PlaylistControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/1")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage()))
+                    .andDo(document("playlist-update-duplicate",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("중복된 플레이리스트 제목"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -324,11 +482,21 @@ class PlaylistControllerTest {
             given(playlistService.deletePlaylist(any(), eq(1L))).willReturn(response);
 
             // when & then
-            mockMvc.perform(delete("/api/playlists/1"))
+            mockMvc.perform(delete("/api/playlists/1")
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 삭제 성공"))
-                    .andExpect(jsonPath("$.data.id").value(1L));
+                    .andExpect(jsonPath("$.data.id").value(1L))
+                    .andDo(document("playlist-delete",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("삭제된 플레이리스트 ID"),
+                                    fieldWithPath("data.deletedAt").type(STRING).description("삭제 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -339,9 +507,17 @@ class PlaylistControllerTest {
                     .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN));
 
             // when & then
-            mockMvc.perform(delete("/api/playlists/1"))
+            mockMvc.perform(delete("/api/playlists/1")
+                            .with(csrf().asHeader()))
                     .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage()))
+                    .andDo(document("playlist-delete-forbidden",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -352,9 +528,17 @@ class PlaylistControllerTest {
                     .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
             // when & then
-            mockMvc.perform(delete("/api/playlists/1"))
+            mockMvc.perform(delete("/api/playlists/1")
+                            .with(csrf().asHeader()))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()))
+                    .andDo(document("playlist-delete-not-found",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/controller/PlaylistTrackControllerTest.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.playlisttrack.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
 import com.fivefy.domain.playlisttrack.dto.request.PlaylistTrackCreateRequest;
@@ -10,32 +11,33 @@ import com.fivefy.domain.playlisttrack.service.PlaylistTrackService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@WithMockUser
 @WebMvcTest(PlaylistTrackController.class)
-@AutoConfigureMockMvc(addFilters = false)
-public class PlaylistTrackControllerTest {
-
-    @Autowired private MockMvc mockMvc;
-    @Autowired private ObjectMapper objectMapper;
+public class PlaylistTrackControllerTest extends RestDocsSupport {
 
     @MockitoBean private PlaylistTrackService playlistTrackService;
     @MockitoBean private JwtUtil jwtUtil;
@@ -59,16 +61,31 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andDo(print())
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 트랙 추가 성공"))
                     .andExpect(jsonPath("$.data.id").value(1L))
                     .andExpect(jsonPath("$.data.playlistId").value(1L))
                     .andExpect(jsonPath("$.data.trackId").value(10L))
-                    .andExpect(jsonPath("$.data.position").value(1));
+                    .andExpect(jsonPath("$.data.position").value(1))
+                    .andDo(document("playlist-track-add",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("추가할 트랙 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.id").type(NUMBER).description("플레이리스트 트랙 ID"),
+                                    fieldWithPath("data.playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data.trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data.position").type(NUMBER).description("플레이리스트 내 순서"),
+                                    fieldWithPath("data.createdAt").type(STRING).description("추가 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -82,10 +99,20 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(invalidRequest))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playlist-track-add-invalid",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -99,11 +126,22 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_ACCESS_FORBIDDEN.getMessage()))
+                    .andDo(document("playlist-track-add-forbidden",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("추가할 트랙 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -117,11 +155,22 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()))
+                    .andDo(document("playlist-track-add-not-found",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("추가할 트랙 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -135,11 +184,22 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(post("/api/playlists/{playlistId}/tracks", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_TRACK_ALREADY_EXISTS.getMessage()))
+                    .andDo(document("playlist-track-add-duplicate",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("이미 추가된 트랙 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -161,7 +221,6 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(get("/api/playlists/{playlistId}/tracks", 1L))
-                    .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 트랙 목록 조회 성공"))
@@ -169,7 +228,20 @@ public class PlaylistTrackControllerTest {
                     .andExpect(jsonPath("$.data[0].trackId").value(10L))
                     .andExpect(jsonPath("$.data[0].position").value(1))
                     .andExpect(jsonPath("$.data[1].trackId").value(20L))
-                    .andExpect(jsonPath("$.data[1].position").value(2));
+                    .andExpect(jsonPath("$.data[1].position").value(2))
+                    .andDo(document("playlist-track-get-list",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("플레이리스트 트랙 목록"),
+                                    fieldWithPath("data[].id").type(NUMBER).description("플레이리스트 트랙 ID"),
+                                    fieldWithPath("data[].playlistId").type(NUMBER).description("플레이리스트 ID"),
+                                    fieldWithPath("data[].trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data[].position").type(NUMBER).description("플레이리스트 내 순서"),
+                                    fieldWithPath("data[].createdAt").type(STRING).description("추가 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -183,7 +255,14 @@ public class PlaylistTrackControllerTest {
             mockMvc.perform(get("/api/playlists/{playlistId}/tracks", 1L))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()))
+                    .andDo(document("playlist-track-get-list-not-found",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -202,13 +281,24 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andDo(print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 트랙 순서 변경 성공"))
-                    .andExpect(jsonPath("$.data").doesNotExist());
+                    .andExpect(jsonPath("$.data").doesNotExist())
+                    .andDo(document("playlist-track-update-order",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("순서를 변경할 트랙 ID"),
+                                    fieldWithPath("position").type(NUMBER).description("변경할 순서")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -219,10 +309,24 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andDo(print())
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("playlist-track-update-order-invalid",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("순서를 변경할 트랙 ID"),
+                                    fieldWithPath("position").type(NUMBER).description("변경할 순서 (1 미만)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                                    fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                                    fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+                            )
+                    ));
         }
 
         @Test
@@ -237,11 +341,23 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage()))
+                    .andDo(document("playlist-track-update-order-forbidden",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("순서를 변경할 트랙 ID"),
+                                    fieldWithPath("position").type(NUMBER).description("변경할 순서")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -256,11 +372,23 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_NOT_FOUND.getMessage()))
+                    .andDo(document("playlist-track-update-order-not-found",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("순서를 변경할 트랙 ID"),
+                                    fieldWithPath("position").type(NUMBER).description("변경할 순서")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -275,11 +403,23 @@ public class PlaylistTrackControllerTest {
 
             // when & then
             mockMvc.perform(patch("/api/playlists/{playlistId}/tracks/index", 1L)
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT.getMessage()))
+                    .andDo(document("playlist-track-update-order-conflict",
+                            requestFields(
+                                    fieldWithPath("trackId").type(NUMBER).description("순서를 변경할 트랙 ID"),
+                                    fieldWithPath("position").type(NUMBER).description("충돌이 발생한 순서")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 
@@ -295,12 +435,19 @@ public class PlaylistTrackControllerTest {
                     .deleteTrack(any(), any(), any());
 
             // when & then
-            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L))
-                    .andDo(print())
+            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("플레이리스트 트랙 삭제 성공"))
-                    .andExpect(jsonPath("$.data").doesNotExist());
+                    .andExpect(jsonPath("$.data").doesNotExist())
+                    .andDo(document("playlist-track-delete",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -312,10 +459,18 @@ public class PlaylistTrackControllerTest {
                     .deleteTrack(any(), eq(1L), eq(10L));
 
             // when & then
-            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L))
+            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage()))
+                    .andDo(document("playlist-track-delete-forbidden",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -327,10 +482,18 @@ public class PlaylistTrackControllerTest {
                     .deleteTrack(any(), eq(1L), eq(10L));
 
             // when & then
-            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L))
+            mockMvc.perform(delete("/api/playlists/{playlistId}/tracks/{trackId}", 1L, 10L)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
-                            .value(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage()));
+                            .value(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND.getMessage()))
+                    .andDo(document("playlist-track-delete-not-found",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/popularchart/controller/PopularChartControllerTest.java
+++ b/src/test/java/com/fivefy/domain/popularchart/controller/PopularChartControllerTest.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.popularchart.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.popularchart.dto.response.PopularChartResponse;
 import com.fivefy.domain.popularchart.enums.PopularChartErrorCode;
@@ -9,27 +10,26 @@ import com.fivefy.domain.popularchart.service.PopularChartService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@WithMockUser
 @WebMvcTest(PopularChartController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class PopularChartControllerTest {
-
-    @Autowired private MockMvc mockMvc;
+class PopularChartControllerTest extends RestDocsSupport {
 
     @MockitoBean private PopularChartService popularChartService;
     @MockitoBean private PopularChartGenerateService popularChartGenerateService;
@@ -62,7 +62,20 @@ class PopularChartControllerTest {
                     .andExpect(jsonPath("$.data[0].rank").value(1))
                     .andExpect(jsonPath("$.data[0].playCount").value(300))
                     .andExpect(jsonPath("$.data[1].trackId").value(102L))
-                    .andExpect(jsonPath("$.data[1].rank").value(2));
+                    .andExpect(jsonPath("$.data[1].rank").value(2))
+                    .andDo(document("popular-chart-get-top100",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("인기 차트 목록"),
+                                    fieldWithPath("data[].id").type(NUMBER).description("인기 차트 ID"),
+                                    fieldWithPath("data[].trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data[].rank").type(NUMBER).description("차트 순위"),
+                                    fieldWithPath("data[].playCount").type(NUMBER).description("재생 수"),
+                                    fieldWithPath("data[].snapshotDate").type(STRING).description("차트 스냅샷 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -87,7 +100,20 @@ class PopularChartControllerTest {
                     .andExpect(jsonPath("$.data[0].id").value(1L))
                     .andExpect(jsonPath("$.data[0].trackId").value(101L))
                     .andExpect(jsonPath("$.data[0].rank").value(1))
-                    .andExpect(jsonPath("$.data[0].playCount").value(300));
+                    .andExpect(jsonPath("$.data[0].playCount").value(300))
+                    .andDo(document("popular-chart-get-top100-with-date",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data").type(ARRAY).description("인기 차트 목록"),
+                                    fieldWithPath("data[].id").type(NUMBER).description("인기 차트 ID"),
+                                    fieldWithPath("data[].trackId").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data[].rank").type(NUMBER).description("차트 순위"),
+                                    fieldWithPath("data[].playCount").type(NUMBER).description("재생 수"),
+                                    fieldWithPath("data[].snapshotDate").type(STRING).description("차트 스냅샷 일시")
+                            )
+                    ));
         }
 
         @Test
@@ -101,7 +127,14 @@ class PopularChartControllerTest {
             mockMvc.perform(get("/api/popular-charts/top100"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
-                            .value(PopularChartErrorCode.CHART_NOT_FOUND.getMessage()));
+                            .value(PopularChartErrorCode.CHART_NOT_FOUND.getMessage()))
+                    .andDo(document("popular-chart-get-top100-not-found",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
 
         @Test
@@ -116,7 +149,14 @@ class PopularChartControllerTest {
                             .param("snapshotDate", "2026-04-07"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message")
-                            .value(PopularChartErrorCode.INVALID_SNAPSHOT_DATE.getMessage()));
+                            .value(PopularChartErrorCode.INVALID_SNAPSHOT_DATE.getMessage()))
+                    .andDo(document("popular-chart-get-top100-invalid-date",
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/popularchart/controller/PopularChartTestControllerTest.java
+++ b/src/test/java/com/fivefy/domain/popularchart/controller/PopularChartTestControllerTest.java
@@ -1,32 +1,31 @@
 package com.fivefy.domain.popularchart.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.domain.popularchart.service.PopularChartGenerateService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WithMockUser
 @WebMvcTest(PopularChartTestController.class)
-@AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("local")
-class PopularChartTestControllerTest {
-
-    @Autowired private MockMvc mockMvc;
+class PopularChartTestControllerTest extends RestDocsSupport {
 
     @MockitoBean private PopularChartGenerateService popularChartGenerateService;
     @MockitoBean private JwtUtil jwtUtil;
@@ -36,9 +35,11 @@ class PopularChartTestControllerTest {
     @DisplayName("테스트용 인기 차트 생성 API 호출 성공")
     void generate_success() throws Exception {
         // when & then
-        mockMvc.perform(post("/test/popular-charts/generate"))
+        mockMvc.perform(post("/test/popular-charts/generate")
+                .with(csrf()))
                 .andExpect(status().isOk())
-                .andExpect(content().string("ok"));
+                .andExpect(content().string("ok"))
+                .andDo(document("popular-chart-test-generate"));
 
         verify(popularChartGenerateService, times(1))
                 .generateWeeklyChart(any(LocalDate.class));


### PR DESCRIPTION
## 개요

> 인기 차트 도메인(PopularChart)에 대해 컨트롤러, 서비스, 스케줄러, 엔티티 단위 테스트를 추가하고  
REST Docs 기반 API 문서화를 적용하여 전체 흐름을 검증하였습니다.  

## 변경 사항

### 1. REST Docs 테스트 코드 추가

- PlaylistController 테스트 코드 작성
  - API 요청/응답 검증
  - REST Docs 문서화 추가

- PlaylistTrackController 테스트 코드 작성
  - 트랙 추가/조회/순서 변경/삭제 API 검증
  - REST Docs 문서화 추가

- PlaybackController 테스트 코드 작성
  - 재생/일시정지/건너뛰기/정지/조회 API 검증
  - REST Docs 문서화 추가

- PopularChartController 테스트 코드 작성
  - snapshotDate 기반 인기 차트 조회 API 검증
  - REST Docs 문서화 추가

- PopularChartTestController 테스트 코드 작성
  - 테스트용 인기 차트 생성 API 검증

---

### 2. REST Docs 문서 구성

- index.adoc 기반 API 문서 구조 작성
- 도메인별 API 문서 분리
  - Playlist
  - PlaylistTrack
  - Playback
  - PopularChart
- 성공/에러 케이스별 snippet include 구성


## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [x] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 플레이리스트, 플레이리스트 트랙, 재생, 인기 차트 REST API 엔드포인트에 대한 상세 API 문서를 추가했습니다. 각 엔드포인트별 요청/응답 스키마, 요청 검증 오류, 권한 오류, 리소스 없음 등 다양한 오류 케이스 문서를 포함합니다.

* **테스트**
  * API 엔드포인트 테스트의 자동화된 문서 생성 기능을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->