### PR TITLE
feat: 플레이리스트 생성 시 구독 검증 로직 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -588,6 +588,13 @@ include::{snippets}/playlist-create-invalid/request-fields.adoc[]
 include::{snippets}/playlist-create-invalid/http-response.adoc[]
 include::{snippets}/playlist-create-invalid/response-fields.adoc[]
 
+==== 에러 케이스 — 유효한 구독 없음
+
+include::{snippets}/playlist-create-subscription-required/http-request.adoc[]
+include::{snippets}/playlist-create-subscription-required/request-fields.adoc[]
+include::{snippets}/playlist-create-subscription-required/http-response.adoc[]
+include::{snippets}/playlist-create-subscription-required/response-fields.adoc[]
+
 ==== 에러 케이스 - 중복 제목
 
 include::{snippets}/playlist-create-duplicate/http-request.adoc[]

--- a/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/playlist/enums/PlaylistErrorCode.java
@@ -16,6 +16,7 @@ public enum PlaylistErrorCode implements ErrorCode {
     PLAYLIST_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 수정 권한이 없습니다"),
     PLAYLIST_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트 삭제 권한이 없습니다"),
     ALREADY_DELETED_PLAYLIST(HttpStatus.BAD_REQUEST, "이미 삭제된 플레이리스트입니다"),
+    PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED(HttpStatus.FORBIDDEN, "플레이리스트 생성은 구독 회원만 가능합니다"),
 
     // PlaylistTrack
     PLAYLIST_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "플레이리스트에 대한 권한이 없습니다"),

--- a/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
@@ -9,11 +9,15 @@ import com.fivefy.domain.playlist.dto.response.PlaylistResponse;
 import com.fivefy.domain.playlist.entity.Playlist;
 import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
 import com.fivefy.domain.playlist.repository.PlaylistRepository;
+import com.fivefy.domain.subscription.enums.SubscriptionStatus;
+import com.fivefy.domain.subscription.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +25,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class PlaylistService {
 
     private final PlaylistRepository playlistRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     @Transactional
     public PlaylistResponse createPlaylist(Long userId, PlaylistCreateRequest request) {
+        // 플레이리스트 생성 전 구독 상태 검증
+        // TRIAL 또는 ACTIVE 상태인 경우에만 생성 가능
+        validateSubscription(userId);
+
         // 중복 제목 여부 검사
         if (playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title())) {
             throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
@@ -88,5 +97,19 @@ public class PlaylistService {
         playlist.delete();
 
         return PlaylistDeleteResponse.from(playlist);
+    }
+
+    private void validateSubscription(Long userId) {
+        // 사용자 구독 상태 조회
+        // TRIAL(체험), ACTIVE(유료) 상태인 경우 유효한 구독으로 판단
+        boolean hasValidSubscription = subscriptionRepository.existsByUserIdAndStatusIn(
+                userId,
+                List.of(SubscriptionStatus.TRIAL, SubscriptionStatus.ACTIVE)
+        );
+
+        // 유효한 구독이 없으면 플레이리스트 생성 불가
+        if (!hasValidSubscription) {
+            throw new BusinessException(PlaylistErrorCode.PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED);
+        }
     }
 }

--- a/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
@@ -15,4 +15,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     List<Subscription> findAllByPointOrderIdIn(List<Long> pointOrderIds);
 
     Optional<Subscription> findByUserIdAndPlanType(Long userId, SubscriptionPlanType planType);
+
+    // 사용자 구독 상태가 TRIAL 또는 ACTIVE인지 확인하기 위한 존재 여부 조회
+    boolean existsByUserIdAndStatusIn(Long userId, List<SubscriptionStatus> statuses);
 }

--- a/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/controller/PlaylistControllerTest.java
@@ -143,6 +143,36 @@ class PlaylistControllerTest extends RestDocsSupport {
         }
 
         @Test
