### PR TITLE
feat: 트랙 등록 신청 관리자 조회 및 승인/거절 API 추가

### DIFF
--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -5,6 +5,7 @@ import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
@@ -111,6 +112,22 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 목록 조회 성공", response)
+        );
+    }
+
+    /**
+     * 트랙 등록 신청 승인 API (관리자)
+     */
+    @PostMapping("/admin/track-applications/{applicationId}/approve")
+    public ResponseEntity<BaseResponse<TrackApplicationApproveResponse>> approveTrackApplication(
+            @AuthenticationPrincipal Long adminId,
+            @PathVariable Long applicationId
+    ) {
+        TrackApplicationApproveResponse response =
+                trackService.approveTrackApplication(adminId, applicationId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 승인 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -5,10 +5,7 @@ import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
-import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.service.TrackService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -128,6 +125,23 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 승인 성공", response)
+        );
+    }
+
+    /**
+     * 트랙 등록 신청 거절 API (관리자)
+     */
+    @PostMapping("/admin/track-applications/{applicationId}/reject")
+    public ResponseEntity<BaseResponse<TrackApplicationRejectResponse>> rejectTrackApplication(
+            @AuthenticationPrincipal Long adminId,
+            @PathVariable Long applicationId,
+            @Valid @RequestBody String rejectionReason
+    ) {
+        TrackApplicationRejectResponse response =
+                trackService.rejectTrackApplication(adminId, applicationId, rejectionReason);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 거절 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -1,13 +1,19 @@
 package com.fivefy.domain.track.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
+import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.service.TrackService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -85,6 +91,26 @@ public class TrackApplicationController {
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 상세 조회 성공", response)
+        );
+    }
+
+    /**
+     * 트랙 등록 신청 목록 조회 API (관리자)
+     */
+    @GetMapping("/admin/track-applications")
+    public ResponseEntity<BaseResponse<PageResponse<TrackApplicationListResponse>>> getTrackApplications(
+            @RequestParam(required = false) ApplicationStatus status,
+            @PageableDefault(
+                    size = 10,
+                    sort = "createdAt",
+                    direction = Sort.Direction.ASC
+            ) Pageable pageable
+    ) {
+        PageResponse<TrackApplicationListResponse> response =
+                trackService.getTrackApplications(status, pageable);
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 목록 조회 성공", response)
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/dto/request/TrackApplicationRejectRequest.java
+++ b/src/main/java/com/fivefy/domain/track/dto/request/TrackApplicationRejectRequest.java
@@ -1,0 +1,14 @@
+package com.fivefy.domain.track.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 트랙 등록 신청 거절 요청 DTO
+ */
+public record TrackApplicationRejectRequest(
+        @NotBlank(message = "거절 사유는 필수입니다")
+        @Size(max = 255, message = "거절 사유는 255자 이하여야 합니다")
+        String rejectionReason
+) {
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationApproveResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationApproveResponse.java
@@ -1,0 +1,29 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.domain.track.entity.TrackApplication;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 승인 응답 DTO
+ */
+public record TrackApplicationApproveResponse(
+        Long applicationId,
+        Long trackId,
+        String status,
+        Long reviewedByAdminId,
+        LocalDateTime reviewedAt
+) {
+    public static TrackApplicationApproveResponse from(
+            TrackApplication application,
+            Long trackId
+    ) {
+        return new TrackApplicationApproveResponse(
+                application.getId(),
+                trackId,
+                application.getStatus().name(),
+                application.getReviewedByAdminId(),
+                application.getReviewedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationListResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationListResponse.java
@@ -1,0 +1,30 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.enums.TrackType;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 목록 응답 DTO
+ */
+public record TrackApplicationListResponse(
+        Long applicationId,
+        Long requesterUserId,
+        TrackType trackType,
+        String title,
+        ApplicationStatus status,
+        LocalDateTime createdAt
+) {
+    public static TrackApplicationListResponse from(TrackApplication application) {
+        return new TrackApplicationListResponse(
+                application.getId(),
+                application.getRequesterUserId(),
+                application.getTrackType(),
+                application.getTitle(),
+                application.getStatus(),
+                application.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationRejectResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationRejectResponse.java
@@ -1,0 +1,27 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.domain.track.entity.TrackApplication;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 등록 신청 거절 응답 DTO
+ */
+public record TrackApplicationRejectResponse(
+        Long applicationId,
+        ApplicationStatus status,
+        Long reviewedByAdminId,
+        LocalDateTime reviewedAt,
+        String rejectionReason
+) {
+    public static TrackApplicationRejectResponse from(TrackApplication application) {
+        return new TrackApplicationRejectResponse(
+                application.getId(),
+                application.getStatus(),
+                application.getReviewedByAdminId(),
+                application.getReviewedAt(),
+                application.getRejectionReason()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -88,9 +89,29 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
                 .fetch();
     }
 
+    /**
+     * 트랙 등록 신청 목록 조회
+     */
     @Override
-    public Page<TrackApplication> searchTrackApplications(ApplicationStatus status, Pageable pageable) {
-        return null;
+    public Page<TrackApplication> searchTrackApplications(
+            ApplicationStatus status,
+            Pageable pageable
+    ) {
+        List<TrackApplication> content = queryFactory
+                .selectFrom(trackApplication)
+                .where(statusEq(status))
+                .orderBy(trackApplication.createdAt.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(trackApplication.count())
+                .from(trackApplication)
+                .where(statusEq(status))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0L : total);
     }
 
     // 같은 앨범 내 동일 trackNumber 또는 동일 title 중복 조건
@@ -102,5 +123,10 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
         BooleanExpression sameTitle = trackApplication.title.eq(title);
 
         return sameTrackNumber.or(sameTitle);
+    }
+
+    // 상태 필터 조건
+    private BooleanExpression statusEq(ApplicationStatus status) {
+        return status == null ? null : trackApplication.status.eq(status);
     }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -1,5 +1,7 @@
 package com.fivefy.domain.track.service;
 
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
 import com.fivefy.domain.album.enums.AlbumErrorCode;
@@ -11,6 +13,7 @@ import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
+import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -21,6 +24,8 @@ import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -157,6 +162,22 @@ public class TrackService {
         validateTrackApplicationDetailAccess(userId, user, application);
 
         return TrackApplicationDetailResponse.from(application);
+    }
+
+    /**
+     * 트랙 등록 신청 목록 조회 (관리자)
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<TrackApplicationListResponse> getTrackApplications(
+            ApplicationStatus status,
+            Pageable pageable
+    ) {
+        Page<TrackApplication> page =
+                trackApplicationRepository.searchTrackApplications(status, pageable);
+
+        return PageResponse.from(
+                page.map(TrackApplicationListResponse::from)
+        );
     }
 
     // =========================

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -12,13 +12,16 @@ import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
 import com.fivefy.domain.track.repository.TrackApplicationRepository;
+import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
@@ -29,6 +32,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -42,6 +46,7 @@ public class TrackService {
     private final UserRepository userRepository;
     private final AlbumRepository albumRepository;
     private final ArtistRepository artistRepository;
+    private final TrackRepository trackRepository;
 
     /**
      * 자유 창작 트랙 등록 신청
@@ -178,6 +183,22 @@ public class TrackService {
         return PageResponse.from(
                 page.map(TrackApplicationListResponse::from)
         );
+    }
+
+    /**
+     * 트랙 등록 신청 승인 (관리자)
+     */
+    @Transactional
+    public TrackApplicationApproveResponse approveTrackApplication(Long adminId, Long applicationId) {
+        TrackApplication application = findTrackApplication(applicationId);
+
+        // 상태 전이는 엔티티에 위임
+        application.approve(adminId);
+
+        // 승인된 신청 기반 트랙 생성
+        Track savedTrack = trackRepository.save(createTrack(application));
+
+        return TrackApplicationApproveResponse.from(application, savedTrack.getId());
     }
 
     // =========================
@@ -319,5 +340,56 @@ public class TrackService {
                     TrackApplicationErrorCode.ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN
             );
         }
+    }
+
+    // =========================
+// 생성 / 후처리
+// =========================
+
+    // 승인된 신청 기반 트랙 생성
+    private Track createTrack(TrackApplication application) {
+        if (application.getTrackType() == TrackType.FREE_CREATION) {
+            return Track.createFreeCreation(
+                    application.getRequesterUserId(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec()
+            );
+        }
+
+        LocalDateTime scheduledPublishAt =
+                calculateScheduledPublishAt(application.getPublishDelayDays());
+
+        Track track = Track.createOfficialRelease(
+                application.getRequesterUserId(),
+                application.getArtistId(),
+                application.getAlbumId(),
+                application.getTrackNumber(),
+                application.getTitle(),
+                application.getLyrics(),
+                application.getGenre(),
+                application.getAudioUrl(),
+                application.getDurationSec(),
+                application.getFeaturedArtistText(),
+                scheduledPublishAt
+        );
+
+        // 즉시 공개
+        if (application.getPublishDelayDays() == 0) {
+            track.publish();
+        }
+
+        return track;
+    }
+
+    // 공개 예약 시각 계산
+    private LocalDateTime calculateScheduledPublishAt(Integer publishDelayDays) {
+        if (publishDelayDays == null || publishDelayDays == 0) {
+            return null;
+        }
+
+        return LocalDateTime.now().plusDays(publishDelayDays);
     }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -12,10 +12,7 @@ import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
-import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -199,6 +196,23 @@ public class TrackService {
         Track savedTrack = trackRepository.save(createTrack(application));
 
         return TrackApplicationApproveResponse.from(application, savedTrack.getId());
+    }
+
+    /**
+     * 트랙 등록 신청 거절 (관리자)
+     */
+    @Transactional
+    public TrackApplicationRejectResponse rejectTrackApplication(
+            Long adminId,
+            Long applicationId,
+            String rejectionReason
+    ) {
+        TrackApplication application = findTrackApplication(applicationId);
+
+        // 상태 전이는 엔티티에 위임
+        application.reject(adminId, rejectionReason);
+
+        return TrackApplicationRejectResponse.from(application);
     }
 
     // =========================

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -12,10 +12,7 @@ import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
-import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
-import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -1246,6 +1243,93 @@ class TrackServiceTest {
             assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 등록 신청 거절")
+    class RejectTrackApplication {
+
+        @Test
+        @DisplayName("거절 성공")
+        void rejectTrackApplication_success() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+            String rejectionReason = "트랙 정보가 부족합니다";
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            TrackApplicationRejectResponse response =
+                    trackService.rejectTrackApplication(adminId, applicationId, rejectionReason);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.REJECTED);
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
+            assertThat(response.rejectionReason()).isEqualTo(rejectionReason);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청이면 거절 실패")
+        void rejectTrackApplication_fail_whenNotFound() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    trackService.rejectTrackApplication(adminId, applicationId, "사유")
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 처리된 신청이면 거절 실패")
+        void rejectTrackApplication_fail_whenAlreadyProcessed() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    0
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+            application.approve(adminId);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            assertThatThrownBy(() ->
+                    trackService.rejectTrackApplication(adminId, applicationId, "사유")
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED.getMessage());
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -12,9 +12,11 @@ import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackApplicationApproveResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
+import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
@@ -66,6 +68,9 @@ class TrackServiceTest {
 
     @Mock
     private AlbumRepository albumRepository;
+
+    @Mock
+    private TrackRepository trackRepository;
 
     @InjectMocks
     private TrackService trackService;
@@ -1047,6 +1052,200 @@ class TrackServiceTest {
             assertThat(response.content()).isEmpty();
             assertThat(response.totalElements()).isZero();
             assertThat(response.totalPages()).isZero();
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 등록 신청 승인")
+    class ApproveTrackApplication {
+
+        @Test
+        @DisplayName("즉시 공개 신청이면 승인과 함께 트랙 생성 및 공개 성공")
+        void approveTrackApplication_success_whenImmediatePublish() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    0
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            Track savedTrack = Track.createOfficialRelease(
+                    application.getRequesterUserId(),
+                    application.getArtistId(),
+                    application.getAlbumId(),
+                    application.getTrackNumber(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec(),
+                    application.getFeaturedArtistText(),
+                    null
+            );
+            savedTrack.publish();
+            ReflectionTestUtils.setField(savedTrack, "id", 1000L);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
+
+            TrackApplicationApproveResponse response =
+                    trackService.approveTrackApplication(adminId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.trackId()).isEqualTo(1000L);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("예약 공개 신청이면 승인과 함께 트랙 생성 성공")
+        void approveTrackApplication_success_whenScheduledPublish() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            Track savedTrack = Track.createOfficialRelease(
+                    application.getRequesterUserId(),
+                    application.getArtistId(),
+                    application.getAlbumId(),
+                    application.getTrackNumber(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec(),
+                    application.getFeaturedArtistText(),
+                    LocalDateTime.now().plusDays(3)
+            );
+            ReflectionTestUtils.setField(savedTrack, "id", 1000L);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
+
+            TrackApplicationApproveResponse response =
+                    trackService.approveTrackApplication(adminId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.trackId()).isEqualTo(1000L);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청이면 승인 실패")
+        void approveTrackApplication_fail_whenNotFound() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.approveTrackApplication(adminId, applicationId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미 처리된 신청이면 승인 실패")
+        void approveTrackApplication_fail_whenAlreadyProcessed() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    100L,
+                    200L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    0
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+            application.approve(adminId);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+
+            assertThatThrownBy(() -> trackService.approveTrackApplication(adminId, applicationId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED.getMessage());
+        }
+
+        @Test
+        @DisplayName("자유 창작 신청이면 승인과 함께 트랙 생성 및 공개 성공")
+        void approveTrackApplication_success_whenFreeCreation() {
+            Long adminId = 1L;
+            Long applicationId = 10L;
+
+            TrackApplication application = TrackApplication.create(
+                    2L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "밤편지 AI 버전",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application, "id", applicationId);
+
+            Track savedTrack = Track.createFreeCreation(
+                    application.getRequesterUserId(),
+                    application.getTitle(),
+                    application.getLyrics(),
+                    application.getGenre(),
+                    application.getAudioUrl(),
+                    application.getDurationSec()
+            );
+            ReflectionTestUtils.setField(savedTrack, "id", 1000L);
+
+            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
+
+            TrackApplicationApproveResponse response =
+                    trackService.approveTrackApplication(adminId, applicationId);
+
+            assertThat(response.applicationId()).isEqualTo(applicationId);
+            assertThat(response.trackId()).isEqualTo(1000L);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
+            assertThat(response.reviewedAt()).isNotNull();
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.track.service;
 
+import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
@@ -12,6 +13,7 @@ import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackApplicationDetailResponse;
+import com.fivefy.domain.track.dto.response.TrackApplicationListResponse;
 import com.fivefy.domain.track.dto.response.TrackApplicationResponse;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
@@ -29,6 +31,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -723,12 +729,12 @@ class TrackServiceTest {
                 when(application1.getCreatedAt()).thenReturn(LocalDateTime.now());
                 when(application2.getCreatedAt()).thenReturn(LocalDateTime.now());
 
-                List<TrackApplicationResponse> result =
+                List<TrackApplicationResponse> response =
                         trackService.getMyTrackApplications(userId);
 
-                assertThat(result).hasSize(2);
-                assertThat(result.get(0).applicationId()).isEqualTo(1L);
-                assertThat(result.get(1).applicationId()).isEqualTo(2L);
+                assertThat(response).hasSize(2);
+                assertThat(response.get(0).applicationId()).isEqualTo(1L);
+                assertThat(response.get(1).applicationId()).isEqualTo(2L);
             }
 
             @Test
@@ -756,10 +762,10 @@ class TrackServiceTest {
                 when(trackApplicationRepository.searchMyTrackApplications(userId))
                         .thenReturn(List.of());
 
-                List<TrackApplicationResponse> result =
+                List<TrackApplicationResponse> response =
                         trackService.getMyTrackApplications(userId);
 
-                assertThat(result).isEmpty();
+                assertThat(response).isEmpty();
             }
         }
     }
@@ -919,6 +925,128 @@ class TrackServiceTest {
             assertThatThrownBy(() -> trackService.getTrackApplication(userId, applicationId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 등록 신청 목록 조회")
+    class GetTrackApplications {
+
+        @Test
+        @DisplayName("상태 조건 없이 오래된순 목록 조회 성공")
+        void getTrackApplications_success_withoutStatus() {
+            Pageable pageable = PageRequest.of(0, 10);
+
+            TrackApplication application1 = TrackApplication.create(
+                    1L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "첫 번째 신청",
+                    "가사1",
+                    "BALLAD",
+                    "https://example.com/audio1.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application1, "id", 1L);
+            ReflectionTestUtils.setField(
+                    application1,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 14, 15, 0, 0)
+            );
+
+            TrackApplication application2 = TrackApplication.create(
+                    2L,
+                    TrackType.OFFICIAL_RELEASE,
+                    10L,
+                    100L,
+                    1L,
+                    "두 번째 신청",
+                    "가사2",
+                    "BALLAD",
+                    "https://example.com/audio2.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+            ReflectionTestUtils.setField(application2, "id", 2L);
+            ReflectionTestUtils.setField(
+                    application2,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 15, 15, 0, 0)
+            );
+
+            when(trackApplicationRepository.searchTrackApplications(null, pageable))
+                    .thenReturn(new PageImpl<>(List.of(application1, application2), pageable, 2));
+
+            PageResponse<TrackApplicationListResponse> response =
+                    trackService.getTrackApplications(null, pageable);
+
+            assertThat(response.content()).hasSize(2);
+            assertThat(response.content().get(0).applicationId()).isEqualTo(1L);
+            assertThat(response.content().get(0).requesterUserId()).isEqualTo(1L);
+            assertThat(response.content().get(0).title()).isEqualTo("첫 번째 신청");
+            assertThat(response.content().get(1).applicationId()).isEqualTo(2L);
+            assertThat(response.page()).isEqualTo(0);
+            assertThat(response.size()).isEqualTo(10);
+            assertThat(response.totalElements()).isEqualTo(2);
+            assertThat(response.totalPages()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("상태 조건으로 목록 조회 성공")
+        void getTrackApplications_success_withStatus() {
+            Pageable pageable = PageRequest.of(0, 10);
+
+            TrackApplication application = TrackApplication.create(
+                    1L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    null,
+                    "승인 대기 신청",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L,
+                    null,
+                    null
+            );
+            ReflectionTestUtils.setField(application, "id", 1L);
+            ReflectionTestUtils.setField(
+                    application,
+                    "createdAt",
+                    LocalDateTime.of(2026, 4, 14, 15, 0, 0)
+            );
+
+            when(trackApplicationRepository.searchTrackApplications(ApplicationStatus.PENDING, pageable))
+                    .thenReturn(new PageImpl<>(List.of(application), pageable, 1));
+
+            PageResponse<TrackApplicationListResponse> response =
+                    trackService.getTrackApplications(ApplicationStatus.PENDING, pageable);
+
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).status()).isEqualTo(ApplicationStatus.PENDING);
+            assertThat(response.totalElements()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("조회 결과가 없으면 빈 페이지 조회 성공")
+        void getTrackApplications_success_whenEmpty() {
+            Pageable pageable = PageRequest.of(0, 10);
+
+            when(trackApplicationRepository.searchTrackApplications(ApplicationStatus.REJECTED, pageable))
+                    .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+            PageResponse<TrackApplicationListResponse> response =
+                    trackService.getTrackApplications(ApplicationStatus.REJECTED, pageable);
+
+            assertThat(response.content()).isEmpty();
+            assertThat(response.totalElements()).isZero();
+            assertThat(response.totalPages()).isZero();
         }
     }
 }


### PR DESCRIPTION
## 개요

> 트랙 등록 신청 관리자 조회 및 승인/거절 API를 추가하고  
> 승인 시 실제 트랙 생성까지 이어지는 처리 흐름 구현

## 변경 사항

### 1. 관리자 트랙 등록 신청 목록 조회 API

- **GET /api/admin/track-applications**
- 상태 조건 기반 신청 목록 조회 API 추가
- `ApplicationStatus` 조건 필터 지원
- 기본 페이지/정렬 조건 추가
  - `size = 10`
  - `sort = createdAt`
  - `direction = ASC`
- `TrackApplicationListResponse` DTO 추가
- Querydsl 기반 신청 목록 조회 구현
- `PageResponse` 매핑 적용

### 2. 관리자 트랙 등록 신청 승인 API

- **POST /api/admin/track-applications/{applicationId}/approve**
- `TrackApplicationApproveResponse` DTO 추가
- 트랙 등록 신청 승인 서비스 로직 구현
- 신청 상태 전이는 엔티티 `approve()`에 위임
- 승인된 신청 정보를 기반으로 실제 `Track` 생성 및 저장
- 신청 유형별 트랙 생성 분기 처리
  - 자유 창작
  - 정식 발매

### 3. 관리자 트랙 등록 신청 거절 API

- **POST /api/admin/track-applications/{applicationId}/reject**
- `TrackApplicationRejectRequest` DTO 추가
- `TrackApplicationRejectResponse` DTO 추가
- 트랙 등록 신청 거절 서비스 로직 구현
- 신청 상태 전이는 엔티티 `reject()`에 위임
- 거절 사유 기반 상태 변경 및 응답 매핑 처리

### 4. 승인 후 트랙 생성 흐름 구성

- 신청 유형에 따라 `Track` 생성 로직 분리
  - 자유 창작 신청 → `createFreeCreation()`
  - 정식 발매 신청 → `createOfficialRelease()`
- `publishDelayDays` 기준 공개 시점 계산 로직 추가
- 즉시 공개 신청(`publishDelayDays = 0`)이면 승인 후 `publish()` 처리
- 예약 공개 신청이면 예약 시점 기준 트랙 생성

### 5. Querydsl 목록 조회 구현

- `TrackApplicationQueryRepositoryImpl`에 관리자 신청 목록 조회 구현
- 상태 조건 필터 적용
- `createdAt ASC` 정렬
- offset / limit 기반 페이징 처리
- total count 조회 후 `PageImpl` 반환

### 6. 서비스 테스트 추가

- 트랙 등록 신청 목록 조회 테스트 추가
  - 상태 조건 없이 오래된순 조회
  - 상태 조건 기반 조회
  - 빈 페이지 조회

- 트랙 등록 신청 승인 테스트 추가
  - 즉시 공개 신청 승인 성공
  - 예약 공개 신청 승인 성공
  - 자유 창작 신청 승인 성공
  - 존재하지 않는 신청 예외
  - 이미 처리된 신청 예외

- 트랙 등록 신청 거절 테스트 추가
  - 거절 성공
  - 존재하지 않는 신청 예외
  - 이미 처리된 신청 예외

## 변경 유형

- [x] 기능 추가 (feat)
- [x] 테스트 (test)

## 테스트 방법

1. `GET /api/admin/track-applications` 호출 시 상태 조건, 페이지 정보, 오래된순 정렬 확인
2. `POST /api/admin/track-applications/{applicationId}/approve` 호출 시 신청 승인 후 실제 Track 생성 여부 확인
3. `publishDelayDays = 0` 신청 승인 시 즉시 공개 처리 여부 확인
4. `POST /api/admin/track-applications/{applicationId}/reject` 호출 시 거절 사유와 상태 변경 확인
5. 존재하지 않는 신청 / 이미 처리된 신청 예외 케이스 확인
6. `TrackServiceTest` 전체 실행

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트