### PR TITLE
test: search 도메인 Controller, Service 단위테스트 추가

### DIFF
--- a/src/test/java/com/fivefy/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/fivefy/domain/search/controller/SearchControllerTest.java
@@ -1,0 +1,174 @@
+package com.fivefy.domain.search.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.search.dto.response.SearchArtistResponse;
+import com.fivefy.domain.search.dto.response.SearchResponse;
+import com.fivefy.domain.search.enums.SearchErrorCode;
+import com.fivefy.domain.search.service.SearchHistoryService;
+import com.fivefy.domain.search.service.SearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = {SearchController.class, SearchHistoryController.class})
+class SearchControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private SearchService searchService;
+
+    @MockitoBean
+    private SearchHistoryService searchHistoryService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private StringRedisTemplate stringRedisTemplate;;
+
+    @Nested
+    @DisplayName("검색")
+    class Search {
+
+        @Test
+        @DisplayName("정상 검색 시 200을 반환한다")
+        void search_validKeyword_returns200() throws Exception {
+            // given
+            SearchResponse response = new SearchResponse(List.of(), Page.empty(), Page.empty(), 0);
+            given(searchService.search(anyString(), any(), any())).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/search")
+                            .param("keyword", "루나"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("검색 성공"));
+        }
+
+        @Test
+        @DisplayName("검색 결과에 artists, tracks, albums, resultCount가 포함된다")
+        void search_returnsResultData() throws Exception {
+            // given
+            SearchArtistResponse artist = new SearchArtistResponse(1L, "루나", "https://img.example.com/luna.jpg");
+            PageImpl<Object> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
+            SearchResponse response = new SearchResponse(List.of(artist), Page.empty(), Page.empty(), 1);
+            given(searchService.search(anyString(), any(), any())).willReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/search")
+                            .param("keyword", "루나"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.artists[0].id").value(1L))
+                    .andExpect(jsonPath("$.data.artists[0].name").value("루나"))
+                    .andExpect(jsonPath("$.data.resultCount").value(1));
+        }
+
+        @Test
+        @DisplayName("공백 keyword로 요청 시 서비스에서 예외가 발생하여 400을 반환한다")
+        void search_blankKeyword_returns400() throws Exception {
+            // given
+            given(searchService.search(anyString(), any(), any()))
+                    .willThrow(new BusinessException(SearchErrorCode.ERR_SEARCH_KEYWORD_BLANK));
+
+            // when & then
+            mockMvc.perform(get("/api/search")
+                            .param("keyword", "   "))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(SearchErrorCode.ERR_SEARCH_KEYWORD_BLANK.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("최근 검색 기록 조회")
+    class GetRecentSearchHistories {
+
+        @Test
+        @DisplayName("최근 검색 기록 조회 시 200을 반환한다")
+        void getRecentSearchHistories_returns200() throws Exception {
+            // given
+            given(searchHistoryService.getRecentSearchHistories(any()))
+                    .willReturn(List.of("아이유", "루나"));
+
+            // when & then
+            mockMvc.perform(get("/api/search-histories"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("최근 검색 기록 조회 성공"))
+                    .andExpect(jsonPath("$.data[0]").value("아이유"))
+                    .andExpect(jsonPath("$.data[1]").value("루나"));
+        }
+
+        @Test
+        @DisplayName("최근 검색 기록이 없으면 빈 리스트를 반환한다")
+        void getRecentSearchHistories_empty_returnsEmptyList() throws Exception {
+            // given
+            given(searchHistoryService.getRecentSearchHistories(any()))
+                    .willReturn(List.of());
+
+            // when & then
+            mockMvc.perform(get("/api/search-histories"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("검색 기록 삭제")
+    class DeleteAllRecentSearchHistories {
+
+        @Test
+        @DisplayName("전체 검색 기록 삭제 시 200을 반환한다")
+        void deleteAllRecentSearchHistories_returns200() throws Exception {
+            // given
+            doNothing().when(searchHistoryService).deleteAllRecentSearchHistories(any());
+
+            // when & then
+            mockMvc.perform(delete("/api/search-histories"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("최근 검색 기록 전체 삭제 성공"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/search-histories/recent")
+    class DeleteRecentSearchHistory {
+
+        @Test
+        @DisplayName("개별 검색 기록 삭제 시 200을 반환한다")
+        void deleteRecentSearchHistory_returns200() throws Exception {
+            // given
+            doNothing().when(searchHistoryService).deleteRecentSearchHistory(any(), anyString());
+
+            // when & then
+            mockMvc.perform(delete("/api/search-histories/recent")
+                            .param("keyword", "아이유"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("최근 검색 기록 삭제 성공"));
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
+++ b/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
@@ -1,0 +1,105 @@
+package com.fivefy.domain.search.service;
+
+import com.fivefy.domain.search.repository.SearchHistoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SearchHistoryServiceTest {
+
+    @InjectMocks
+    private SearchHistoryService searchHistoryService;
+
+    @Mock
+    private SearchHistoryRepository searchHistoryRepository;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ListOperations<String, String> listOperations;
+
+    private static final Long USER_ID = 1L;
+    private static final String KEYWORD = "아이유";
+    private static final String REDIS_KEY = "search:recent:" + USER_ID;
+
+    @Nested
+    @DisplayName("검색 기록 저장")
+    class SaveSearchHistory {
+
+        @Test
+        @DisplayName("검색 기록 저장 시 DB에 INSERT 된다")
+        void saveSearchHistory_savesToDB() {
+            // given
+            given(redisTemplate.opsForList()).willReturn(listOperations);
+
+            // when
+            searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
+
+            // then
+            verify(searchHistoryRepository, times(1)).save(any());
+        }
+
+        @Test
+        @DisplayName("검색 기록 저장 시 Redis에 leftPush 된다")
+        void saveSearchHistory_leftPushToRedis() {
+            // given
+            given(redisTemplate.opsForList()).willReturn(listOperations);
+
+            // when
+            searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
+
+            // then
+            verify(listOperations, times(1)).leftPush(REDIS_KEY, KEYWORD);
+        }
+
+        @Test
+        @DisplayName("Redis 최근 기록 10개 초과 시 trim 된다")
+        void saveSearchHistory_trimAfterPush() {
+            // given
+            given(redisTemplate.opsForList()).willReturn(listOperations);
+
+            // when
+            searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
+
+            // then
+            verify(listOperations, times(1)).trim(REDIS_KEY, 0, 9);
+        }
+
+        @Test
+        @DisplayName("중복 키워드 저장 시 remove 후 leftPush 된다")
+        void saveSearchHistory_removeThenLeftPushForDuplicate() {
+            // given
+            given(redisTemplate.opsForList()).willReturn(listOperations);
+
+            // when
+            searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
+
+            // then
+            verify(listOperations, times(1)).remove(REDIS_KEY, 0, KEYWORD);
+            verify(listOperations, times(1)).leftPush(REDIS_KEY, KEYWORD);
+        }
+
+        @Test
+        @DisplayName("userId null 시 Redis 저장이 스킵된다")
+        void saveSearchHistory_nullUserId_skipsRedis() {
+            // when
+            searchHistoryService.saveSearchHistory(null, KEYWORD, 10);
+
+            // then
+            verify(redisTemplate, never()).opsForList();
+            verify(searchHistoryRepository, times(1)).save(any()); // DB는 저장
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
+++ b/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
@@ -11,7 +11,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 
-import static org.mockito.ArgumentMatchers.any;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -100,6 +103,66 @@ class SearchHistoryServiceTest {
             // then
             verify(redisTemplate, never()).opsForList();
             verify(searchHistoryRepository, times(1)).save(any()); // DB는 저장
+        }
+    }
+
+    @Nested
+    @DisplayName("최근 검색 기록 조회")
+    class GetRecentSearchHistories {
+
+        @Test
+        @DisplayName("최근 검색 기록을 Redis에서 조회한다")
+        void getRecentSearchHistories_returnsFromRedis() {
+            // given
+            given(redisTemplate.opsForList()).willReturn(listOperations);
+            given(listOperations.range(REDIS_KEY, 0, -1))
+                    .willReturn(List.of("아이유", "루나", "뉴진스"));
+
+            // when
+            List<String> result = searchHistoryService.getRecentSearchHistories(USER_ID);
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result).containsExactly("아이유", "루나", "뉴진스");
+        }
+
+        @Test
+        @DisplayName("userId null 시 빈 리스트를 반환한다")
+        void getRecentSearchHistories_nullUserId_returnsEmptyList() {
+            // when
+            List<String> result = searchHistoryService.getRecentSearchHistories(null);
+
+            // then
+            assertThat(result).isEmpty();
+            verify(redisTemplate, never()).opsForList();
+        }
+    }
+
+    @Nested
+    @DisplayName("검색 기록 삭제")
+    class DeleteSearchHistory {
+
+        @Test
+        @DisplayName("개별 검색 기록을 Redis에서 삭제한다")
+        void deleteRecentSearchHistory_removesFromRedis() {
+            // given
+            given(redisTemplate.opsForList()).willReturn(listOperations);
+
+            // when
+            searchHistoryService.deleteRecentSearchHistory(USER_ID, KEYWORD);
+
+            // then
+            verify(listOperations, times(1)).remove(REDIS_KEY, 0, KEYWORD);
+        }
+
+        @Test
+        @DisplayName("전체 검색 기록을 Redis에서 삭제한다")
+        void deleteAllRecentSearchHistories_deletesKeyFromRedis() {
+            // when
+            searchHistoryService.deleteAllRecentSearchHistories(USER_ID);
+
+            // then
+            verify(redisTemplate, times(1)).delete(REDIS_KEY);
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/search/service/SearchServiceTest.java
+++ b/src/test/java/com/fivefy/domain/search/service/SearchServiceTest.java
@@ -1,0 +1,130 @@
+package com.fivefy.domain.search.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.search.dto.response.SearchAlbumResponse;
+import com.fivefy.domain.search.dto.response.SearchArtistResponse;
+import com.fivefy.domain.search.dto.response.SearchResponse;
+import com.fivefy.domain.search.dto.response.SearchTrackResponse;
+import com.fivefy.domain.search.enums.SearchErrorCode;
+import com.fivefy.domain.search.repository.SearchQueryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SearchServiceTest {
+
+    @InjectMocks
+    private SearchService searchService;
+
+    @Mock
+    private SearchQueryRepository searchQueryRepository;
+
+    @Mock
+    private SearchHistoryService searchHistoryService;
+
+    private final Pageable pageable = PageRequest.of(0, 20);
+
+    @Test
+    @DisplayName("빈 검색어 입력 시 예외가 발생한다")
+    void search_blankKeyword_throwsException() {
+        assertThatThrownBy(() -> searchService.search("   ", pageable, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(SearchErrorCode.ERR_SEARCH_KEYWORD_BLANK.getMessage());
+    }
+
+    @Test
+    @DisplayName("정상 검색 시 SearchResponse를 반환한다")
+    void search_validKeyword_returnsSearchResponse() {
+        // given
+        given(searchQueryRepository.searchArtists(anyString(), anyInt()))
+                .willReturn(List.of());
+        given(searchQueryRepository.searchTracks(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+        given(searchQueryRepository.searchAlbums(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+
+        // when
+        SearchResponse response = searchService.search("루나", pageable, 1L);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.artists()).isNotNull();
+        assertThat(response.tracks()).isNotNull();
+        assertThat(response.albums()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그인 상태에서 검색 시 검색 기록 저장이 호출된다")
+    void search_loggedIn_savesSearchHistory() {
+        // given
+        Long userId = 1L;
+        given(searchQueryRepository.searchArtists(anyString(), anyInt()))
+                .willReturn(List.of());
+        given(searchQueryRepository.searchTracks(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+        given(searchQueryRepository.searchAlbums(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+
+        // when
+        searchService.search("루나", pageable, userId);
+
+        // then
+        verify(searchHistoryService, times(1))
+                .saveSearchHistory(eq(userId), eq("루나"), anyInt());
+    }
+
+    @Test
+    @DisplayName("비로그인 상태에서 검색 시 userId null로 검색 기록 저장이 호출된다")
+    void search_notLoggedIn_savesSearchHistoryWithNullUserId() {
+        // given
+        given(searchQueryRepository.searchArtists(anyString(), anyInt()))
+                .willReturn(List.of());
+        given(searchQueryRepository.searchTracks(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+        given(searchQueryRepository.searchAlbums(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+
+        // when
+        searchService.search("루나", pageable, null);
+
+        // then
+        verify(searchHistoryService, times(1))
+                .saveSearchHistory(eq(null), eq("루나"), anyInt());
+    }
+
+    @Test
+    @DisplayName("검색 기록 저장 실패 시에도 검색 결과가 정상 반환된다")
+    void search_saveHistoryFails_stillReturnsResponse() {
+        // given
+        given(searchQueryRepository.searchArtists(anyString(), anyInt()))
+                .willReturn(List.of());
+        given(searchQueryRepository.searchTracks(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+        given(searchQueryRepository.searchAlbums(anyString(), anyList(), any(Pageable.class)))
+                .willReturn(Page.empty());
+        doThrow(new RuntimeException("Redis 장애"))
+                .when(searchHistoryService).saveSearchHistory(any(), anyString(), anyInt());
+
+        // when
+        SearchResponse response = searchService.search("루나", pageable, 1L);
+
+        // then
+        assertThat(response).isNotNull();
+    }
+}


### PR DESCRIPTION
## 개요
검색 도메인(검색, 검색 기록)의 단위 테스트 추가

## 변경 사항
- SearchControllerTest  검색 API 및 검색 기록 API 컨트롤러 단위 테스트
- SearchServiceTest  검색 서비스 단위 테스트 (빈 키워드 예외, 검색 기록 저장 호출, 기록 저장 실패 시 검색 결과 정상 반환)

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 검색 기능에 대한 포괄적인 테스트 커버리지 추가
  * 검색 컨트롤러, 서비스, 이력 관리 관련 테스트 구성
  * 검색 동작, 오류 처리, 이력 작업 검증 로직 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->