+        @DisplayName("유효한 구독이 없으면 403 반환")
+        void createPlaylistWithoutValidSubscription() throws Exception {
+            // given
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(playlistService.createPlaylist(any(), any(PlaylistCreateRequest.class)))
+                    .willThrow(new BusinessException(PlaylistErrorCode.PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED));
+
+            // when & then
+            mockMvc.perform(post("/api/playlists")
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message")
+                            .value(PlaylistErrorCode.PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED.getMessage()))
+                    .andDo(document("playlist-create-subscription-required",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("플레이리스트 제목"),
+                                    fieldWithPath("description").type(STRING).description("플레이리스트 설명")
+                            ),
+                            responseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("에러 메시지")
+                            )
+                    ));
+        }
+
+        @Test
         @DisplayName("중복 제목으로 생성 시 409 반환")
         void createPlaylistWithDuplicateName() throws Exception {
             // given

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -9,6 +9,8 @@ import com.fivefy.domain.playlist.dto.response.PlaylistResponse;
 import com.fivefy.domain.playlist.entity.Playlist;
 import com.fivefy.domain.playlist.enums.PlaylistErrorCode;
 import com.fivefy.domain.playlist.repository.PlaylistRepository;
+import com.fivefy.domain.subscription.enums.SubscriptionStatus;
+import com.fivefy.domain.subscription.repository.SubscriptionRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,7 @@ class PlaylistServiceTest {
     private PlaylistService playlistService;
 
     @Mock private PlaylistRepository playlistRepository;
+    @Mock private SubscriptionRepository subscriptionRepository;
 
     @Nested
     @DisplayName("플레이리스트 생성")
@@ -49,6 +52,11 @@ class PlaylistServiceTest {
             // given
             Long userId = 1L;
             PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.TRIAL, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
 
             Playlist playlist = Playlist.create(userId, request.title(), request.description());
             ReflectionTestUtils.setField(playlist, "id", 1L);
@@ -78,6 +86,11 @@ class PlaylistServiceTest {
             Long userId = 1L;
             PlaylistCreateRequest request = new PlaylistCreateRequest("중복 제목", "설명");
 
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.TRIAL, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
             given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
                     .willReturn(true);
 
@@ -86,6 +99,28 @@ class PlaylistServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
 
+            verify(playlistRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("유효한 구독이 없으면 플레이리스트 생성 시 예외 발생")
+        void createPlaylistWithoutValidSubscription() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.TRIAL, SubscriptionStatus.ACTIVE)
+            )).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED.getMessage());
+
+            verify(playlistRepository, never())
+                    .existsByUserIdAndTitleAndDeletedAtIsNull(anyLong(), anyString());
             verify(playlistRepository, never()).save(any());
         }
     }


### PR DESCRIPTION
## 개요

> 플레이리스트 생성 시 사용자 구독 상태를 검증하여,  
유효한 구독(TRIAL, ACTIVE)을 가진 사용자만 생성할 수 있도록 정책을 추가했습니다.  
테스트 코드를 통해 정상/예외 흐름을 검증했습니다.

## 변경 사항

### 1. 플레이리스트 생성 정책 보완

- 플레이리스트 생성 시 구독 여부 검증 로직 추가
- 유효한 구독 상태(TRIAL, ACTIVE)만 생성 가능하도록 제한
- 구독이 없는 사용자에 대해 예외 처리 추가

---

### 2. 서비스 로직 수정

- PlaylistService 생성 로직에 구독 검증 추가
  - SubscriptionRepository를 통해 사용자 구독 상태 조회
  - 유효한 구독이 없는 경우 BusinessException 발생

---

### 3. 에러 코드 추가

- 구독이 없는 경우를 위한 에러 코드 추가
  - PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED

---

### 4. 테스트 코드 보완

- PlaylistServiceTest
  - 구독이 있는 경우 생성 성공 테스트
  - 구독이 없는 경우 예외 발생 테스트

- PlaylistControllerTest
  - API 호출 시 구독 여부에 따른 응답 검증

---

### 5. API 문서화

- REST Docs 기반 플레이리스트 생성 API 문서화 추가

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [x] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> 플레이리스트 생성 시 구독 여부에 따른 동작을 검증합니다.

### 1. 구독이 있는 경우

- 유효한 구독(TRIAL, ACTIVE) 사용자로 생성 요청
- 정상적으로 플레이리스트 생성되는지 확인

---

### 2. 구독이 없는 경우

- 구독이 없는 사용자로 생성 요청
- PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED 예외 발생 확인

## 스크린샷
- 구독이 있는 경우 (생성 성공)
<img width="1312" height="895" alt="image" src="https://github.com/user-attachments/assets/08d95bea-b1e0-4024-89ea-40f28014f371" />

- 구독이 없는 경우 (생성 실패)
<img width="1311" height="678" alt="image" src="https://github.com/user-attachments/assets/6bbd0db8-9aae-48bf-b9a4-6bef83d592da" />

- 테스트 커버리지 (JaCoCo 100%)
<img width="1724" height="397" alt="image" src="https://github.com/user-attachments/assets/7c5cbafc-3fc2-4765-b820-de93ee1d4f77" />


## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 플레이리스트 생성 기능에 유효한 구독 여부 확인 요구사항 추가
  * 구독하지 않은 사용자가 플레이리스트 생성을 시도할 경우 명확한 오류 메시지 표시

* **문서화**
  * 플레이리스트 생성 API의 구독 미보유 시 에러 케이스 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->