### PR TITLE
## refactor: 트랙 신청 거절 요청 DTO 적용 및 신청 목록 정렬 처리 보강

### DIFF
--- a/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackApplicationController.java
@@ -5,6 +5,7 @@ import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
 import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.request.TrackApplicationRejectRequest;
 import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.service.TrackService;
 import jakarta.validation.Valid;
@@ -135,10 +136,10 @@ public class TrackApplicationController {
     public ResponseEntity<BaseResponse<TrackApplicationRejectResponse>> rejectTrackApplication(
             @AuthenticationPrincipal Long adminId,
             @PathVariable Long applicationId,
-            @Valid @RequestBody String rejectionReason
+            @Valid @RequestBody TrackApplicationRejectRequest request
     ) {
         TrackApplicationRejectResponse response =
-                trackService.rejectTrackApplication(adminId, applicationId, rejectionReason);
+                trackService.rejectTrackApplication(adminId, applicationId, request.rejectionReason());
 
         return ResponseEntity.status(HttpStatus.OK).body(
                 BaseResponse.success(HttpStatus.OK, "트랙 등록 신청 거절 성공", response)

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.fivefy.domain.track.repository;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.entity.TrackApplication;
 import com.fivefy.domain.track.enums.TrackType;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -100,7 +102,7 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
         List<TrackApplication> content = queryFactory
                 .selectFrom(trackApplication)
                 .where(statusEq(status))
-                .orderBy(trackApplication.createdAt.asc())
+                .orderBy(getOrderSpecifiers(pageable))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -123,6 +125,26 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
         BooleanExpression sameTitle = trackApplication.title.eq(title);
 
         return sameTrackNumber.or(sameTitle);
+    }
+
+    /**
+     * Pageable 정렬 조건을 Querydsl OrderSpecifier로 변환
+     */
+    private OrderSpecifier<?>[] getOrderSpecifiers(Pageable pageable) {
+        return pageable.getSort().stream()
+                .map(order -> {
+                    // Spring Sort -> Querydsl 정렬 방향으로 변환
+                    Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+
+                    // 정렬 대상 필드에 맞는 OrderSpecifier 생성
+                    return switch (order.getProperty()) {
+                        case "createdAt" -> new OrderSpecifier<>(direction, trackApplication.createdAt);
+                        case "status" -> new OrderSpecifier<>(direction, trackApplication.status);
+                        // 지원하지 않는 정렬 조건이면 createdAt 기준으로 fallback
+                        default -> new OrderSpecifier<>(Order.DESC, trackApplication.createdAt);
+                    };
+                })
+                .toArray(OrderSpecifier[]::new);
     }
 
     // 상태 필터 조건


### PR DESCRIPTION
## 개요

트랙 신청 거절 요청 구조를 DTO 기반으로 정리하고  
트랙 신청 목록 Querydsl 조회에 Pageable 정렬 조건 반영

## 변경 사항

### 트랙 신청 거절 요청 구조 정리

- 트랙 신청 거절 API 요청값을 문자열에서 `TrackApplicationRejectRequest` DTO로 변경
- Controller에서 `request.rejectionReason()` 기반으로 서비스 호출하도록 정리
- 거절 요청 구조를 다른 신청 도메인과 동일한 DTO 방식으로 통일

### 트랙 신청 목록 Querydsl 정렬 처리 보강

- 트랙 신청 목록 Querydsl 조회에 Pageable 정렬 조건 반영
- `createdAt`, `status` 기준 `OrderSpecifier` 변환 로직 추가
- 지원하지 않는 정렬 조건은 `createdAt DESC` 기준 fallback 처리
- 기존 고정 정렬(`createdAt ASC`) 방식 제거

## 변경 유형

- [x] 리팩토링 (refactor)

## 테스트 방법

1. 트랙 신청 거절 API 호출 시 DTO 요청 본문으로 정상 처리되는지 확인
2. 트랙 신청 목록 조회 시 `sort=createdAt,asc` 정렬 적용 확인
3. 트랙 신청 목록 조회 시 `sort=status,desc` 정렬 적용 확인
4. 지원하지 않는 정렬 조건 전달 시 `createdAt DESC` fallback 동작 확인

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트