### PR TITLE
feat: 트랙 등록 신청(Application) 도메인 전환 및 생성/조회 API 구현

### DIFF
--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -5,6 +5,7 @@ import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
@@ -111,6 +112,22 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 목록 조회 성공", response)
+        );
+    }
+
+    /**
+     * 트랙 등록 신청 승인 API (관리자)
+     */
+    @PostMapping("/admin/track-applications/{applicationId}/approve")
+    public ResponseEntity<BaseResponse<TrackApplicationApproveResponse>> approveTrackApplication(
+            @AuthenticationPrincipal Long adminId,
+            @PathVariable Long applicationId
+    ) {
+        TrackApplicationApproveResponse response =
+                trackService.approveTrackApplication(adminId, applicationId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 승인 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -1,0 +1,42 @@
+package com.fivefy.domain.track.controller;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.service.TrackService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 트랙 등록 신청 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TrackApplicationController {
+
+    private final TrackService trackService;
+
+    /**
+     * 자유 창작 트랙 등록 신청 API
+     */
+    @PostMapping("/track-applications/free-creations")
+    public ResponseEntity<BaseResponse<TrackApplicationResponse>> createFreeTrackApplication(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody FreeTrackApplicationCreateRequest request
+    ) {
+        TrackApplicationResponse response =
+                trackService.createFreeTrackApplication(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                BaseResponse.success(HttpStatus.CREATED, "자유 창작 트랙 등록 신청 성공", response)
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -5,10 +5,7 @@ import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
-import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.service.TrackService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -128,6 +125,23 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 승인 성공", response)
+        );
+    }
+
+    /**
+     * 트랙 등록 신청 거절 API (관리자)
+     */
+    @PostMapping("/admin/track-applications/{applicationId}/reject")
+    public ResponseEntity<BaseResponse<TrackApplicationRejectResponse>> rejectTrackApplication(
+            @AuthenticationPrincipal Long adminId,
+            @PathVariable Long applicationId,
+            @Valid @RequestBody String rejectionReason
+    ) {
+        TrackApplicationRejectResponse response =
+                trackService.rejectTrackApplication(adminId, applicationId, rejectionReason);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 거절 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -2,6 +2,7 @@ package com.fivefy.domain.track.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.service.TrackService;
 import jakarta.validation.Valid;
@@ -37,6 +38,22 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 BaseResponse.success(HttpStatus.CREATED, "자유 창작 트랙 등록 신청 성공", response)
+        );
+    }
+
+    /**
+     * 정식 발매 트랙 등록 신청 API
+     */
+    @PostMapping("/track-applications/official-releases")
+    public ResponseEntity<BaseResponse<TrackApplicationResponse>> createOfficialTrackApplication(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody OfficialTrackApplicationCreateRequest request
+    ) {
+        TrackApplicationResponse response =
+                trackService.createOfficialTrackApplication(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                BaseResponse.success(HttpStatus.CREATED, "정식 발매 트랙 등록 신청 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.track.controller;
 import com.fivefy.common.dto.response.BaseResponse;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.service.TrackService;
 import jakarta.validation.Valid;
@@ -68,6 +69,22 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "내 트랙 등록 신청 목록 조회 성공", response)
+        );
+    }
+
+    /**
+     * 트랙 등록 신청 상세 조회 API
+     */
+    @GetMapping("/track-applications/{applicationId}")
+    public ResponseEntity<BaseResponse<TrackApplicationDetailResponse>> getTrackApplication(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long applicationId
+    ) {
+        TrackApplicationDetailResponse response =
+                trackService.getTrackApplication(userId, applicationId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 상세 조회 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -10,10 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 /**
  * 트랙 등록 신청 컨트롤러
@@ -54,6 +53,21 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 BaseResponse.success(HttpStatus.CREATED, "정식 발매 트랙 등록 신청 성공", response)
+        );
+    }
+
+    /**
+     * 내 트랙 등록 신청 목록 조회 API
+     */
+    @GetMapping("/track-applications/me")
+    public ResponseEntity<BaseResponse<List<TrackApplicationResponse>>> getMyTrackApplications(
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<TrackApplicationResponse> response =
+                trackService.getMyTrackApplications(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "내 트랙 등록 신청 목록 조회 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -1,13 +1,19 @@
 package com.fivefy.domain.track.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
+import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.service.TrackService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -85,6 +91,26 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 상세 조회 성공", response)
+        );
+    }
+
+    /**
+     * 트랙 등록 신청 목록 조회 API (관리자)
+     */
+    @GetMapping("/admin/track-applications")
+    public ResponseEntity<BaseResponse<PageResponse<TrackApplicationListResponse>>> getTrackApplications(
+            @RequestParam(required = false) ApplicationStatus status,
+            @PageableDefault(
+                    size = 10,
+                    sort = "createdAt",
+                    direction = Sort.Direction.ASC
+            ) Pageable pageable
+    ) {
+        PageResponse<TrackApplicationListResponse> response =
+                trackService.getTrackApplications(status, pageable);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 목록 조회 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/dto/request/FreeTrackApplicationCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/track/dto/request/FreeTrackApplicationCreateRequest.java
@@ -1,0 +1,31 @@
+package com.fivefy.domain.track.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 자유 창작 트랙 등록 신청 요청 DTO
+ */
+public record FreeTrackApplicationCreateRequest(
+
+        @NotBlank(message = "트랙 제목은 필수입니다")
+        @Size(max = 150, message = "트랙 제목은 150자 이하여야 합니다")
+        String title,
+
+        String lyrics,
+
+        @NotBlank(message = "장르는 필수입니다")
+        @Size(max = 100, message = "장르는 100자 이하여야 합니다")
+        String genre,
+
+        @NotBlank(message = "오디오 URL은 필수입니다")
+        @Size(max = 255, message = "오디오 URL은 255자 이하여야 합니다")
+        String audioUrl,
+
+        @NotNull(message = "재생 시간은 필수입니다")
+        @Positive(message = "재생 시간은 1초 이상이어야 합니다")
+        Long durationSec
+) {
+}

--- a/src/main/java/com/fivefy/domain/track/dto/request/OfficialTrackApplicationCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/track/dto/request/OfficialTrackApplicationCreateRequest.java
@@ -1,11 +1,6 @@
 package com.fivefy.domain.track.dto.request;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 
 /**
  * 정식 발매 트랙 등록 신청 요청 DTO

--- a/src/main/java/com/fivefy/domain/track/dto/request/OfficialTrackApplicationCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/track/dto/request/OfficialTrackApplicationCreateRequest.java
@@ -1,0 +1,50 @@
+package com.fivefy.domain.track.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 정식 발매 트랙 등록 신청 요청 DTO
+ */
+public record OfficialTrackApplicationCreateRequest(
+        @NotNull(message = "아티스트 ID는 필수입니다")
+        Long artistId,
+
+        @NotNull(message = "앨범 ID는 필수입니다")
+        Long albumId,
+
+        @NotNull(message = "트랙 번호는 필수입니다")
+        @Positive(message = "트랙 번호는 1 이상이어야 합니다")
+        Long trackNumber,
+
+        @NotBlank(message = "트랙 제목은 필수입니다")
+        @Size(max = 150, message = "트랙 제목은 150자 이하여야 합니다")
+        String title,
+
+        String lyrics,
+
+        @NotBlank(message = "장르는 필수입니다")
+        @Size(max = 100, message = "장르는 100자 이하여야 합니다")
+        String genre,
+
+        @NotBlank(message = "오디오 URL은 필수입니다")
+        @Size(max = 255, message = "오디오 URL은 255자 이하여야 합니다")
+        String audioUrl,
+
+        @NotNull(message = "재생 시간은 필수입니다")
+        @Positive(message = "재생 시간은 1초 이상이어야 합니다")
+        Long durationSec,
+
+        @Size(max = 255, message = "피처링 아티스트 정보는 255자 이하여야 합니다")
+        String featuredArtistText,
+
+        @NotNull(message = "공개 예약 옵션은 필수입니다")
+        @Min(value = 0, message = "공개 예약 옵션은 0 이상이어야 합니다")
+        @Max(value = 7, message = "공개 예약 옵션은 7 이하여야 합니다")
+        Integer publishDelayDays
+) {
+}

--- a/src/main/java/com/fivefy/domain/track/dto/request/TrackApplicationRejectRequest.java
+++ b/src/main/java/com/fivefy/domain/track/dto/request/TrackApplicationRejectRequest.java
@@ -1,0 +1,14 @@
+package com.fivefy.domain.track.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 트랙 등록 신청 거절 요청 DTO
+ */
+public record TrackApplicationRejectRequest(
+        @NotBlank(message = "거절 사유는 필수입니다")
+        @Size(max = 255, message = "거절 사유는 255자 이하여야 합니다")
+        String rejectionReason
+) {
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationApproveResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationApproveResponse.java
@@ -1,0 +1,29 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.domain.track.entity.TrackApplication;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 승인 응답 DTO
+ */
+public record TrackApplicationApproveResponse(
+        Long applicationId,
+        Long trackId,
+        String status,
+        Long reviewedByAdminId,
+        LocalDateTime reviewedAt
+) {
+    public static TrackApplicationApproveResponse from(
+            TrackApplication application,
+            Long trackId
+    ) {
+        return new TrackApplicationApproveResponse(
+                application.getId(),
+                trackId,
+                application.getStatus().name(),
+                application.getReviewedByAdminId(),
+                application.getReviewedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationDetailResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationDetailResponse.java
@@ -1,0 +1,56 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 상세 응답 DTO
+ */
+public record TrackApplicationDetailResponse(
+        Long applicationId,
+        Long requesterUserId,
+        TrackType trackType,
+        Long artistId,
+        Long albumId,
+        Long trackNumber,
+        String title,
+        String lyrics,
+        String genre,
+        String audioUrl,
+        Long durationSec,
+        String featuredArtistText,
+        Integer publishDelayDays,
+        ApplicationStatus status,
+        Long reviewedByAdminId,
+        LocalDateTime reviewedAt,
+        String rejectionReason,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static TrackApplicationDetailResponse from(TrackApplication application) {
+        return new TrackApplicationDetailResponse(
+                application.getId(),
+                application.getRequesterUserId(),
+                application.getTrackType(),
+                application.getArtistId(),
+                application.getAlbumId(),
+                application.getTrackNumber(),
+                application.getTitle(),
+                application.getLyrics(),
+                application.getGenre(),
+                application.getAudioUrl(),
+                application.getDurationSec(),
+                application.getFeaturedArtistText(),
+                application.getPublishDelayDays(),
+                application.getStatus(),
+                application.getReviewedByAdminId(),
+                application.getReviewedAt(),
+                application.getRejectionReason(),
+                application.getCreatedAt(),
+                application.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationListResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationListResponse.java
@@ -1,0 +1,30 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 목록 응답 DTO
+ */
+public record TrackApplicationListResponse(
+        Long applicationId,
+        Long requesterUserId,
+        TrackType trackType,
+        String title,
+        ApplicationStatus status,
+        LocalDateTime createdAt
+) {
+    public static TrackApplicationListResponse from(TrackApplication application) {
+        return new TrackApplicationListResponse(
+                application.getId(),
+                application.getRequesterUserId(),
+                application.getTrackType(),
+                application.getTitle(),
+                application.getStatus(),
+                application.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationRejectResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationRejectResponse.java
@@ -1,0 +1,27 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.TrackApplication;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 거절 응답 DTO
+ */
+public record TrackApplicationRejectResponse(
+        Long applicationId,
+        ApplicationStatus status,
+        Long reviewedByAdminId,
+        LocalDateTime reviewedAt,
+        String rejectionReason
+) {
+    public static TrackApplicationRejectResponse from(TrackApplication application) {
+        return new TrackApplicationRejectResponse(
+                application.getId(),
+                application.getStatus(),
+                application.getReviewedByAdminId(),
+                application.getReviewedAt(),
+                application.getRejectionReason()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationResponse.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.track.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackType;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
  * - 자유 창작 / 정식 발매 공통으로 사용
  * - 자유 창작의 경우 artistId, albumId는 null
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TrackApplicationResponse(
 
         Long applicationId,

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationResponse.java
@@ -1,0 +1,40 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 생성 응답 DTO
+ *
+ * - 자유 창작 / 정식 발매 공통으로 사용
+ * - 자유 창작의 경우 artistId, albumId는 null
+ */
+public record TrackApplicationResponse(
+
+        Long applicationId,
+        TrackType trackType,
+        Long artistId,
+        Long albumId,
+        String title,
+        ApplicationStatus status,
+        LocalDateTime createdAt
+) {
+
+    /**
+     * TrackApplication 엔티티 → 응답 DTO 변환
+     */
+    public static TrackApplicationResponse from(TrackApplication trackApplication) {
+        return new TrackApplicationResponse(
+                trackApplication.getId(),
+                trackApplication.getTrackType(),
+                trackApplication.getArtistId(),
+                trackApplication.getAlbumId(),
+                trackApplication.getTitle(),
+                trackApplication.getStatus(),
+                trackApplication.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/entity/Track.java
+++ b/src/main/java/com/fivefy/domain/track/entity/Track.java
@@ -93,8 +93,7 @@ public class Track extends BaseEntity {
             String lyrics,
             String genre,
             String audioUrl,
-            Long durationSec,
-            LocalDateTime scheduledPublishAt
+            Long durationSec
     ) {
         validateNonNull(ownerUserId, "ownerUserId");
         validateNonNull(title, "title");
@@ -111,8 +110,8 @@ public class Track extends BaseEntity {
         track.genre = genre;
         track.audioUrl = audioUrl;
         track.durationSec = durationSec;
-        track.scheduledPublishAt = scheduledPublishAt;
         track.status = TrackStatus.PUBLISHED;
+        track.publishedAt = LocalDateTime.now();
         track.playCount = 0L;
 
         return track;

--- a/src/main/java/com/fivefy/domain/track/entity/Track.java
+++ b/src/main/java/com/fivefy/domain/track/entity/Track.java
@@ -15,6 +15,9 @@ import java.time.LocalDateTime;
 
 import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
+/**
+ * 트랙 엔티티
+ */
 @Getter
 @Entity
 @Table(
@@ -87,6 +90,9 @@ public class Track extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    /**
+     * 자유 창작 트랙 생성
+     */
     public static Track createFreeCreation(
             Long ownerUserId,
             String title,
@@ -100,6 +106,8 @@ public class Track extends BaseEntity {
         validateNonNull(genre, "genre");
         validateNonNull(audioUrl, "audioUrl");
         validateNonNull(durationSec, "durationSec");
+
+        validateDurationSec(durationSec);
 
         Track track = new Track();
 
@@ -117,6 +125,9 @@ public class Track extends BaseEntity {
         return track;
     }
 
+    /**
+     * 정식 발매 트랙 생성
+     */
     public static Track createOfficialRelease(
             Long ownerUserId,
             Long artistId,
@@ -139,13 +150,8 @@ public class Track extends BaseEntity {
         validateNonNull(audioUrl, "audioUrl");
         validateNonNull(durationSec, "durationSec");
 
-        if (trackNumber <= 0L) {
-            throw new BusinessException(TrackErrorCode.ERR_INVALID_TRACK_NUMBER);
-        }
-
-        if (durationSec <= 0L) {
-            throw new BusinessException(TrackErrorCode.ERR_INVALID_DURATION_SEC);
-        }
+        validateTrackNumber(trackNumber);
+        validateDurationSec(durationSec);
 
         Track track = new Track();
 
@@ -167,38 +173,54 @@ public class Track extends BaseEntity {
         return track;
     }
 
+    /**
+     * 트랙 공개
+     */
     public void publish() {
         validateNotDeleted();
 
         if (this.status == TrackStatus.PUBLISHED) {
             throw new BusinessException(TrackErrorCode.ERR_TRACK_ALREADY_PUBLISHED);
         }
+
         this.status = TrackStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();
     }
 
+    /**
+     * 트랙 차단
+     */
     public void block() {
         validateNotDeleted();
 
         if (this.status == TrackStatus.BLOCKED) {
             throw new BusinessException(TrackErrorCode.ERR_TRACK_ALREADY_BLOCKED);
         }
+
         this.status = TrackStatus.BLOCKED;
     }
 
+    /**
+     * 재생 수 증가
+     */
     public void increasePlayCount() {
         validateNotDeleted();
 
         if (this.status != TrackStatus.PUBLISHED) {
             throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_PUBLISHED);
         }
+
         this.playCount++;
     }
 
+    /**
+     * soft delete
+     */
     public void softDelete() {
         if (this.deletedAt != null) {
             throw new BusinessException(TrackErrorCode.ERR_TRACK_ALREADY_DELETED);
         }
+
         this.deletedAt = LocalDateTime.now();
     }
 
@@ -213,6 +235,18 @@ public class Track extends BaseEntity {
     public boolean isOwnedBy(Long ownerUserId) {
         validateNonNull(ownerUserId, "ownerUserId");
         return this.ownerUserId.equals(ownerUserId);
+    }
+
+    private static void validateTrackNumber(Long trackNumber) {
+        if (trackNumber <= 0L) {
+            throw new BusinessException(TrackErrorCode.ERR_INVALID_TRACK_NUMBER);
+        }
+    }
+
+    private static void validateDurationSec(Long durationSec) {
+        if (durationSec <= 0L) {
+            throw new BusinessException(TrackErrorCode.ERR_INVALID_DURATION_SEC);
+        }
     }
 
     private void validateNotDeleted() {

--- a/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
@@ -3,7 +3,7 @@ package com.fivefy.domain.track.entity;
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.track.enums.TrackReleaseErrorCode;
+import com.fivefy.domain.track.enums.TrackApplicationErrorcode;
 import com.fivefy.domain.track.enums.TrackType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,16 +18,16 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 @Getter
 @Entity
 @Table(
-        name = "track_release_requests",
+        name = "track_applications",
         indexes = {
-                @Index(name = "idx_track_release_request_requester_user_id", columnList = "requester_user_id"),
-                @Index(name = "idx_track_release_request_artist_id", columnList = "artist_id"),
-                @Index(name = "idx_track_release_request_album_id", columnList = "album_id"),
-                @Index(name = "idx_track_release_request_status", columnList = "status")
+                @Index(name = "idx_track_application_requester_user_id", columnList = "requester_user_id"),
+                @Index(name = "idx_track_application_artist_id", columnList = "artist_id"),
+                @Index(name = "idx_track_application_album_id", columnList = "album_id"),
+                @Index(name = "idx_track_application_status", columnList = "status")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TrackReleaseRequest extends BaseEntity {
+public class TrackApplication extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -87,7 +87,7 @@ public class TrackReleaseRequest extends BaseEntity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    public static TrackReleaseRequest create(
+    public static TrackApplication create(
             Long requesterUserId,
             TrackType trackType,
             Long artistId,
@@ -108,7 +108,7 @@ public class TrackReleaseRequest extends BaseEntity {
         validateNonNull(audioUrl, "audioUrl");
         validateNonNull(durationSec, "durationSec");
 
-        TrackReleaseRequest request = new TrackReleaseRequest();
+        TrackApplication request = new TrackApplication();
 
         request.requesterUserId = requesterUserId;
         request.trackType = trackType;
@@ -151,7 +151,7 @@ public class TrackReleaseRequest extends BaseEntity {
 
     private void validatePending() {
         if (this.status != ApplicationStatus.PENDING) {
-            throw new BusinessException(TrackReleaseErrorCode.ERR_TRACK_RELEASE_ALREADY_PROCESSED);
+            throw new BusinessException(TrackApplicationErrorcode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
@@ -4,6 +4,7 @@ import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
+import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -87,6 +88,9 @@ public class TrackApplication extends BaseEntity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    /**
+     * 트랙 등록 신청 생성
+     */
     public static TrackApplication create(
             Long requesterUserId,
             TrackType trackType,
@@ -108,6 +112,8 @@ public class TrackApplication extends BaseEntity {
         validateNonNull(audioUrl, "audioUrl");
         validateNonNull(durationSec, "durationSec");
 
+        validateDurationSec(durationSec);
+
         TrackApplication application = new TrackApplication();
 
         application.requesterUserId = requesterUserId;
@@ -127,7 +133,9 @@ public class TrackApplication extends BaseEntity {
         return application;
     }
 
-
+    /**
+     * 트랙 등록 신청 승인
+     */
     public void approve(Long adminId) {
         validateNonNull(adminId, "adminId");
         validatePending();
@@ -138,6 +146,9 @@ public class TrackApplication extends BaseEntity {
         this.rejectionReason = null;
     }
 
+    /**
+     * 트랙 등록 신청 거절
+     */
     public void reject(Long adminId, String rejectionReason) {
         validateNonNull(adminId, "adminId");
         validateNonNull(rejectionReason, "rejectionReason");
@@ -149,9 +160,19 @@ public class TrackApplication extends BaseEntity {
         this.rejectionReason = rejectionReason;
     }
 
+    // 상태 검증 (PENDING만 처리 가능)
     private void validatePending() {
         if (this.status != ApplicationStatus.PENDING) {
-            throw new BusinessException(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED);
+            throw new BusinessException(
+                    TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED
+            );
+        }
+    }
+
+    // 재생 시간 검증
+    private static void validateDurationSec(Long durationSec) {
+        if (durationSec <= 0L) {
+            throw new BusinessException(TrackErrorCode.ERR_INVALID_DURATION_SEC);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
@@ -68,8 +68,8 @@ public class TrackApplication extends BaseEntity {
     @Column(name = "featured_artist_text", length = 255)
     private String featuredArtistText;
 
-    @Column(name = "scheduled_publish_at")
-    private LocalDateTime scheduledPublishAt;
+    @Column(name = "publish_delay_days")
+    private Integer publishDelayDays;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
@@ -103,15 +103,15 @@ public class TrackApplication extends BaseEntity {
             String audioUrl,
             Long durationSec,
             String featuredArtistText,
-            LocalDateTime scheduledPublishAt
+            Integer publishDelayDays
     ) {
         validateNonNull(requesterUserId, "requesterUserId");
         validateNonNull(trackType, "trackType");
         validateNonNull(title, "title");
         validateNonNull(genre, "genre");
         validateNonNull(audioUrl, "audioUrl");
-        validateNonNull(durationSec, "durationSec");
 
+        validatePublishDelayDays(publishDelayDays);
         validateDurationSec(durationSec);
 
         TrackApplication application = new TrackApplication();
@@ -127,7 +127,7 @@ public class TrackApplication extends BaseEntity {
         application.audioUrl = audioUrl;
         application.durationSec = durationSec;
         application.featuredArtistText = featuredArtistText;
-        application.scheduledPublishAt = scheduledPublishAt;
+        application.publishDelayDays = publishDelayDays;
         application.status = ApplicationStatus.PENDING;
 
         return application;
@@ -171,8 +171,17 @@ public class TrackApplication extends BaseEntity {
 
     // 재생 시간 검증
     private static void validateDurationSec(Long durationSec) {
+        validateNonNull(durationSec, "durationSec");
+
         if (durationSec <= 0L) {
             throw new BusinessException(TrackErrorCode.ERR_INVALID_DURATION_SEC);
+        }
+    }
+
+    // 공개 예약 옵션 검증
+    private static void validatePublishDelayDays(Integer publishDelayDays) {
+        if (publishDelayDays != null && (publishDelayDays < 0 || publishDelayDays > 7)) {
+            throw new BusinessException(TrackApplicationErrorCode.ERR_INVALID_PUBLISH_DELAY_DAYS);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackApplication.java
@@ -3,7 +3,7 @@ package com.fivefy.domain.track.entity;
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.track.enums.TrackApplicationErrorcode;
+import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -108,23 +108,23 @@ public class TrackApplication extends BaseEntity {
         validateNonNull(audioUrl, "audioUrl");
         validateNonNull(durationSec, "durationSec");
 
-        TrackApplication request = new TrackApplication();
+        TrackApplication application = new TrackApplication();
 
-        request.requesterUserId = requesterUserId;
-        request.trackType = trackType;
-        request.artistId = artistId;
-        request.albumId = albumId;
-        request.trackNumber = trackNumber;
-        request.title = title;
-        request.lyrics = lyrics;
-        request.genre = genre;
-        request.audioUrl = audioUrl;
-        request.durationSec = durationSec;
-        request.featuredArtistText = featuredArtistText;
-        request.scheduledPublishAt = scheduledPublishAt;
-        request.status = ApplicationStatus.PENDING;
+        application.requesterUserId = requesterUserId;
+        application.trackType = trackType;
+        application.artistId = artistId;
+        application.albumId = albumId;
+        application.trackNumber = trackNumber;
+        application.title = title;
+        application.lyrics = lyrics;
+        application.genre = genre;
+        application.audioUrl = audioUrl;
+        application.durationSec = durationSec;
+        application.featuredArtistText = featuredArtistText;
+        application.scheduledPublishAt = scheduledPublishAt;
+        application.status = ApplicationStatus.PENDING;
 
-        return request;
+        return application;
     }
 
 
@@ -151,7 +151,7 @@ public class TrackApplication extends BaseEntity {
 
     private void validatePending() {
         if (this.status != ApplicationStatus.PENDING) {
-            throw new BusinessException(TrackApplicationErrorcode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED);
+            throw new BusinessException(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum TrackApplicationErrorCode implements ErrorCode {
-    ERR_TRACK_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 신청입니다");
+    ERR_TRACK_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 신청입니다"),
+    ERR_TRACK_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리 중인 트랙 등록 신청이 존재합니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
@@ -7,7 +7,10 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum TrackApplicationErrorCode implements ErrorCode {
     ERR_TRACK_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 신청입니다"),
-    ERR_TRACK_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리 중인 트랙 등록 신청이 존재합니다");
+    ERR_TRACK_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리 중인 트랙 등록 신청이 존재합니다"),
+    ERR_INVALID_PUBLISH_DELAY_DAYS(HttpStatus.BAD_REQUEST, "공개 예약 옵션은 0 이상 7 이하여야 합니다"),
+    ERR_INACTIVE_ARTIST_CANNOT_REQUEST_OFFICIAL_RELEASE(HttpStatus.FORBIDDEN, "승인된 아티스트만 정식 발매 트랙 등록 신청이 가능합니다"),
+    ERR_ALBUM_ARTIST_MISMATCH(HttpStatus.BAD_REQUEST, "앨범과 아티스트 정보가 일치하지 않습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
@@ -10,6 +10,8 @@ public enum TrackApplicationErrorCode implements ErrorCode {
     ERR_TRACK_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리 중인 트랙 등록 신청이 존재합니다"),
     ERR_INVALID_PUBLISH_DELAY_DAYS(HttpStatus.BAD_REQUEST, "공개 예약 옵션은 0 이상 7 이하여야 합니다"),
     ERR_INACTIVE_ARTIST_CANNOT_REQUEST_OFFICIAL_RELEASE(HttpStatus.FORBIDDEN, "승인된 아티스트만 정식 발매 트랙 등록 신청이 가능합니다"),
+    ERR_TRACK_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "트랙 등록 신청이 존재하지 않습니다"),
+    ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 또는 관리자만 트랙 등록 신청 상세 정보를 조회할 수 있습니다"),
     ERR_ALBUM_ARTIST_MISMATCH(HttpStatus.BAD_REQUEST, "앨범과 아티스트 정보가 일치하지 않습니다");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
@@ -5,13 +5,13 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum TrackReleaseErrorCode implements ErrorCode {
-    ERR_TRACK_RELEASE_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 요청입니다");
+public enum TrackApplicationErrorcode implements ErrorCode {
+    ERR_TRACK_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 요청입니다");
 
     private final HttpStatus httpStatus;
     private final String message;
 
-    TrackReleaseErrorCode(HttpStatus httpStatus, String message) {
+    TrackApplicationErrorcode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackApplicationErrorCode.java
@@ -5,13 +5,13 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum TrackApplicationErrorcode implements ErrorCode {
-    ERR_TRACK_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 요청입니다");
+public enum TrackApplicationErrorCode implements ErrorCode {
+    ERR_TRACK_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 트랙 등록 신청입니다");
 
     private final HttpStatus httpStatus;
     private final String message;
 
-    TrackApplicationErrorcode(HttpStatus httpStatus, String message) {
+    TrackApplicationErrorCode(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepository.java
@@ -1,0 +1,26 @@
+package com.fivefy.domain.track.repository;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface TrackApplicationQueryRepository {
+    boolean existsActiveApplication(
+            Long requesterUserId,
+            TrackType trackType,
+            Long artistId,
+            Long albumId,
+            String title
+    );
+
+    List<TrackApplication> searchMyTrackApplications(Long requesterUserId);
+
+    Page<TrackApplication> searchTrackApplications(
+            ApplicationStatus status,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepository.java
@@ -2,18 +2,25 @@ package com.fivefy.domain.track.repository;
 
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.entity.TrackApplication;
-import com.fivefy.domain.track.enums.TrackType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-
+/**
+ * TrackApplication Querydsl 전용 Repository
+ */
 public interface TrackApplicationQueryRepository {
-    boolean existsActiveApplication(
+    boolean existsPendingFreeCreationApplication(
             Long requesterUserId,
-            TrackType trackType,
+            String title,
+            String audioUrl
+    );
+
+    boolean existsPendingOfficialReleaseApplication(
+            Long requesterUserId,
             Long artistId,
             Long albumId,
+            Long trackNumber,
             String title
     );
 

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -1,4 +1,63 @@
 package com.fivefy.domain.track.repository;
 
-public interface TrackApplicationQueryRepositoryImpl {
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.QTrackApplication;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * TrackApplication Querydsl 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 자유 창작 PENDING 중복 신청 여부 조회
+     */
+    @Override
+    public boolean existsPendingFreeCreationApplication(
+            Long requesterUserId,
+            String title,
+            String audioUrl
+    ) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(QTrackApplication.trackApplication)
+                .where(
+                        QTrackApplication.trackApplication.requesterUserId.eq(requesterUserId),
+                        QTrackApplication.trackApplication.status.eq(ApplicationStatus.PENDING),
+                        QTrackApplication.trackApplication.artistId.isNull(),
+                        QTrackApplication.trackApplication.albumId.isNull(),
+                        QTrackApplication.trackApplication.trackNumber.isNull(),
+                        QTrackApplication.trackApplication.title.eq(title),
+                        QTrackApplication.trackApplication.audioUrl.eq(audioUrl)
+                )
+                .fetchFirst();
+
+        return result != null;
+    }
+
+    @Override
+    public boolean existsPendingOfficialReleaseApplication(Long requesterUserId, Long artistId, Long albumId, Long trackNumber, String title) {
+        return false;
+    }
+
+    @Override
+    public List<TrackApplication> searchMyTrackApplications(Long requesterUserId) {
+        return List.of();
+    }
+
+    @Override
+    public Page<TrackApplication> searchTrackApplications(ApplicationStatus status, Pageable pageable) {
+        return null;
+    }
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.fivefy.domain.track.repository;
 
 import com.fivefy.common.enums.ApplicationStatus;
-import com.fivefy.domain.track.entity.QTrackApplication;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackType;
 import com.querydsl.core.types.dsl.BooleanExpression;

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.fivefy.domain.track.repository;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.entity.QTrackApplication;
 import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackType;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -10,6 +12,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+
+import static com.fivefy.domain.track.entity.QTrackApplication.trackApplication;
 
 /**
  * TrackApplication Querydsl 구현체
@@ -31,24 +35,46 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
     ) {
         Integer result = queryFactory
                 .selectOne()
-                .from(QTrackApplication.trackApplication)
+                .from(trackApplication)
                 .where(
-                        QTrackApplication.trackApplication.requesterUserId.eq(requesterUserId),
-                        QTrackApplication.trackApplication.status.eq(ApplicationStatus.PENDING),
-                        QTrackApplication.trackApplication.artistId.isNull(),
-                        QTrackApplication.trackApplication.albumId.isNull(),
-                        QTrackApplication.trackApplication.trackNumber.isNull(),
-                        QTrackApplication.trackApplication.title.eq(title),
-                        QTrackApplication.trackApplication.audioUrl.eq(audioUrl)
+                        trackApplication.requesterUserId.eq(requesterUserId),
+                        trackApplication.status.eq(ApplicationStatus.PENDING),
+                        trackApplication.artistId.isNull(),
+                        trackApplication.albumId.isNull(),
+                        trackApplication.trackNumber.isNull(),
+                        trackApplication.title.eq(title),
+                        trackApplication.audioUrl.eq(audioUrl)
                 )
                 .fetchFirst();
 
         return result != null;
     }
 
+    /**
+     * 정식 발매 PENDING 중복 신청 여부 조회
+     */
     @Override
-    public boolean existsPendingOfficialReleaseApplication(Long requesterUserId, Long artistId, Long albumId, Long trackNumber, String title) {
-        return false;
+    public boolean existsPendingOfficialReleaseApplication(
+            Long requesterUserId,
+            Long artistId,
+            Long albumId,
+            Long trackNumber,
+            String title
+    ) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(trackApplication)
+                .where(
+                        trackApplication.requesterUserId.eq(requesterUserId),
+                        trackApplication.status.eq(ApplicationStatus.PENDING),
+                        trackApplication.trackType.eq(TrackType.OFFICIAL_RELEASE),
+                        trackApplication.artistId.eq(artistId),
+                        trackApplication.albumId.eq(albumId),
+                        officialReleaseDuplicateCondition(trackNumber, title)
+                )
+                .fetchFirst();
+
+        return result != null;
     }
 
     @Override
@@ -59,5 +85,16 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
     @Override
     public Page<TrackApplication> searchTrackApplications(ApplicationStatus status, Pageable pageable) {
         return null;
+    }
+
+    // 같은 앨범 내 동일 trackNumber 또는 동일 title 중복 조건
+    private BooleanExpression officialReleaseDuplicateCondition(
+            Long trackNumber,
+            String title
+    ) {
+        BooleanExpression sameTrackNumber = trackApplication.trackNumber.eq(trackNumber);
+        BooleanExpression sameTitle = trackApplication.title.eq(title);
+
+        return sameTrackNumber.or(sameTitle);
     }
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -88,9 +89,29 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
                 .fetch();
     }
 
+    /**
+     * 트랙 등록 신청 목록 조회
+     */
     @Override
-    public Page<TrackApplication> searchTrackApplications(ApplicationStatus status, Pageable pageable) {
-        return null;
+    public Page<TrackApplication> searchTrackApplications(
+            ApplicationStatus status,
+            Pageable pageable
+    ) {
+        List<TrackApplication> content = queryFactory
+                .selectFrom(trackApplication)
+                .where(statusEq(status))
+                .orderBy(trackApplication.createdAt.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(trackApplication.count())
+                .from(trackApplication)
+                .where(statusEq(status))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0L : total);
     }
 
     // 같은 앨범 내 동일 trackNumber 또는 동일 title 중복 조건
@@ -102,5 +123,10 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
         BooleanExpression sameTitle = trackApplication.title.eq(title);
 
         return sameTrackNumber.or(sameTitle);
+    }
+
+    // 상태 필터 조건
+    private BooleanExpression statusEq(ApplicationStatus status) {
+        return status == null ? null : trackApplication.status.eq(status);
     }
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -77,9 +77,16 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
         return result != null;
     }
 
+    /**
+     * 내 트랙 등록 신청 목록 조회
+     */
     @Override
     public List<TrackApplication> searchMyTrackApplications(Long requesterUserId) {
-        return List.of();
+        return queryFactory
+                .selectFrom(trackApplication)
+                .where(trackApplication.requesterUserId.eq(requesterUserId))
+                .orderBy(trackApplication.createdAt.desc())
+                .fetch();
     }
 
     @Override

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.fivefy.domain.track.repository;
+
+public interface TrackApplicationQueryRepositoryImpl {
+}

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationRepository.java
@@ -3,5 +3,5 @@ package com.fivefy.domain.track.repository;
 import com.fivefy.domain.track.entity.TrackApplication;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TrackApplicationRepository extends JpaRepository<TrackApplication, Long> {
+public interface TrackApplicationRepository extends JpaRepository<TrackApplication, Long>, TrackApplicationQueryRepository {
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationRepository.java
@@ -1,0 +1,7 @@
+package com.fivefy.domain.track.repository;
+
+import com.fivefy.domain.track.entity.TrackApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrackApplicationRepository extends JpaRepository<TrackApplication, Long> {
+}

--- a/src/main/java/com/fivefy/domain/track/repository/TrackReleaseRequestRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackReleaseRequestRepository.java
@@ -1,7 +1,0 @@
-package com.fivefy.domain.track.repository;
-
-import com.fivefy.domain.track.entity.TrackReleaseRequest;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface TrackReleaseRequestRepository extends JpaRepository<TrackReleaseRequest, Long> {
-}

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -1,5 +1,7 @@
 package com.fivefy.domain.track.service;
 
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
 import com.fivefy.domain.album.enums.AlbumErrorCode;
@@ -11,6 +13,7 @@ import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
+import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -21,6 +24,8 @@ import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -157,6 +162,22 @@ public class TrackService {
         validateTrackApplicationDetailAccess(userId, user, application);
 
         return TrackApplicationDetailResponse.from(application);
+    }
+
+    /**
+     * 트랙 등록 신청 목록 조회 (관리자)
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<TrackApplicationListResponse> getTrackApplications(
+            ApplicationStatus status,
+            Pageable pageable
+    ) {
+        Page<TrackApplication> page =
+                trackApplicationRepository.searchTrackApplications(status, pageable);
+
+        return PageResponse.from(
+                page.map(TrackApplicationListResponse::from)
+        );
     }
 
     // =========================

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -10,6 +10,7 @@ import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -17,6 +18,7 @@ import com.fivefy.domain.track.enums.TrackType;
 import com.fivefy.domain.track.repository.TrackApplicationRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -143,6 +145,20 @@ public class TrackService {
                 .toList();
     }
 
+    /**
+     * 트랙 등록 신청 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public TrackApplicationDetailResponse getTrackApplication(Long userId, Long applicationId) {
+        TrackApplication application = findTrackApplication(applicationId);
+        User user = findUser(userId);
+
+        // 신청자 또는 관리자만 조회 가능
+        validateTrackApplicationDetailAccess(userId, user, application);
+
+        return TrackApplicationDetailResponse.from(application);
+    }
+
     // =========================
     // 조회
     // =========================
@@ -185,6 +201,13 @@ public class TrackService {
         }
 
         return album;
+    }
+
+    // 트랙 등록 신청 조회
+    private TrackApplication findTrackApplication(Long applicationId) {
+        return trackApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(
+                        TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND));
     }
 
     // =========================
@@ -257,6 +280,22 @@ public class TrackService {
         )) {
             throw new BusinessException(
                     TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS
+            );
+        }
+    }
+
+    // 상세 조회 권한 검증
+    private void validateTrackApplicationDetailAccess(
+            Long userId,
+            User user,
+            TrackApplication application
+    ) {
+        boolean isRequester = application.getRequesterUserId().equals(userId);
+        boolean isAdmin = user.getRole() == UserRole.ADMIN;
+
+        if (!isRequester && !isAdmin) {
+            throw new BusinessException(
+                    TrackApplicationErrorCode.ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN
             );
         }
     }

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -12,13 +12,16 @@ import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
 import com.fivefy.domain.track.repository.TrackApplicationRepository;
+import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
@@ -29,6 +32,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -42,6 +46,7 @@ public class TrackService {
     private final UserRepository userRepository;
     private final AlbumRepository albumRepository;
     private final ArtistRepository artistRepository;
+    private final TrackRepository trackRepository;
 
     /**
      * 자유 창작 트랙 등록 신청
@@ -178,6 +183,22 @@ public class TrackService {
         return PageResponse.from(
                 page.map(TrackApplicationListResponse::from)
         );
+    }
+
+    /**
+     * 트랙 등록 신청 승인 (관리자)
+     */
+    @Transactional
+    public TrackApplicationApproveResponse approveTrackApplication(Long adminId, Long applicationId) {
+        TrackApplication application = findTrackApplication(applicationId);
+
+        // 상태 전이는 엔티티에 위임
+        application.approve(adminId);
+
+        // 승인된 신청 기반 트랙 생성
+        Track savedTrack = trackRepository.save(createTrack(application));
+
+        return TrackApplicationApproveResponse.from(application, savedTrack.getId());
     }
 
     // =========================
@@ -319,5 +340,56 @@ public class TrackService {
                     TrackApplicationErrorCode.ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN
             );
         }
+    }
+
+    // =========================
+// 생성 / 후처리
+// =========================
+
+    // 승인된 신청 기반 트랙 생성
+    private Track createTrack(TrackApplication application) {
+        if (application.getTrackType() == TrackType.FREE_CREATION) {
+            return Track.createFreeCreation(
+                    application.getRequesterUserId(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec()
+            );
+        }
+
+        LocalDateTime scheduledPublishAt =
+                calculateScheduledPublishAt(application.getPublishDelayDays());
+
+        Track track = Track.createOfficialRelease(
+                application.getRequesterUserId(),
+                application.getArtistId(),
+                application.getAlbumId(),
+                application.getTrackNumber(),
+                application.getTitle(),
+                application.getLyrics(),
+                application.getGenre(),
+                application.getAudioUrl(),
+                application.getDurationSec(),
+                application.getFeaturedArtistText(),
+                scheduledPublishAt
+        );
+
+        // 즉시 공개
+        if (application.getPublishDelayDays() == 0) {
+            track.publish();
+        }
+
+        return track;
+    }
+
+    // 공개 예약 시각 계산
+    private LocalDateTime calculateScheduledPublishAt(Integer publishDelayDays) {
+        if (publishDelayDays == null || publishDelayDays == 0) {
+            return null;
+        }
+
+        return LocalDateTime.now().plusDays(publishDelayDays);
     }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -12,10 +12,7 @@ import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
-import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -199,6 +196,23 @@ public class TrackService {
         Track savedTrack = trackRepository.save(createTrack(application));
 
         return TrackApplicationApproveResponse.from(application, savedTrack.getId());
+    }
+
+    /**
+     * 트랙 등록 신청 거절 (관리자)
+     */
+    @Transactional
+    public TrackApplicationRejectResponse rejectTrackApplication(
+            Long adminId,
+            Long applicationId,
+            String rejectionReason
+    ) {
+        TrackApplication application = findTrackApplication(applicationId);
+
+        // 상태 전이는 엔티티에 위임
+        application.reject(adminId, rejectionReason);
+
+        return TrackApplicationRejectResponse.from(application);
     }
 
     // =========================

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -1,7 +1,15 @@
 package com.fivefy.domain.track.service;
 
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.entity.Album;
+import com.fivefy.domain.album.enums.AlbumErrorCode;
+import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
+import com.fivefy.domain.artist.enums.ArtistStatus;
+import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -23,6 +31,8 @@ public class TrackService {
 
     private final TrackApplicationRepository trackApplicationRepository;
     private final UserRepository userRepository;
+    private final AlbumRepository albumRepository;
+    private final ArtistRepository artistRepository;
 
     /**
      * 자유 창작 트랙 등록 신청
@@ -59,10 +69,143 @@ public class TrackService {
         return TrackApplicationResponse.from(savedApplication);
     }
 
+    /**
+     * 정식 발매 트랙 등록 신청
+     */
+    @Transactional
+    public TrackApplicationResponse createOfficialTrackApplication(
+            Long userId,
+            OfficialTrackApplicationCreateRequest request
+    ) {
+        // 신청 유저 존재 확인
+        findUser(userId);
+
+        // 아티스트 조회 및 삭제 여부 검증
+        Artist artist = findNotDeletedArtist(request.artistId());
+
+        // 소유자 검증
+        validateArtistOwner(userId, artist);
+
+        // 아티스트 상태 검증
+        validateArtistActive(artist);
+
+        // 앨범 조회 및 삭제 여부 검증
+        Album album = findNotDeletedAlbum(request.albumId());
+
+        // 앨범-아티스트 일치 검증
+        validateAlbumArtistMatch(album, request.artistId());
+
+        // 공개 예약 옵션 검증
+        validatePublishDelayDays(request.publishDelayDays());
+
+        // 정식 발매 중복 신청 검증
+        validateDuplicateOfficialReleaseApplication(
+                userId,
+                request.artistId(),
+                request.albumId(),
+                request.trackNumber(),
+                request.title()
+        );
+
+        // 등록 신청 생성 및 저장
+        TrackApplication savedApplication = trackApplicationRepository.save(
+                TrackApplication.create(
+                        userId,
+                        TrackType.OFFICIAL_RELEASE,
+                        request.artistId(),
+                        request.albumId(),
+                        request.trackNumber(),
+                        request.title(),
+                        request.lyrics(),
+                        request.genre(),
+                        request.audioUrl(),
+                        request.durationSec(),
+                        request.featuredArtistText(),
+                        request.publishDelayDays()
+                )
+        );
+
+        return TrackApplicationResponse.from(savedApplication);
+    }
+
+    // =========================
+    // 조회
+    // =========================
+
     // 유저 조회
     private User findUser(Long userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
+    }
+
+    // 아티스트 조회
+    private Artist findArtist(Long artistId) {
+        return artistRepository.findById(artistId)
+                .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND));
+    }
+
+    // 삭제되지 않은 아티스트 조회
+    private Artist findNotDeletedArtist(Long artistId) {
+        Artist artist = findArtist(artistId);
+
+        if (artist.isDeleted()) {
+            throw new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND);
+        }
+
+        return artist;
+    }
+
+    // 앨범 조회
+    private Album findAlbum(Long albumId) {
+        return albumRepository.findById(albumId)
+                .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND));
+    }
+
+    // 삭제되지 않은 앨범 조회
+    private Album findNotDeletedAlbum(Long albumId) {
+        Album album = findAlbum(albumId);
+
+        if (album.getDeletedAt() != null) {
+            throw new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND);
+        }
+
+        return album;
+    }
+
+    // =========================
+    // 검증
+    // =========================
+
+    // 아티스트 소유자 검증
+    private void validateArtistOwner(Long userId, Artist artist) {
+        if (!artist.isOwnedBy(userId)) {
+            throw new BusinessException(ArtistErrorCode.ERR_FORBIDDEN_ARTIST_ACCESS);
+        }
+    }
+
+    // 아티스트 상태 검증
+    private void validateArtistActive(Artist artist) {
+        if (artist.getStatus() != ArtistStatus.ACTIVE) {
+            throw new BusinessException(
+                    TrackApplicationErrorCode.ERR_INACTIVE_ARTIST_CANNOT_REQUEST_OFFICIAL_RELEASE
+            );
+        }
+    }
+
+    // 앨범-아티스트 일치 검증
+    private void validateAlbumArtistMatch(Album album, Long artistId) {
+        if (!album.getArtistId().equals(artistId)) {
+            throw new BusinessException(TrackApplicationErrorCode.ERR_ALBUM_ARTIST_MISMATCH);
+        }
+    }
+
+    // 공개 예약 옵션 검증
+    private void validatePublishDelayDays(Integer publishDelayDays) {
+        if (publishDelayDays == null || publishDelayDays < 0 || publishDelayDays > 7) {
+            throw new BusinessException(
+                    TrackApplicationErrorCode.ERR_INVALID_PUBLISH_DELAY_DAYS
+            );
+        }
     }
 
     // 자유 창작 중복 신청 검증
@@ -75,6 +218,27 @@ public class TrackService {
                 requesterUserId,
                 title,
                 audioUrl
+        )) {
+            throw new BusinessException(
+                    TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS
+            );
+        }
+    }
+
+    // 정식 발매 중복 신청 검증
+    private void validateDuplicateOfficialReleaseApplication(
+            Long requesterUserId,
+            Long artistId,
+            Long albumId,
+            Long trackNumber,
+            String title
+    ) {
+        if (trackApplicationRepository.existsPendingOfficialReleaseApplication(
+                requesterUserId,
+                artistId,
+                albumId,
+                trackNumber,
+                title
         )) {
             throw new BusinessException(
                     TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -22,6 +22,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 /**
  * 트랙 도메인 서비스
  */
@@ -126,6 +128,19 @@ public class TrackService {
         );
 
         return TrackApplicationResponse.from(savedApplication);
+    }
+
+    /**
+     * 내 트랙 등록 신청 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<TrackApplicationResponse> getMyTrackApplications(Long userId) {
+        findUser(userId);
+
+        return trackApplicationRepository.searchMyTrackApplications(userId)
+                .stream()
+                .map(TrackApplicationResponse::from)
+                .toList();
     }
 
     // =========================

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -1,0 +1,84 @@
+package com.fivefy.domain.track.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
+import com.fivefy.domain.track.enums.TrackType;
+import com.fivefy.domain.track.repository.TrackApplicationRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 트랙 도메인 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class TrackService {
+
+    private final TrackApplicationRepository trackApplicationRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 자유 창작 트랙 등록 신청
+     */
+    @Transactional
+    public TrackApplicationResponse createFreeTrackApplication(
+            Long userId,
+            FreeTrackApplicationCreateRequest request
+    ) {
+        // 신청 유저 존재 확인
+        findUser(userId);
+
+        // 자유 창작 PENDING 중복 신청 검증
+        validateDuplicateFreeCreationApplication(userId, request.title(), request.audioUrl());
+
+        // 등록 신청 생성 및 저장
+        TrackApplication savedApplication = trackApplicationRepository.save(
+                TrackApplication.create(
+                        userId,
+                        TrackType.FREE_CREATION,
+                        null,
+                        null,
+                        null,
+                        request.title(),
+                        request.lyrics(),
+                        request.genre(),
+                        request.audioUrl(),
+                        request.durationSec(),
+                        null,
+                        null
+                )
+        );
+
+        return TrackApplicationResponse.from(savedApplication);
+    }
+
+    // 유저 조회
+    private User findUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
+    }
+
+    // 자유 창작 중복 신청 검증
+    private void validateDuplicateFreeCreationApplication(
+            Long requesterUserId,
+            String title,
+            String audioUrl
+    ) {
+        if (trackApplicationRepository.existsPendingFreeCreationApplication(
+                requesterUserId,
+                title,
+                audioUrl
+        )) {
+            throw new BusinessException(
+                    TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS
+            );
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -11,6 +11,7 @@ import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -19,6 +20,7 @@ import com.fivefy.domain.track.repository.TrackApplicationRepository;
 import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -759,6 +761,164 @@ class TrackServiceTest {
 
                 assertThat(result).isEmpty();
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 등록 신청 상세 조회")
+    class GetTrackApplication {
+
+        @Test
+        @DisplayName("신청자 본인이면 상세 조회 성공")
+        void getTrackApplication_success_whenRequester() {
+            Long userId = 1L;
+            Long applicationId = 100L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            TrackApplication application = TrackApplication.create(
+                    userId,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "밤편지 AI 버전",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+            ReflectionTestUtils.setField(
+                    application,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 19, 21, 0, 0)
+            );
+            ReflectionTestUtils.setField(
+                    application,
+                    "updatedAt",
+                    LocalDateTime.of(2026, 4, 19, 21, 0, 0)
+            );
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            TrackApplicationDetailResponse response =
+                    trackService.getTrackApplication(userId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.requesterUserId()).isEqualTo(userId);
+            assertThat(response.trackType()).isEqualTo(TrackType.FREE_CREATION);
+            assertThat(response.artistId()).isNull();
+            assertThat(response.albumId()).isNull();
+            assertThat(response.trackNumber()).isNull();
+            assertThat(response.title()).isEqualTo("밤편지 AI 버전");
+            assertThat(response.genre()).isEqualTo("BALLAD");
+            assertThat(response.audioUrl()).isEqualTo("https://example.com/audio.mp3");
+            assertThat(response.durationSec()).isEqualTo(210L);
+            assertThat(response.publishDelayDays()).isNull();
+            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("관리자면 상세 조회 성공")
+        void getTrackApplication_success_whenAdmin() {
+            Long userId = 99L;
+            Long applicationId = 100L;
+            Long requesterUserId = 1L;
+
+            User admin = mock(User.class);
+            when(admin.getRole()).thenReturn(UserRole.ADMIN);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(admin));
+
+            TrackApplication application = TrackApplication.create(
+                    requesterUserId,
+                    TrackType.OFFICIAL_RELEASE,
+                    10L,
+                    100L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+            ReflectionTestUtils.setField(
+                    application,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 19, 21, 0, 0)
+            );
+            ReflectionTestUtils.setField(
+                    application,
+                    "updatedAt",
+                    LocalDateTime.of(2026, 4, 19, 21, 0, 0)
+            );
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            TrackApplicationDetailResponse response =
+                    trackService.getTrackApplication(userId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.requesterUserId()).isEqualTo(requesterUserId);
+            assertThat(response.trackType()).isEqualTo(TrackType.OFFICIAL_RELEASE);
+            assertThat(response.artistId()).isEqualTo(10L);
+            assertThat(response.albumId()).isEqualTo(100L);
+            assertThat(response.trackNumber()).isEqualTo(1L);
+            assertThat(response.title()).isEqualTo("밤편지");
+            assertThat(response.featuredArtistText()).isEqualTo("feat. 10cm");
+            assertThat(response.publishDelayDays()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("본인도 관리자도 아니면 상세 조회 실패")
+        void getTrackApplication_fail_whenForbidden() {
+            Long userId = 2L;
+            Long applicationId = 100L;
+
+            User user = mock(User.class);
+            when(user.getRole()).thenReturn(UserRole.USER);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            TrackApplication application = TrackApplication.create(
+                    1L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "밤편지 AI 버전",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            assertThatThrownBy(() -> trackService.getTrackApplication(userId, applicationId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청이면 상세 조회 실패")
+        void getTrackApplication_fail_whenNotFound() {
+            Long userId = 1L;
+            Long applicationId = 100L;
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.getTrackApplication(userId, applicationId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage());
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -30,6 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -687,6 +688,77 @@ class TrackServiceTest {
             assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS.getMessage());
+        }
+
+        @Nested
+        @DisplayName("내 트랙 등록 신청 목록 조회")
+        class GetMyTrackApplications {
+
+            @Test
+            @DisplayName("내 트랙 등록 신청 목록 조회 성공")
+            void getMyTrackApplications_success() {
+                Long userId = 1L;
+
+                User user = mock(User.class);
+                when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                        .thenReturn(Optional.of(user));
+
+                TrackApplication application1 = mock(TrackApplication.class);
+                TrackApplication application2 = mock(TrackApplication.class);
+
+                when(trackApplicationRepository.searchMyTrackApplications(userId))
+                        .thenReturn(List.of(application1, application2));
+
+                when(application1.getId()).thenReturn(1L);
+                when(application2.getId()).thenReturn(2L);
+
+                when(application1.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+                when(application2.getTrackType()).thenReturn(TrackType.OFFICIAL_RELEASE);
+
+                when(application1.getStatus()).thenReturn(ApplicationStatus.PENDING);
+                when(application2.getStatus()).thenReturn(ApplicationStatus.PENDING);
+
+                when(application1.getCreatedAt()).thenReturn(LocalDateTime.now());
+                when(application2.getCreatedAt()).thenReturn(LocalDateTime.now());
+
+                List<TrackApplicationResponse> result =
+                        trackService.getMyTrackApplications(userId);
+
+                assertThat(result).hasSize(2);
+                assertThat(result.get(0).applicationId()).isEqualTo(1L);
+                assertThat(result.get(1).applicationId()).isEqualTo(2L);
+            }
+
+            @Test
+            @DisplayName("존재하지 않는 유저면 목록 조회 실패")
+            void getMyTrackApplications_fail_whenUserNotFound() {
+                Long userId = 1L;
+
+                when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                        .thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> trackService.getMyTrackApplications(userId))
+                        .isInstanceOf(BusinessException.class)
+                        .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+            }
+
+            @Test
+            @DisplayName("등록 신청이 없으면 빈 리스트 반환")
+            void getMyTrackApplications_empty() {
+                Long userId = 1L;
+
+                User user = mock(User.class);
+                when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                        .thenReturn(Optional.of(user));
+
+                when(trackApplicationRepository.searchMyTrackApplications(userId))
+                        .thenReturn(List.of());
+
+                List<TrackApplicationResponse> result =
+                        trackService.getMyTrackApplications(userId);
+
+                assertThat(result).isEmpty();
+            }
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -1,12 +1,22 @@
 package com.fivefy.domain.track.service;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.entity.Album;
+import com.fivefy.domain.album.enums.AlbumErrorCode;
+import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
+import com.fivefy.domain.artist.enums.ArtistType;
+import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
 import com.fivefy.domain.track.repository.TrackApplicationRepository;
+import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.repository.UserRepository;
@@ -41,6 +51,12 @@ class TrackServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    @Mock
+    private AlbumRepository albumRepository;
 
     @InjectMocks
     private TrackService trackService;
@@ -153,6 +169,522 @@ class TrackServiceTest {
             )).thenReturn(true);
 
             assertThatThrownBy(() -> trackService.createFreeTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("정식 발매 트랙 등록 신청 생성")
+    class CreateOfficialTrackApplication {
+
+        @Test
+        @DisplayName("정식 발매 트랙 등록 신청 성공")
+        void createOfficialTrackApplication_success() {
+            Long userId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            albumId,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+            when(trackApplicationRepository.existsPendingOfficialReleaseApplication(
+                    userId,
+                    artistId,
+                    albumId,
+                    request.trackNumber(),
+                    request.title()
+            )).thenReturn(false);
+
+            TrackApplication savedApplication = TrackApplication.create(
+                    userId,
+                    TrackType.OFFICIAL_RELEASE,
+                    artistId,
+                    albumId,
+                    request.trackNumber(),
+                    request.title(),
+                    request.lyrics(),
+                    request.genre(),
+                    request.audioUrl(),
+                    request.durationSec(),
+                    request.featuredArtistText(),
+                    request.publishDelayDays()
+            );
+            ReflectionTestUtils.setField(savedApplication, "id", 2L);
+            ReflectionTestUtils.setField(
+                    savedApplication,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 19, 21, 0, 0)
+            );
+
+            when(trackApplicationRepository.save(any(TrackApplication.class)))
+                    .thenReturn(savedApplication);
+
+            TrackApplicationResponse response =
+                    trackService.createOfficialTrackApplication(userId, request);
+
+            assertThat(response.applicationId()).isEqualTo(2L);
+            assertThat(response.trackType()).isEqualTo(TrackType.OFFICIAL_RELEASE);
+            assertThat(response.artistId()).isEqualTo(artistId);
+            assertThat(response.albumId()).isEqualTo(albumId);
+            assertThat(response.title()).isEqualTo("밤편지");
+            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
+            assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 19, 21, 0, 0));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenUserNotFound() {
+            Long userId = 1L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            10L,
+                            100L,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 아티스트면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenArtistNotFound() {
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            100L,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제된 아티스트면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenArtistDeleted() {
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            100L,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+            ReflectionTestUtils.setField(artist, "deletedAt", LocalDateTime.of(2026, 4, 19, 20, 0, 0));
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("아티스트 소유자가 아니면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenForbiddenArtistAccess() {
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            100L,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    2L,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistErrorCode.ERR_FORBIDDEN_ARTIST_ACCESS.getMessage());
+        }
+
+        @Test
+        @DisplayName("비활성화된 아티스트면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenArtistInactive() {
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            100L,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+            artist.deactivate();
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_INACTIVE_ARTIST_CANNOT_REQUEST_OFFICIAL_RELEASE.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 앨범이면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenAlbumNotFound() {
+            Long userId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            albumId,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumErrorCode.ERR_ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제된 앨범이면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenAlbumDeleted() {
+            Long userId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            albumId,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+            ReflectionTestUtils.setField(album, "deletedAt", LocalDateTime.of(2026, 4, 19, 20, 0, 0));
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumErrorCode.ERR_ALBUM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("앨범과 아티스트 정보가 일치하지 않으면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenAlbumArtistMismatch() {
+            Long userId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            albumId,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            Album album = Album.create(
+                    999L,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_ALBUM_ARTIST_MISMATCH.getMessage());
+        }
+
+        @Test
+        @DisplayName("공개 예약 옵션이 범위를 벗어나면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenInvalidPublishDelayDays() {
+            Long userId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            albumId,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            8
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_INVALID_PUBLISH_DELAY_DAYS.getMessage());
+        }
+
+        @Test
+        @DisplayName("동일한 진행 중 신청이 이미 있으면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenAlreadyExists() {
+            Long userId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            albumId,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+            when(trackApplicationRepository.existsPendingOfficialReleaseApplication(
+                    userId,
+                    artistId,
+                    albumId,
+                    request.trackNumber(),
+                    request.title()
+            )).thenReturn(true);
+
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS.getMessage());
         }

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -12,10 +12,7 @@ import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
-import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -1246,6 +1243,93 @@ class TrackServiceTest {
             assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 등록 신청 거절")
+    class RejectTrackApplication {
+
+        @Test
+        @DisplayName("거절 성공")
+        void rejectTrackApplication_success() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+            String rejectionReason = "트랙 정보가 부족합니다";
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            TrackApplicationRejectResponse response =
+                    trackService.rejectTrackApplication(adminId, applicationId, rejectionReason);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.REJECTED);
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
+            assertThat(response.rejectionReason()).isEqualTo(rejectionReason);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청이면 거절 실패")
+        void rejectTrackApplication_fail_whenNotFound() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    trackService.rejectTrackApplication(adminId, applicationId, "사유")
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 처리된 신청이면 거절 실패")
+        void rejectTrackApplication_fail_whenAlreadyProcessed() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    0
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+            application.approve(adminId);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            assertThatThrownBy(() ->
+                    trackService.rejectTrackApplication(adminId, applicationId, "사유")
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED.getMessage());
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -1,0 +1,160 @@
+package com.fivefy.domain.track.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
+import com.fivefy.domain.track.enums.TrackType;
+import com.fivefy.domain.track.repository.TrackApplicationRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * TrackService의 비즈니스 로직을 검증하는 단위 테스트
+ *
+ * 자유 창작 트랙 등록 신청 생성 기능을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class TrackServiceTest {
+
+    @Mock
+    private TrackApplicationRepository trackApplicationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TrackService trackService;
+
+    @Nested
+    @DisplayName("자유 창작 트랙 등록 신청 생성")
+    class CreateFreeTrackApplication {
+
+        @Test
+        @DisplayName("자유 창작 트랙 등록 신청 성공")
+        void createFreeTrackApplication_success() {
+            Long userId = 1L;
+
+            FreeTrackApplicationCreateRequest request =
+                    new FreeTrackApplicationCreateRequest(
+                            "밤편지 AI 버전",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            210L
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            when(trackApplicationRepository.existsPendingFreeCreationApplication(
+                    userId,
+                    request.title(),
+                    request.audioUrl()
+            )).thenReturn(false);
+
+            TrackApplication savedApplication = TrackApplication.create(
+                    userId,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    request.title(),
+                    request.lyrics(),
+                    request.genre(),
+                    request.audioUrl(),
+                    request.durationSec(),
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(savedApplication, "id", 1L);
+            ReflectionTestUtils.setField(
+                    savedApplication,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 19, 20, 0, 0)
+            );
+
+            when(trackApplicationRepository.save(any(TrackApplication.class)))
+                    .thenReturn(savedApplication);
+
+            TrackApplicationResponse response =
+                    trackService.createFreeTrackApplication(userId, request);
+
+            assertThat(response.applicationId()).isEqualTo(1L);
+            assertThat(response.trackType()).isEqualTo(TrackType.FREE_CREATION);
+            assertThat(response.artistId()).isNull();
+            assertThat(response.albumId()).isNull();
+            assertThat(response.title()).isEqualTo("밤편지 AI 버전");
+            assertThat(response.status()).isEqualTo(savedApplication.getStatus());
+            assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 19, 20, 0, 0));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 자유 창작 트랙 등록 신청 생성 실패")
+        void createFreeTrackApplication_fail_whenUserNotFound() {
+            Long userId = 1L;
+
+            FreeTrackApplicationCreateRequest request =
+                    new FreeTrackApplicationCreateRequest(
+                            "밤편지 AI 버전",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            210L
+                    );
+
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.createFreeTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("동일한 진행 중 신청이 이미 있으면 자유 창작 트랙 등록 신청 생성 실패")
+        void createFreeTrackApplication_fail_whenAlreadyExists() {
+            Long userId = 1L;
+
+            FreeTrackApplicationCreateRequest request =
+                    new FreeTrackApplicationCreateRequest(
+                            "밤편지 AI 버전",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            210L
+                    );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            when(trackApplicationRepository.existsPendingFreeCreationApplication(
+                    userId,
+                    request.title(),
+                    request.audioUrl()
+            )).thenReturn(true);
+
+            assertThatThrownBy(() -> trackService.createFreeTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -12,9 +12,11 @@ import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
@@ -66,6 +68,9 @@ class TrackServiceTest {
 
     @Mock
     private AlbumRepository albumRepository;
+
+    @Mock
+    private TrackRepository trackRepository;
 
     @InjectMocks
     private TrackService trackService;
@@ -1047,6 +1052,200 @@ class TrackServiceTest {
             assertThat(response.content()).isEmpty();
             assertThat(response.totalElements()).isZero();
             assertThat(response.totalPages()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 등록 신청 승인")
+    class ApproveTrackApplication {
+
+        @Test
+        @DisplayName("즉시 공개 신청이면 승인과 함께 트랙 생성 및 공개 성공")
+        void approveTrackApplication_success_whenImmediatePublish() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    0
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            Track savedTrack = Track.createOfficialRelease(
+                    application.getRequesterUserId(),
+                    application.getArtistId(),
+                    application.getAlbumId(),
+                    application.getTrackNumber(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec(),
+                    application.getFeaturedArtistText(),
+                    null
+            );
+            savedTrack.publish();
+            ReflectionTestUtils.setField(savedTrack, "id", 1000L);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
+
+            TrackApplicationApproveResponse response =
+                    trackService.approveTrackApplication(adminId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.trackId()).isEqualTo(1000L);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("예약 공개 신청이면 승인과 함께 트랙 생성 성공")
+        void approveTrackApplication_success_whenScheduledPublish() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            Track savedTrack = Track.createOfficialRelease(
+                    application.getRequesterUserId(),
+                    application.getArtistId(),
+                    application.getAlbumId(),
+                    application.getTrackNumber(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec(),
+                    application.getFeaturedArtistText(),
+                    LocalDateTime.now().plusDays(3)
+            );
+            ReflectionTestUtils.setField(savedTrack, "id", 1000L);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
+
+            TrackApplicationApproveResponse response =
+                    trackService.approveTrackApplication(adminId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.trackId()).isEqualTo(1000L);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청이면 승인 실패")
+        void approveTrackApplication_fail_whenNotFound() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.approveTrackApplication(adminId, applicationId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 처리된 신청이면 승인 실패")
+        void approveTrackApplication_fail_whenAlreadyProcessed() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    0
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+            application.approve(adminId);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            assertThatThrownBy(() -> trackService.approveTrackApplication(adminId, applicationId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED.getMessage());
+        }
+
+        @Test
+        @DisplayName("자유 창작 신청이면 승인과 함께 트랙 생성 및 공개 성공")
+        void approveTrackApplication_success_whenFreeCreation() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "밤편지 AI 버전",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            Track savedTrack = Track.createFreeCreation(
+                    application.getRequesterUserId(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec()
+            );
+            ReflectionTestUtils.setField(savedTrack, "id", 1000L);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
+
+            TrackApplicationApproveResponse response =
+                    trackService.approveTrackApplication(adminId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.trackId()).isEqualTo(1000L);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.track.service;
 
+import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
@@ -12,6 +13,7 @@ import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
+import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -29,6 +31,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -723,12 +729,12 @@ class TrackServiceTest {
                 when(application1.getCreatedAt()).thenReturn(LocalDateTime.now());
                 when(application2.getCreatedAt()).thenReturn(LocalDateTime.now());
 
-                List<TrackApplicationResponse> result =
+                List<TrackApplicationResponse> response =
                         trackService.getMyTrackApplications(userId);
 
-                assertThat(result).hasSize(2);
-                assertThat(result.get(0).applicationId()).isEqualTo(1L);
-                assertThat(result.get(1).applicationId()).isEqualTo(2L);
+                assertThat(response).hasSize(2);
+                assertThat(response.get(0).applicationId()).isEqualTo(1L);
+                assertThat(response.get(1).applicationId()).isEqualTo(2L);
             }
 
             @Test
@@ -756,10 +762,10 @@ class TrackServiceTest {
                 when(trackApplicationRepository.searchMyTrackApplications(userId))
                         .thenReturn(List.of());
 
-                List<TrackApplicationResponse> result =
+                List<TrackApplicationResponse> response =
                         trackService.getMyTrackApplications(userId);
 
-                assertThat(result).isEmpty();
+                assertThat(response).isEmpty();
             }
         }
     }
@@ -919,6 +925,128 @@ class TrackServiceTest {
             assertThatThrownBy(() -> trackService.getTrackApplication(userId, applicationId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 등록 신청 목록 조회")
+    class GetTrackApplications {
+
+        @Test
+        @DisplayName("상태 조건 없이 오래된순 목록 조회 성공")
+        void getTrackApplications_success_withoutStatus() {
+            Pageable pageable = PageRequest.of(0, 10);
+
+            TrackApplication application1 = TrackApplication.create(
+                    1L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "첫 번째 신청",
+                    "가사1",
+                    "BALLAD",
+                    "https://example.com/audio1.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application1, "id", 1L);
+            ReflectionTestUtils.setField(
+                    application1,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 14, 15, 0, 0)
+            );
+
+            TrackApplication application2 = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    10L,
+                    100L,
+                    1L,
+                    "두 번째 신청",
+                    "가사2",
+                    "BALLAD",
+                    "https://example.com/audio2.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+            ReflectionTestUtils.setField(application2, "id", 2L);
+            ReflectionTestUtils.setField(
+                    application2,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 15, 15, 0, 0)
+            );
+
+            when(trackApplicationRepository.searchTrackApplications(null, pageable))
+                    .thenReturn(new PageImpl<>(List.of(application1, application2), pageable, 2));
+
+            PageResponse<TrackApplicationListResponse> response =
+                    trackService.getTrackApplications(null, pageable);
+
+            assertThat(response.content()).hasSize(2);
+            assertThat(response.content().get(0).applicationId()).isEqualTo(1L);
+            assertThat(response.content().get(0).requesterUserId()).isEqualTo(1L);
+            assertThat(response.content().get(0).title()).isEqualTo("첫 번째 신청");
+            assertThat(response.content().get(1).applicationId()).isEqualTo(2L);
+            assertThat(response.page()).isEqualTo(0);
+            assertThat(response.size()).isEqualTo(10);
+            assertThat(response.totalElements()).isEqualTo(2);
+            assertThat(response.totalPages()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("상태 조건으로 목록 조회 성공")
+        void getTrackApplications_success_withStatus() {
+            Pageable pageable = PageRequest.of(0, 10);
+
+            TrackApplication application = TrackApplication.create(
+                    1L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "승인 대기 신청",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application, "id", 1L);
+            ReflectionTestUtils.setField(
+                    application,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 14, 15, 0, 0)
+            );
+
+            when(trackApplicationRepository.searchTrackApplications(ApplicationStatus.PENDING, pageable))
+                    .thenReturn(new PageImpl<>(List.of(application), pageable, 1));
+
+            PageResponse<TrackApplicationListResponse> response =
+                    trackService.getTrackApplications(ApplicationStatus.PENDING, pageable);
+
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).status()).isEqualTo(ApplicationStatus.PENDING);
+            assertThat(response.totalElements()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("조회 결과가 없으면 빈 페이지 조회 성공")
+        void getTrackApplications_success_whenEmpty() {
+            Pageable pageable = PageRequest.of(0, 10);
+
+            when(trackApplicationRepository.searchTrackApplications(ApplicationStatus.REJECTED, pageable))
+                    .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+            PageResponse<TrackApplicationListResponse> response =
+                    trackService.getTrackApplications(ApplicationStatus.REJECTED, pageable);
+
+            assertThat(response.content()).isEmpty();
+            assertThat(response.totalElements()).isZero();
+            assertThat(response.totalPages()).isZero();
         }
     }
 }


### PR DESCRIPTION
## 개요

> 트랙 등록 요청 구조를 Application 도메인으로 전환하고  
> 자유 창작 / 정식 발매 트랙 등록 신청 API + 조회 흐름 + 검증 정책을 구현

---

## 변경 사항

### 1. Track → Application 도메인 전환 (핵심 구조 변경)

- TrackReleaseRequest → TrackApplication으로 리팩토링
- 테이블명 `track_release_requests` → `track_applications`
- 인덱스명 Application 기준으로 통일
- ErrorCode 구조 전면 변경 (`TrackApplicationErrorCode`)
- publish 정책 변경
  - scheduledPublishAt 제거
  - publishDelayDays 도입

→ “요청” 개념을 명확한 Application 도메인으로 정착

---

### 2. Track 엔티티 생성 정책 정리

#### 자유 창작
- 즉시 PUBLISHED 상태
- publishedAt = now()
- scheduledPublishAt 제거

#### 정식 발매
- trackNumber / durationSec 검증 로직 분리
- validate 메서드 내부 캡슐화

→ 엔티티는 상태 생성 + 내부 검증만 담당하도록 정리

---

### 3. TrackApplication 생성 정책 정의

- ApplicationStatus = PENDING 기본 설정
- durationSec / publishDelayDays 엔티티 내부 검증
- publishDelayDays 범위 (0 ~ 7) 제한

→ Application은 “사용자 입력 상태 보관” 역할에 집중

---

### 4. Querydsl 조회 구조 분리

- TrackApplicationQueryRepository 도입
- 중복 신청 검증을 Querydsl로 분리

#### 자유 창작 중복 조건
- requesterUserId
- PENDING
- artistId / albumId / trackNumber = null
- title + audioUrl

#### 정식 발매 중복 조건
- requesterUserId
- PENDING
- trackType = OFFICIAL_RELEASE
- artistId + albumId
- (trackNumber OR title)

→ 도메인 정책 기반 중복 검증 분리

---

### 5. 트랙 등록 신청 API 구현

#### 5-1. 자유 창작

**POST /api/track-applications/free-creations**

흐름:
- 유저 존재 검증
- PENDING 중복 신청 검증
- TrackApplication 생성
- 저장 후 Response 반환

---

#### 5-2. 정식 발매

**POST /api/track-applications/official-releases**

흐름:
- 유저 존재 검증
- 아티스트 검증
  - 존재 / 삭제 / 소유자 / ACTIVE 상태
- 앨범 검증
  - 존재 / 삭제 / 아티스트 일치
- publishDelayDays 검증
- PENDING 중복 신청 검증
- TrackApplication 생성 및 저장

---

### 6. 트랙 등록 신청 조회 API

#### 내 신청 목록 조회

**GET /api/track-applications/me**

- 유저 검증
- Querydsl 기반 조회
- createdAt DESC 정렬

---

#### 상세 조회

**GET /api/track-applications/{applicationId}**

- 신청 존재 검증
- 유저 조회
- 권한 검증
  - 신청자 or ADMIN
- 상세 DTO 매핑

---

### 7. Controller 구조

- Base path: `/api`
- ResponseEntity + BaseResponse 구조 통일
- 상태 코드
  - 생성: 201
  - 조회: 200
- @AuthenticationPrincipal 기반 인증 처리

---

### 8. 예외 코드 추가

- ERR_TRACK_APPLICATION_ALREADY_EXISTS (409)
- ERR_INVALID_PUBLISH_DELAY_DAYS
- ERR_INACTIVE_ARTIST_CANNOT_REQUEST_OFFICIAL_RELEASE
- ERR_ALBUM_ARTIST_MISMATCH
- ERR_TRACK_APPLICATION_NOT_FOUND
- ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN

---

### 9. ServiceTest 추가

- 자유 창작 / 정식 발매 전체 흐름 검증
- 모든 예외 케이스 포함
  - 유저 없음
  - 아티스트 / 앨범 검증
  - 권한 / 상태
  - 중복 신청
- 상세 조회 권한 분기 테스트 포함

→ 실제 서비스 로직 기준 검증 완료

---

## 변경 유형

- [x] 기능 추가 (feat)
- [x] 리팩토링 (refactor)
- [x] 테스트 (test)

---

## 테스트 방법

```text
1. 자유 창작 신청 → 중복 신청 시 409 확인
2. 정식 발매 신청 → 아티스트/앨범 검증 흐름 확인
3. publishDelayDays 범위 초과 시 400 확인
4. 내 신청 목록 조회 정상 반환 확인
5. 상세 조회
   - 본인 / ADMIN 접근 성공
   - 타 유저 접근 시 403
   - 존재하지 않으면 404
6. ServiceTest 전체 실행
```

## 체크리스트
- [x] 코드 자체 리뷰 완료  
- [x] 테스트 코드 작성 / 확인  
- [ ] 관련 문서 업데이트