### PR TITLE
test: 트랙 등록 신청 API 컨트롤러 테스트 및 REST Docs 문서화 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -572,6 +572,143 @@ include::{snippets}/albums-by-artist-not-found/response-fields.adoc[]
 
 ---
 
+== Track API
+
+=== 자유 창작 트랙 등록 신청 생성
+
+include::{snippets}/track-applications-free-creations-create/http-request.adoc[]
+include::{snippets}/track-applications-free-creations-create/request-fields.adoc[]
+include::{snippets}/track-applications-free-creations-create/http-response.adoc[]
+include::{snippets}/track-applications-free-creations-create/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/track-applications-free-creations-create-invalid/http-request.adoc[]
+include::{snippets}/track-applications-free-creations-create-invalid/request-fields.adoc[]
+include::{snippets}/track-applications-free-creations-create-invalid/http-response.adoc[]
+include::{snippets}/track-applications-free-creations-create-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 중복 신청
+
+include::{snippets}/track-applications-free-creations-create-duplicate/http-request.adoc[]
+include::{snippets}/track-applications-free-creations-create-duplicate/request-fields.adoc[]
+include::{snippets}/track-applications-free-creations-create-duplicate/http-response.adoc[]
+include::{snippets}/track-applications-free-creations-create-duplicate/response-fields.adoc[]
+
+---
+
+=== 정식 발매 트랙 등록 신청 생성
+
+include::{snippets}/track-applications-official-releases-create/http-request.adoc[]
+include::{snippets}/track-applications-official-releases-create/request-fields.adoc[]
+include::{snippets}/track-applications-official-releases-create/http-response.adoc[]
+include::{snippets}/track-applications-official-releases-create/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/track-applications-official-releases-create-invalid/http-request.adoc[]
+include::{snippets}/track-applications-official-releases-create-invalid/request-fields.adoc[]
+include::{snippets}/track-applications-official-releases-create-invalid/http-response.adoc[]
+include::{snippets}/track-applications-official-releases-create-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 중복 신청
+
+include::{snippets}/track-applications-official-releases-create-duplicate/http-request.adoc[]
+include::{snippets}/track-applications-official-releases-create-duplicate/request-fields.adoc[]
+include::{snippets}/track-applications-official-releases-create-duplicate/http-response.adoc[]
+include::{snippets}/track-applications-official-releases-create-duplicate/response-fields.adoc[]
+
+---
+
+=== 내 트랙 등록 신청 목록 조회
+
+include::{snippets}/track-applications-me-get/http-request.adoc[]
+include::{snippets}/track-applications-me-get/http-response.adoc[]
+include::{snippets}/track-applications-me-get/response-fields.adoc[]
+
+---
+
+=== 트랙 등록 신청 상세 조회
+
+include::{snippets}/track-applications-get/http-request.adoc[]
+include::{snippets}/track-applications-get/path-parameters.adoc[]
+include::{snippets}/track-applications-get/http-response.adoc[]
+include::{snippets}/track-applications-get/response-fields.adoc[]
+
+==== 에러 케이스 - 조회 권한 없음
+
+include::{snippets}/track-applications-get-forbidden/http-request.adoc[]
+include::{snippets}/track-applications-get-forbidden/path-parameters.adoc[]
+include::{snippets}/track-applications-get-forbidden/http-response.adoc[]
+include::{snippets}/track-applications-get-forbidden/response-fields.adoc[]
+
+==== 에러 케이스 - 신청 없음
+
+include::{snippets}/track-applications-get-not-found/http-request.adoc[]
+include::{snippets}/track-applications-get-not-found/path-parameters.adoc[]
+include::{snippets}/track-applications-get-not-found/http-response.adoc[]
+include::{snippets}/track-applications-get-not-found/response-fields.adoc[]
+
+---
+
+=== 트랙 등록 신청 목록 조회
+
+include::{snippets}/admin-track-applications-get/http-request.adoc[]
+include::{snippets}/admin-track-applications-get/http-response.adoc[]
+include::{snippets}/admin-track-applications-get/response-fields.adoc[]
+
+---
+
+=== 트랙 등록 신청 승인
+
+include::{snippets}/admin-track-applications-approve/http-request.adoc[]
+include::{snippets}/admin-track-applications-approve/path-parameters.adoc[]
+include::{snippets}/admin-track-applications-approve/http-response.adoc[]
+include::{snippets}/admin-track-applications-approve/response-fields.adoc[]
+
+==== 에러 케이스 - 이미 처리된 신청
+
+include::{snippets}/admin-track-applications-approve-already-processed/http-request.adoc[]
+include::{snippets}/admin-track-applications-approve-already-processed/http-response.adoc[]
+include::{snippets}/admin-track-applications-approve-already-processed/response-fields.adoc[]
+
+==== 에러 케이스 - 신청 없음
+
+include::{snippets}/admin-track-applications-approve-not-found/http-request.adoc[]
+include::{snippets}/admin-track-applications-approve-not-found/http-response.adoc[]
+include::{snippets}/admin-track-applications-approve-not-found/response-fields.adoc[]
+
+---
+
+=== 트랙 등록 신청 거절
+
+include::{snippets}/admin-track-applications-reject/http-request.adoc[]
+include::{snippets}/admin-track-applications-reject/path-parameters.adoc[]
+include::{snippets}/admin-track-applications-reject/request-fields.adoc[]
+include::{snippets}/admin-track-applications-reject/http-response.adoc[]
+include::{snippets}/admin-track-applications-reject/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/admin-track-applications-reject-invalid/http-request.adoc[]
+include::{snippets}/admin-track-applications-reject-invalid/request-fields.adoc[]
+include::{snippets}/admin-track-applications-reject-invalid/http-response.adoc[]
+include::{snippets}/admin-track-applications-reject-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 이미 처리된 신청
+
+include::{snippets}/admin-track-applications-reject-already-processed/http-request.adoc[]
+include::{snippets}/admin-track-applications-reject-already-processed/http-response.adoc[]
+include::{snippets}/admin-track-applications-reject-already-processed/response-fields.adoc[]
+
+==== 에러 케이스 - 신청 없음
+
+include::{snippets}/admin-track-applications-reject-not-found/http-request.adoc[]
+include::{snippets}/admin-track-applications-reject-not-found/http-response.adoc[]
+include::{snippets}/admin-track-applications-reject-not-found/response-fields.adoc[]
+
+---
+
 == Playlist API
 
 === 플레이리스트 생성

--- a/src/main/java/com/fivefy/domain/album/dto/response/AlbumApplicationApproveResponse.java
+++ b/src/main/java/com/fivefy/domain/album/dto/response/AlbumApplicationApproveResponse.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.album.dto.response;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.album.entity.AlbumApplication;
 
 import java.time.LocalDateTime;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 public record AlbumApplicationApproveResponse(
         Long applicationId,
         Long albumId,
-        String status,
+        ApplicationStatus status,
         Long reviewedByAdminId,
         LocalDateTime reviewedAt
 ) {
@@ -21,7 +22,7 @@ public record AlbumApplicationApproveResponse(
         return new AlbumApplicationApproveResponse(
                 application.getId(),
                 albumId,
-                application.getStatus().name(),
+                application.getStatus(),
                 application.getReviewedByAdminId(),
                 application.getReviewedAt()
         );

--- a/src/main/java/com/fivefy/domain/album/dto/response/AlbumDetailResponse.java
+++ b/src/main/java/com/fivefy/domain/album/dto/response/AlbumDetailResponse.java
@@ -4,6 +4,9 @@ import com.fivefy.domain.album.entity.Album;
 
 import java.time.LocalDateTime;
 
+/**
+ * 앨범 상세 조회 응답 DTO
+ */
 public record AlbumDetailResponse(
         Long albumId,
         Long artistId,

--- a/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationApproveResponse.java
+++ b/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationApproveResponse.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.artist.dto.response;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.artist.entity.ArtistApplication;
+import com.fivefy.domain.artist.enums.ArtistType;
 
 import java.time.LocalDateTime;
 
@@ -10,8 +12,8 @@ import java.time.LocalDateTime;
 public record ArtistApplicationApproveResponse(
         Long applicationId,
         Long artistId,
-        String artistType,
-        String status,
+        ArtistType artistType,
+        ApplicationStatus status,
         Long reviewedByAdminId,
         LocalDateTime reviewedAt
 ) {
@@ -22,8 +24,8 @@ public record ArtistApplicationApproveResponse(
         return new ArtistApplicationApproveResponse(
                 application.getId(),
                 artistId,
-                application.getArtistType().name(),
-                application.getStatus().name(),
+                application.getArtistType(),
+                application.getStatus(),
                 application.getReviewedByAdminId(),
                 application.getReviewedAt()
         );

--- a/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationDetailResponse.java
+++ b/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationDetailResponse.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.artist.dto.response;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.artist.entity.ArtistApplication;
+import com.fivefy.domain.artist.enums.ArtistType;
 
 import java.time.LocalDateTime;
 
@@ -11,10 +13,10 @@ public record ArtistApplicationDetailResponse(
         Long applicationId,
         Long requesterUserId,
         String requestedName,
-        String artistType,
+        ArtistType artistType,
         String bio,
         String profileImageUrl,
-        String status,
+        ApplicationStatus status,
         Long reviewedByAdminId,
         LocalDateTime reviewedAt,
         String rejectionReason,
@@ -26,10 +28,10 @@ public record ArtistApplicationDetailResponse(
                 artistApplication.getId(),
                 artistApplication.getRequesterUserId(),
                 artistApplication.getRequestedName(),
-                artistApplication.getArtistType().name(),
+                artistApplication.getArtistType(),
                 artistApplication.getBio(),
                 artistApplication.getProfileImageUrl(),
-                artistApplication.getStatus().name(),
+                artistApplication.getStatus(),
                 artistApplication.getReviewedByAdminId(),
                 artistApplication.getReviewedAt(),
                 artistApplication.getRejectionReason(),

--- a/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationListResponse.java
+++ b/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationListResponse.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.artist.dto.response;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.artist.entity.ArtistApplication;
+import com.fivefy.domain.artist.enums.ArtistType;
 
 import java.time.LocalDateTime;
 
@@ -11,8 +13,8 @@ public record ArtistApplicationListResponse(
         Long applicationId,
         Long requesterUserId,
         String requestedName,
-        String artistType,
-        String status,
+        ArtistType artistType,
+        ApplicationStatus status,
         LocalDateTime createdAt
 ) {
     public static ArtistApplicationListResponse from(ArtistApplication artistApplication) {
@@ -20,8 +22,8 @@ public record ArtistApplicationListResponse(
                 artistApplication.getId(),
                 artistApplication.getRequesterUserId(),
                 artistApplication.getRequestedName(),
-                artistApplication.getArtistType().name(),
-                artistApplication.getStatus().name(),
+                artistApplication.getArtistType(),
+                artistApplication.getStatus(),
                 artistApplication.getCreatedAt()
         );
     }

--- a/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationRejectResponse.java
+++ b/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationRejectResponse.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.artist.dto.response;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.artist.entity.ArtistApplication;
+import com.fivefy.domain.artist.enums.ArtistType;
 
 import java.time.LocalDateTime;
 
@@ -9,8 +11,8 @@ import java.time.LocalDateTime;
  */
 public record ArtistApplicationRejectResponse(
         Long applicationId,
-        String artistType,
-        String status,
+        ArtistType artistType,
+        ApplicationStatus status,
         Long reviewedByAdminId,
         LocalDateTime reviewedAt,
         String rejectionReason
@@ -18,8 +20,8 @@ public record ArtistApplicationRejectResponse(
     public static ArtistApplicationRejectResponse from(ArtistApplication application) {
         return new ArtistApplicationRejectResponse(
                 application.getId(),
-                application.getArtistType().name(),
-                application.getStatus().name(),
+                application.getArtistType(),
+                application.getStatus(),
                 application.getReviewedByAdminId(),
                 application.getReviewedAt(),
                 application.getRejectionReason()

--- a/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationResponse.java
+++ b/src/main/java/com/fivefy/domain/artist/dto/response/ArtistApplicationResponse.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.artist.dto.response;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.artist.entity.ArtistApplication;
+import com.fivefy.domain.artist.enums.ArtistType;
 
 import java.time.LocalDateTime;
 
@@ -10,16 +12,16 @@ import java.time.LocalDateTime;
 public record ArtistApplicationResponse(
         Long applicationId,
         String requestedName,
-        String artistType,
-        String status,
+        ArtistType artistType,
+        ApplicationStatus status,
         LocalDateTime createdAt
 ) {
     public static ArtistApplicationResponse from(ArtistApplication artistApplication) {
         return new ArtistApplicationResponse(
                 artistApplication.getId(),
                 artistApplication.getRequestedName(),
-                artistApplication.getArtistType().name(),
-                artistApplication.getStatus().name(),
+                artistApplication.getArtistType(),
+                artistApplication.getStatus(),
                 artistApplication.getCreatedAt()
         );
     }

--- a/src/main/java/com/fivefy/domain/artist/dto/response/ArtistDetailResponse.java
+++ b/src/main/java/com/fivefy/domain/artist/dto/response/ArtistDetailResponse.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.artist.dto.response;
 
 import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistStatus;
+import com.fivefy.domain.artist.enums.ArtistType;
 
 import java.time.LocalDateTime;
 
@@ -10,8 +12,8 @@ import java.time.LocalDateTime;
 public record ArtistDetailResponse(
         Long artistId,
         String name,
-        String artistType,
-        String status,
+        ArtistType artistType,
+        ArtistStatus status,
         String bio,
         String profileImageUrl,
         LocalDateTime createdAt,
@@ -21,8 +23,8 @@ public record ArtistDetailResponse(
         return new ArtistDetailResponse(
                 artist.getId(),
                 artist.getName(),
-                artist.getArtistType().name(),
-                artist.getStatus().name(),
+                artist.getArtistType(),
+                artist.getStatus(),
                 artist.getBio(),
                 artist.getProfileImageUrl(),
                 artist.getCreatedAt(),

--- a/src/main/java/com/fivefy/domain/artist/dto/response/MyArtistResponse.java
+++ b/src/main/java/com/fivefy/domain/artist/dto/response/MyArtistResponse.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.artist.dto.response;
 
 import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistType;
 
 import java.time.LocalDateTime;
 
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 public record MyArtistResponse(
         Long artistId,
         String name,
-        String artistType,
+        ArtistType artistType,
         String bio,
         String profileImageUrl,
         LocalDateTime createdAt,
@@ -20,7 +21,7 @@ public record MyArtistResponse(
         return new MyArtistResponse(
                 artist.getId(),
                 artist.getName(),
-                artist.getArtistType().name(),
+                artist.getArtistType(),
                 artist.getBio(),
                 artist.getProfileImageUrl(),
                 artist.getCreatedAt(),

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationApproveResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackApplicationApproveResponse.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.track.dto.response;
 
+import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.domain.track.entity.TrackApplication;
 
 import java.time.LocalDateTime;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 public record TrackApplicationApproveResponse(
         Long applicationId,
         Long trackId,
-        String status,
+        ApplicationStatus status,
         Long reviewedByAdminId,
         LocalDateTime reviewedAt
 ) {
@@ -21,7 +22,7 @@ public record TrackApplicationApproveResponse(
         return new TrackApplicationApproveResponse(
                 application.getId(),
                 trackId,
-                application.getStatus().name(),
+                application.getStatus(),
                 application.getReviewedByAdminId(),
                 application.getReviewedAt()
         );

--- a/src/test/java/com/fivefy/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/fivefy/domain/album/controller/AlbumControllerTest.java
@@ -389,7 +389,7 @@ class AlbumControllerTest extends RestDocsSupport {
             AlbumApplicationApproveResponse response = new AlbumApplicationApproveResponse(
                     applicationId,
                     1000L,
-                    "APPROVED",
+                    ApplicationStatus.APPROVED,
                     1L,
                     LocalDateTime.of(2026, 4, 17, 12, 0, 0)
             );

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -43,17 +43,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * AlbumService의 비즈니스 로직을 검증하는 단위 테스트
+ * AlbumService의 비즈니스 로직검증하는 단위 테스트
  *
- * 앨범 등록 신청 생성 기능을 검증한다.
- * 내 앨범 등록 신청 목록 조회 기능을 검증한다.
- * 내 앨범 등록 신청 목록 빈 결과 조회 기능을 검증한다.
- * 앨범 등록 신청 상세 조회 기능을 검증한다.
- * 앨범 등록 신청 목록 조회 기능을 검증한다.
- * 앨범 등록 신청 승인 기능을 검증한다.
- * 앨범 등록 신청 거절 기능을 검증한다.
- * 앨범 상세 조회 기능을 검증한다.
- * 아티스트별 앨범 목록 조회 기능을 검증한다.
+ * 앨범 등록 신청 생성 기능 검증
+ * 내 앨범 등록 신청 목록 조회 기능 검증
+ * 내 앨범 등록 신청 목록 빈 결과 조회 기능 검증
+ * 앨범 등록 신청 상세 조회 기능 검증
+ * 앨범 등록 신청 목록 조회 기능 검증
+ * 앨범 등록 신청 승인 기능 검증
+ * 앨범 등록 신청 거절 기능 검증
+ * 앨범 상세 조회 기능 검증
+ * 아티스트별 앨범 목록 조회 기능 검증
  */
 @ExtendWith(MockitoExtension.class)
 class AlbumServiceTest {
@@ -665,7 +665,7 @@ class AlbumServiceTest {
 
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.albumId()).isEqualTo(1000L);
-            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
         }
@@ -703,7 +703,7 @@ class AlbumServiceTest {
 
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.albumId()).isEqualTo(1000L);
-            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
         }

--- a/src/test/java/com/fivefy/domain/artist/controller/ArtistControllerTest.java
+++ b/src/test/java/com/fivefy/domain/artist/controller/ArtistControllerTest.java
@@ -76,8 +76,8 @@ class ArtistControllerTest extends RestDocsSupport {
             ArtistApplicationResponse response = new ArtistApplicationResponse(
                     1L,
                     "아이유",
-                    ArtistType.SOLO.name(),
-                    ApplicationStatus.PENDING.name(),
+                    ArtistType.SOLO,
+                    ApplicationStatus.PENDING,
                     LocalDateTime.of(2026, 4, 18, 12, 0, 0)
             );
 
@@ -192,15 +192,15 @@ class ArtistControllerTest extends RestDocsSupport {
                     new ArtistApplicationResponse(
                             2L,
                             "아이유",
-                            ArtistType.SOLO.name(),
-                            ApplicationStatus.PENDING.name(),
+                            ArtistType.SOLO,
+                            ApplicationStatus.PENDING,
                             LocalDateTime.of(2026, 4, 18, 12, 0, 0)
                     ),
                     new ArtistApplicationResponse(
                             1L,
                             "아이유 밴드",
-                            ArtistType.COLLABORATION.name(),
-                            ApplicationStatus.PENDING.name(),
+                            ArtistType.COLLABORATION,
+                            ApplicationStatus.PENDING,
                             LocalDateTime.of(2026, 4, 17, 12, 0, 0)
                     )
             );
@@ -242,10 +242,10 @@ class ArtistControllerTest extends RestDocsSupport {
                     applicationId,
                     1L,
                     "아이유",
-                    ArtistType.SOLO.name(),
+                    ArtistType.SOLO,
                     "가수",
                     "https://example.com/iu.jpg",
-                    ApplicationStatus.PENDING.name(),
+                    ApplicationStatus.PENDING,
                     null,
                     null,
                     null,
@@ -348,8 +348,8 @@ class ArtistControllerTest extends RestDocsSupport {
                     1L,
                     1L,
                     "아이유",
-                    ArtistType.SOLO.name(),
-                    ApplicationStatus.PENDING.name(),
+                    ArtistType.SOLO,
+                    ApplicationStatus.PENDING,
                     LocalDateTime.of(2026, 4, 18, 12, 0, 0)
             );
 
@@ -410,8 +410,8 @@ class ArtistControllerTest extends RestDocsSupport {
             ArtistApplicationApproveResponse response = new ArtistApplicationApproveResponse(
                     applicationId,
                     100L,
-                    ArtistType.SOLO.name(),
-                    ApplicationStatus.APPROVED.name(),
+                    ArtistType.SOLO,
+                    ApplicationStatus.APPROVED,
                     1L,
                     LocalDateTime.of(2026, 4, 18, 12, 0, 0)
             );
@@ -484,8 +484,8 @@ class ArtistControllerTest extends RestDocsSupport {
 
             ArtistApplicationRejectResponse response = new ArtistApplicationRejectResponse(
                     applicationId,
-                    ArtistType.SOLO.name(),
-                    ApplicationStatus.REJECTED.name(),
+                    ArtistType.SOLO,
+                    ApplicationStatus.REJECTED,
                     1L,
                     LocalDateTime.of(2026, 4, 18, 12, 0, 0),
                     "정보 부족"
@@ -592,7 +592,7 @@ class ArtistControllerTest extends RestDocsSupport {
                     new MyArtistResponse(
                             2L,
                             "아이유",
-                            ArtistType.SOLO.name(),
+                            ArtistType.SOLO,
                             "가수",
                             "https://example.com/iu.jpg",
                             LocalDateTime.of(2026, 4, 15, 10, 0, 0),
@@ -601,7 +601,7 @@ class ArtistControllerTest extends RestDocsSupport {
                     new MyArtistResponse(
                             1L,
                             "아이유 밴드",
-                            ArtistType.COLLABORATION.name(),
+                            ArtistType.COLLABORATION,
                             "프로젝트 아티스트",
                             "https://example.com/band.jpg",
                             LocalDateTime.of(2026, 4, 14, 10, 0, 0),
@@ -647,8 +647,8 @@ class ArtistControllerTest extends RestDocsSupport {
             ArtistDetailResponse response = new ArtistDetailResponse(
                     artistId,
                     "아이유",
-                    ArtistType.SOLO.name(),
-                    ArtistStatus.ACTIVE.name(),
+                    ArtistType.SOLO,
+                    ArtistStatus.ACTIVE,
                     "가수",
                     "https://example.com/iu.jpg",
                     LocalDateTime.of(2026, 4, 15, 10, 0, 0),
@@ -726,8 +726,8 @@ class ArtistControllerTest extends RestDocsSupport {
             ArtistDetailResponse response = new ArtistDetailResponse(
                     artistId,
                     "아이유 리브랜딩",
-                    ArtistType.SOLO.name(),
-                    ArtistStatus.ACTIVE.name(),
+                    ArtistType.SOLO,
+                    ArtistStatus.ACTIVE,
                     "대한민국 솔로 가수",
                     "https://example.com/new-iu.jpg",
                     LocalDateTime.of(2026, 4, 15, 10, 0, 0),
@@ -899,8 +899,8 @@ class ArtistControllerTest extends RestDocsSupport {
             ArtistDetailResponse response = new ArtistDetailResponse(
                     artistId,
                     "아이유",
-                    ArtistType.SOLO.name(),
-                    ArtistStatus.ACTIVE.name(),
+                    ArtistType.SOLO,
+                    ArtistStatus.ACTIVE,
                     "가수",
                     "https://example.com/iu.jpg",
                     LocalDateTime.of(2026, 4, 15, 10, 0, 0),
@@ -1026,8 +1026,8 @@ class ArtistControllerTest extends RestDocsSupport {
             ArtistDetailResponse response = new ArtistDetailResponse(
                     artistId,
                     "아이유",
-                    ArtistType.SOLO.name(),
-                    ArtistStatus.INACTIVE.name(),
+                    ArtistType.SOLO,
+                    ArtistStatus.INACTIVE,
                     "가수",
                     "https://example.com/iu.jpg",
                     LocalDateTime.of(2026, 4, 15, 10, 0, 0),

--- a/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
@@ -118,8 +118,8 @@ class ArtistServiceTest {
 
             assertThat(response.applicationId()).isEqualTo(1L);
             assertThat(response.requestedName()).isEqualTo("아이유");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
             assertThat(response.createdAt()).isEqualTo(
                     LocalDateTime.of(2026, 4, 14, 22, 30, 0)
             );
@@ -293,10 +293,10 @@ class ArtistServiceTest {
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.requesterUserId()).isEqualTo(userId);
             assertThat(response.requestedName()).isEqualTo("아이유");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
             assertThat(response.bio()).isEqualTo("가수");
             assertThat(response.profileImageUrl()).isEqualTo("https://example.com/iu.jpg");
-            assertThat(response.status()).isEqualTo("PENDING");
+            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
             assertThat(response.reviewedByAdminId()).isNull();
             assertThat(response.reviewedAt()).isNull();
             assertThat(response.rejectionReason()).isNull();
@@ -344,8 +344,8 @@ class ArtistServiceTest {
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.requesterUserId()).isEqualTo(1L);
             assertThat(response.requestedName()).isEqualTo("아이유");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo("PENDING");
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
 
             verify(artistApplicationRepository, times(1)).findById(applicationId);
             verify(userRepository, times(1)).findById(userId);
@@ -491,7 +491,7 @@ class ArtistServiceTest {
                     artistService.getArtistApplications(ApplicationStatus.PENDING, pageable);
 
             assertThat(response.content()).hasSize(1);
-            assertThat(response.content().get(0).status()).isEqualTo(ApplicationStatus.PENDING.name());
+            assertThat(response.content().get(0).status()).isEqualTo(ApplicationStatus.PENDING);
             assertThat(response.totalElements()).isEqualTo(1);
         }
 
@@ -550,8 +550,8 @@ class ArtistServiceTest {
 
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.artistId()).isEqualTo(100L);
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
         }
@@ -624,8 +624,8 @@ class ArtistServiceTest {
                     artistService.rejectArtistApplication(adminId, applicationId, request);
 
             assertThat(response.applicationId()).isEqualTo(applicationId);
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo(ApplicationStatus.REJECTED.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ApplicationStatus.REJECTED);
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
             assertThat(response.rejectionReason()).isEqualTo("정보 부족");
@@ -727,7 +727,7 @@ class ArtistServiceTest {
             assertThat(response).hasSize(2);
             assertThat(response.get(0).artistId()).isEqualTo(2L);
             assertThat(response.get(0).name()).isEqualTo("아이유");
-            assertThat(response.get(0).artistType()).isEqualTo(ArtistType.SOLO.name());
+            assertThat(response.get(0).artistType()).isEqualTo(ArtistType.SOLO);
             assertThat(response.get(0).bio()).isEqualTo("가수");
             assertThat(response.get(0).profileImageUrl()).isEqualTo("https://example.com/iu.jpg");
             assertThat(response.get(0).createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 15, 10, 0, 0));
@@ -735,7 +735,7 @@ class ArtistServiceTest {
 
             assertThat(response.get(1).artistId()).isEqualTo(1L);
             assertThat(response.get(1).name()).isEqualTo("아이유 밴드");
-            assertThat(response.get(1).artistType()).isEqualTo(ArtistType.COLLABORATION.name());
+            assertThat(response.get(1).artistType()).isEqualTo(ArtistType.COLLABORATION);
             assertThat(response.get(1).bio()).isEqualTo("프로젝트 아티스트");
             assertThat(response.get(1).profileImageUrl()).isEqualTo("https://example.com/band.jpg");
             assertThat(response.get(1).createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 14, 10, 0, 0));
@@ -802,8 +802,8 @@ class ArtistServiceTest {
             // then
             assertThat(response.artistId()).isEqualTo(artistId);
             assertThat(response.name()).isEqualTo("아이유");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo(ArtistStatus.ACTIVE.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ArtistStatus.ACTIVE);
 
             verify(artistRepository, times(1)).findById(artistId);
         }
@@ -890,9 +890,9 @@ class ArtistServiceTest {
             // then
             assertThat(response.artistId()).isEqualTo(artistId);
             assertThat(response.name()).isEqualTo("아이유 리브랜딩");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
             assertThat(response.bio()).isEqualTo("대한민국 솔로 가수");
-            assertThat(response.status()).isEqualTo(ArtistStatus.ACTIVE.name());
+            assertThat(response.status()).isEqualTo(ArtistStatus.ACTIVE);
             assertThat(response.profileImageUrl()).isEqualTo("https://example.com/new-iu.jpg");
             assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 15, 10, 0, 0));
 
@@ -1002,8 +1002,8 @@ class ArtistServiceTest {
             // then
             assertThat(response.artistId()).isEqualTo(artistId);
             assertThat(response.name()).isEqualTo("아이유 리브랜딩");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo(ArtistStatus.INACTIVE.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ArtistStatus.INACTIVE);
             assertThat(response.bio()).isEqualTo("대한민국 솔로 가수");
             assertThat(response.profileImageUrl()).isEqualTo("https://example.com/new-iu.jpg");
 
@@ -1161,8 +1161,8 @@ class ArtistServiceTest {
             // then
             assertThat(response.artistId()).isEqualTo(artistId);
             assertThat(response.name()).isEqualTo("아이유");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo(ArtistStatus.ACTIVE.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ArtistStatus.ACTIVE);
             assertThat(response.bio()).isEqualTo("가수");
             assertThat(response.profileImageUrl()).isEqualTo("https://example.com/iu.jpg");
             assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 15, 10, 0, 0));
@@ -1275,8 +1275,8 @@ class ArtistServiceTest {
             // then
             assertThat(response.artistId()).isEqualTo(artistId);
             assertThat(response.name()).isEqualTo("아이유");
-            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO.name());
-            assertThat(response.status()).isEqualTo(ArtistStatus.INACTIVE.name());
+            assertThat(response.artistType()).isEqualTo(ArtistType.SOLO);
+            assertThat(response.status()).isEqualTo(ArtistStatus.INACTIVE);
             assertThat(response.bio()).isEqualTo("가수");
             assertThat(response.profileImageUrl()).isEqualTo("https://example.com/iu.jpg");
             assertThat(artist.getStatus()).isEqualTo(ArtistStatus.INACTIVE);

--- a/src/test/java/com/fivefy/domain/track/controller/TrackApplicationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/track/controller/TrackApplicationControllerTest.java
@@ -850,8 +850,6 @@ class TrackApplicationControllerTest extends RestDocsSupport {
         return new FieldDescriptor[]{
                 fieldWithPath("data.applicationId").type(NUMBER).description("신청 ID"),
                 fieldWithPath("data.trackType").type(STRING).description("트랙 유형"),
-                fieldWithPath("data.artistId").type(NULL).optional().description("아티스트 ID (자유 창작은 없음)"),
-                fieldWithPath("data.albumId").type(NULL).optional().description("앨범 ID (자유 창작은 없음)"),
                 fieldWithPath("data.title").type(STRING).description("트랙 제목"),
                 fieldWithPath("data.status").type(STRING).description("신청 상태"),
                 fieldWithPath("data.createdAt").type(STRING).description("신청 생성 시각")

--- a/src/test/java/com/fivefy/domain/track/controller/TrackApplicationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/track/controller/TrackApplicationControllerTest.java
@@ -1,0 +1,872 @@
+package com.fivefy.domain.track.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.enums.ApplicationStatus;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.common.filter.LastActiveAtFilter;
+import com.fivefy.domain.track.dto.request.FreeTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest;
+import com.fivefy.domain.track.dto.request.TrackApplicationRejectRequest;
+import com.fivefy.domain.track.dto.response.*;
+import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
+import com.fivefy.domain.track.enums.TrackType;
+import com.fivefy.domain.track.service.TrackService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * TrackApplicationController 웹 계층 테스트 및 REST Docs 문서화
+ */
+@WebMvcTest(TrackApplicationController.class)
+class TrackApplicationControllerTest extends RestDocsSupport {
+
+    @MockitoBean
+    private TrackService trackService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private LastActiveAtFilter lastActiveAtFilter;
+
+    @Nested
+    @WithMockUser
+    @DisplayName("자유 창작 트랙 등록 신청 API")
+    class CreateFreeTrackApplication {
+
+        @Test
+        @DisplayName("자유 창작 트랙 등록 신청 성공")
+        void createFreeTrackApplication_success() throws Exception {
+            FreeTrackApplicationCreateRequest request = new FreeTrackApplicationCreateRequest(
+                    "밤편지 AI 버전",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L
+            );
+
+            TrackApplicationResponse response = new TrackApplicationResponse(
+                    1L,
+                    TrackType.FREE_CREATION,
+                    null,
+                    null,
+                    "밤편지 AI 버전",
+                    ApplicationStatus.PENDING,
+                    LocalDateTime.of(2026, 4, 19, 18, 0, 0)
+            );
+
+            given(trackService.createFreeTrackApplication(any(), any(FreeTrackApplicationCreateRequest.class)))
+                    .willReturn(response);
+
+            mockMvc.perform(post("/api/track-applications/free-creations")
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("자유 창작 트랙 등록 신청 성공"))
+                    .andExpect(jsonPath("$.data.applicationId").value(1L))
+                    .andDo(document("track-applications-free-creations-create",
+                            requestFields(
+                                    freeTrackApplicationCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    trackApplicationResponseFieldsForFreeCreation()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("제목 없이 생성 요청 시 400 반환")
+        void createFreeTrackApplication_fail_withoutTitle() throws Exception {
+            FreeTrackApplicationCreateRequest request = new FreeTrackApplicationCreateRequest(
+                    "",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L
+            );
+
+            mockMvc.perform(post("/api/track-applications/free-creations")
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("track-applications-free-creations-create-invalid",
+                            requestFields(
+                                    fieldWithPath("title").type(STRING).description("트랙 제목 (값 없음)"),
+                                    fieldWithPath("lyrics").type(STRING).description("가사"),
+                                    fieldWithPath("genre").type(STRING).description("장르"),
+                                    fieldWithPath("audioUrl").type(STRING).description("오디오 URL"),
+                                    fieldWithPath("durationSec").type(NUMBER).description("재생 시간(초)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("중복 신청 시 409 반환")
+        void createFreeTrackApplication_fail_whenAlreadyExists() throws Exception {
+            FreeTrackApplicationCreateRequest request = new FreeTrackApplicationCreateRequest(
+                    "밤편지 AI 버전",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    210L
+            );
+
+            given(trackService.createFreeTrackApplication(any(), any(FreeTrackApplicationCreateRequest.class)))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS
+                    ));
+
+            mockMvc.perform(post("/api/track-applications/free-creations")
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS.getMessage()
+                    ))
+                    .andDo(document("track-applications-free-creations-create-duplicate",
+                            requestFields(
+                                    freeTrackApplicationCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+
+
+    @Nested
+    @WithMockUser
+    @DisplayName("정식 발매 트랙 등록 신청 API")
+    class CreateOfficialTrackApplication {
+
+        @Test
+        @DisplayName("정식 발매 트랙 등록 신청 성공")
+        void createOfficialTrackApplication_success() throws Exception {
+            OfficialTrackApplicationCreateRequest request = new OfficialTrackApplicationCreateRequest(
+                    10L,
+                    100L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+
+            TrackApplicationResponse response = new TrackApplicationResponse(
+                    1L,
+                    TrackType.OFFICIAL_RELEASE,
+                    10L,
+                    100L,
+                    "밤편지",
+                    ApplicationStatus.PENDING,
+                    LocalDateTime.of(2026, 4, 19, 18, 0, 0)
+            );
+
+            given(trackService.createOfficialTrackApplication(any(), any(OfficialTrackApplicationCreateRequest.class)))
+                    .willReturn(response);
+
+            mockMvc.perform(post("/api/track-applications/official-releases")
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("정식 발매 트랙 등록 신청 성공"))
+                    .andExpect(jsonPath("$.data.applicationId").value(1L))
+                    .andExpect(jsonPath("$.data.trackType").value("OFFICIAL_RELEASE"))
+                    .andDo(document("track-applications-official-releases-create",
+                            requestFields(
+                                    officialTrackApplicationCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    trackApplicationResponseFieldsForOfficialRelease()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("제목 없이 생성 요청 시 400 반환")
+        void createOfficialTrackApplication_fail_withoutTitle() throws Exception {
+            OfficialTrackApplicationCreateRequest request = new OfficialTrackApplicationCreateRequest(
+                    10L,
+                    100L,
+                    1L,
+                    "",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+
+            mockMvc.perform(post("/api/track-applications/official-releases")
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("track-applications-official-releases-create-invalid",
+                            requestFields(
+                                    fieldWithPath("artistId").type(NUMBER).description("아티스트 ID"),
+                                    fieldWithPath("albumId").type(NUMBER).description("앨범 ID"),
+                                    fieldWithPath("trackNumber").type(NUMBER).description("트랙 번호"),
+                                    fieldWithPath("title").type(STRING).description("트랙 제목 (값 없음)"),
+                                    fieldWithPath("lyrics").type(STRING).description("가사"),
+                                    fieldWithPath("genre").type(STRING).description("장르"),
+                                    fieldWithPath("audioUrl").type(STRING).description("오디오 URL"),
+                                    fieldWithPath("durationSec").type(NUMBER).description("재생 시간(초)"),
+                                    fieldWithPath("featuredArtistText").type(STRING).description("피처링 아티스트 정보"),
+                                    fieldWithPath("publishDelayDays").type(NUMBER).description("공개 예약 일수 (0~7)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("중복 신청 시 409 반환")
+        void createOfficialTrackApplication_fail_whenAlreadyExists() throws Exception {
+            OfficialTrackApplicationCreateRequest request = new OfficialTrackApplicationCreateRequest(
+                    10L,
+                    100L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3
+            );
+
+            given(trackService.createOfficialTrackApplication(any(), any(OfficialTrackApplicationCreateRequest.class)))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS
+                    ));
+
+            mockMvc.perform(post("/api/track-applications/official-releases")
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS.getMessage()
+                    ))
+                    .andDo(document("track-applications-official-releases-create-duplicate",
+                            requestFields(
+                                    officialTrackApplicationCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser
+    @DisplayName("내 트랙 등록 신청 목록 조회 API")
+    class GetMyTrackApplications {
+
+        @Test
+        @DisplayName("내 트랙 등록 신청 목록 조회 성공")
+        void getMyTrackApplications_success() throws Exception {
+            List<TrackApplicationResponse> response = List.of(
+                    new TrackApplicationResponse(
+                            2L,
+                            TrackType.OFFICIAL_RELEASE,
+                            10L,
+                            100L,
+                            "두 번째 신청",
+                            ApplicationStatus.PENDING,
+                            LocalDateTime.of(2026, 4, 16, 16, 0, 0)
+                    ),
+                    new TrackApplicationResponse(
+                            1L,
+                            TrackType.FREE_CREATION,
+                            null,
+                            null,
+                            "첫 번째 신청",
+                            ApplicationStatus.PENDING,
+                            LocalDateTime.of(2026, 4, 15, 16, 0, 0)
+                    )
+            );
+
+            given(trackService.getMyTrackApplications(any())).willReturn(response);
+
+            mockMvc.perform(get("/api/track-applications/me"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("내 트랙 등록 신청 목록 조회 성공"))
+                    .andExpect(jsonPath("$.data[0].applicationId").value(2L))
+                    .andExpect(jsonPath("$.data[0].title").value("두 번째 신청"))
+                    .andDo(document("track-applications-me-get",
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    fieldWithPath("data").type(ARRAY).description("내 트랙 등록 신청 목록"),
+                                    fieldWithPath("data[].applicationId").type(NUMBER).description("신청 ID"),
+                                    fieldWithPath("data[].trackType").type(STRING).description("트랙 유형"),
+                                    fieldWithPath("data[].artistId").type(VARIES).optional().description("아티스트 ID"),
+                                    fieldWithPath("data[].albumId").type(VARIES).optional().description("앨범 ID"),
+                                    fieldWithPath("data[].title").type(STRING).description("트랙 제목"),
+                                    fieldWithPath("data[].status").type(STRING).description("신청 상태"),
+                                    fieldWithPath("data[].createdAt").type(STRING).description("신청 생성 시각")
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser
+    @DisplayName("트랙 등록 신청 상세 조회 API")
+    class GetTrackApplication {
+
+        @Test
+        @DisplayName("트랙 등록 신청 상세 조회 성공")
+        void getTrackApplication_success() throws Exception {
+            Long applicationId = 100L;
+
+            TrackApplicationDetailResponse response = new TrackApplicationDetailResponse(
+                    applicationId,
+                    1L,
+                    TrackType.OFFICIAL_RELEASE,
+                    10L,
+                    100L,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    3,
+                    ApplicationStatus.PENDING,
+                    null,
+                    null,
+                    null,
+                    LocalDateTime.of(2026, 4, 19, 18, 0, 0),
+                    LocalDateTime.of(2026, 4, 19, 18, 0, 0)
+            );
+
+            given(trackService.getTrackApplication(any(), eq(applicationId)))
+                    .willReturn(response);
+
+            mockMvc.perform(get("/api/track-applications/{applicationId}", applicationId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 등록 신청 상세 조회 성공"))
+                    .andExpect(jsonPath("$.data.applicationId").value(applicationId))
+                    .andExpect(jsonPath("$.data.title").value("밤편지"))
+                    .andDo(document("track-applications-get",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    fieldWithPath("data.applicationId").type(NUMBER).description("신청 ID"),
+                                    fieldWithPath("data.requesterUserId").type(NUMBER).description("신청자 ID"),
+                                    fieldWithPath("data.trackType").type(STRING).description("트랙 유형"),
+                                    fieldWithPath("data.artistId").type(NUMBER).description("아티스트 ID"),
+                                    fieldWithPath("data.albumId").type(NUMBER).description("앨범 ID"),
+                                    fieldWithPath("data.trackNumber").type(NUMBER).description("트랙 번호"),
+                                    fieldWithPath("data.title").type(STRING).description("트랙 제목"),
+                                    fieldWithPath("data.lyrics").type(STRING).description("가사"),
+                                    fieldWithPath("data.genre").type(STRING).description("장르"),
+                                    fieldWithPath("data.audioUrl").type(STRING).description("오디오 URL"),
+                                    fieldWithPath("data.durationSec").type(NUMBER).description("재생 시간(초)"),
+                                    fieldWithPath("data.featuredArtistText").type(STRING).description("피처링 아티스트 정보"),
+                                    fieldWithPath("data.publishDelayDays").type(NUMBER).description("공개 예약 일수"),
+                                    fieldWithPath("data.status").type(STRING).description("신청 상태"),
+                                    fieldWithPath("data.reviewedByAdminId").type(NULL).description("검토 관리자 ID"),
+                                    fieldWithPath("data.reviewedAt").type(NULL).description("검토 시각"),
+                                    fieldWithPath("data.rejectionReason").type(NULL).description("거절 사유"),
+                                    fieldWithPath("data.createdAt").type(STRING).description("신청 생성 시각"),
+                                    fieldWithPath("data.updatedAt").type(STRING).description("신청 수정 시각")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("다른 사용자의 신청 조회 시 403 반환")
+        void getTrackApplication_fail_forbidden() throws Exception {
+            Long applicationId = 100L;
+
+            given(trackService.getTrackApplication(any(), eq(applicationId)))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN
+                    ));
+
+            mockMvc.perform(get("/api/track-applications/{applicationId}", applicationId))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN.getMessage()
+                    ))
+                    .andDo(document("track-applications-get-forbidden",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청 조회 시 404 반환")
+        void getTrackApplication_fail_notFound() throws Exception {
+            Long applicationId = 999L;
+
+            given(trackService.getTrackApplication(any(), eq(applicationId)))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND
+                    ));
+
+            mockMvc.perform(get("/api/track-applications/{applicationId}", applicationId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage()
+                    ))
+                    .andDo(document("track-applications-get-not-found",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("트랙 등록 신청 목록 조회 API")
+    class GetTrackApplications {
+
+        @Test
+        @DisplayName("트랙 등록 신청 목록 조회 성공")
+        void getTrackApplications_success() throws Exception {
+            TrackApplicationListResponse content = new TrackApplicationListResponse(
+                    1L,
+                    1L,
+                    TrackType.OFFICIAL_RELEASE,
+                    "첫 번째 신청",
+                    ApplicationStatus.PENDING,
+                    LocalDateTime.of(2026, 4, 19, 18, 0, 0)
+            );
+
+            PageResponse<TrackApplicationListResponse> response = PageResponse.from(
+                    new PageImpl<>(List.of(content), PageRequest.of(0, 10), 1)
+            );
+
+            given(trackService.getTrackApplications(eq(null), any(Pageable.class)))
+                    .willReturn(response);
+
+            mockMvc.perform(get("/api/admin/track-applications")
+                            .param("page", "0")
+                            .param("size", "10")
+                            .param("sort", "createdAt,asc"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 등록 신청 목록 조회 성공"))
+                    .andExpect(jsonPath("$.data.content[0].applicationId").value(1L))
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(10))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andDo(document("admin-track-applications-get",
+                            queryParameters(
+                                    parameterWithName("status").optional().description("신청 상태"),
+                                    parameterWithName("page").optional().description("페이지 번호"),
+                                    parameterWithName("size").optional().description("페이지 크기"),
+                                    parameterWithName("sort").optional().description("정렬 조건")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    fieldWithPath("data.content").type(ARRAY).description("신청 목록"),
+                                    fieldWithPath("data.content[].applicationId").type(NUMBER).description("신청 ID"),
+                                    fieldWithPath("data.content[].requesterUserId").type(NUMBER).description("신청자 ID"),
+                                    fieldWithPath("data.content[].trackType").type(STRING).description("트랙 유형"),
+                                    fieldWithPath("data.content[].title").type(STRING).description("트랙 제목"),
+                                    fieldWithPath("data.content[].status").type(STRING).description("신청 상태"),
+                                    fieldWithPath("data.content[].createdAt").type(STRING).description("신청 생성 시각")
+                            ).and(
+                                    pageResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("트랙 등록 신청 승인 API")
+    class ApproveTrackApplication {
+
+        @Test
+        @DisplayName("트랙 등록 신청 승인 성공")
+        void approveTrackApplication_success() throws Exception {
+            Long applicationId = 10L;
+
+            TrackApplicationApproveResponse response = new TrackApplicationApproveResponse(
+                    applicationId,
+                    1000L,
+                    ApplicationStatus.APPROVED,
+                    1L,
+                    LocalDateTime.of(2026, 4, 20, 12, 0, 0)
+            );
+
+            given(trackService.approveTrackApplication(any(), eq(applicationId)))
+                    .willReturn(response);
+
+            mockMvc.perform(post("/api/admin/track-applications/{applicationId}/approve", applicationId)
+                            .with(csrf().asHeader()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 등록 신청 승인 성공"))
+                    .andExpect(jsonPath("$.data.applicationId").value(applicationId))
+                    .andExpect(jsonPath("$.data.trackId").value(1000L))
+                    .andDo(document("admin-track-applications-approve",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    fieldWithPath("data.applicationId").type(NUMBER).description("신청 ID"),
+                                    fieldWithPath("data.trackId").type(NUMBER).description("생성된 트랙 ID"),
+                                    fieldWithPath("data.status").type(STRING).description("신청 상태"),
+                                    fieldWithPath("data.reviewedByAdminId").type(NUMBER).description("승인 관리자 ID"),
+                                    fieldWithPath("data.reviewedAt").type(STRING).description("승인 시각")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("이미 처리된 신청 승인 시 400 반환")
+        void approveTrackApplication_fail_whenAlreadyProcessed() throws Exception {
+            Long applicationId = 10L;
+
+            given(trackService.approveTrackApplication(any(), eq(applicationId)))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED
+                    ));
+
+            mockMvc.perform(post("/api/admin/track-applications/{applicationId}/approve", applicationId)
+                            .with(csrf().asHeader()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED.getMessage()
+                    ))
+                    .andDo(document("admin-track-applications-approve-already-processed",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청 승인 시 404 반환")
+        void approveTrackApplication_fail_notFound() throws Exception {
+            Long applicationId = 999L;
+
+            given(trackService.approveTrackApplication(any(), eq(applicationId)))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND
+                    ));
+
+            mockMvc.perform(post("/api/admin/track-applications/{applicationId}/approve", applicationId)
+                            .with(csrf().asHeader()))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage()
+                    ))
+                    .andDo(document("admin-track-applications-approve-not-found",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("트랙 등록 신청 거절 API")
+    class RejectTrackApplication {
+
+        @Test
+        @DisplayName("트랙 등록 신청 거절 성공")
+        void rejectTrackApplication_success() throws Exception {
+            Long applicationId = 10L;
+            TrackApplicationRejectRequest request =
+                    new TrackApplicationRejectRequest("오디오 정보가 부족합니다");
+
+            TrackApplicationRejectResponse response = new TrackApplicationRejectResponse(
+                    applicationId,
+                    ApplicationStatus.REJECTED,
+                    1L,
+                    LocalDateTime.of(2026, 4, 20, 12, 0, 0),
+                    "오디오 정보가 부족합니다"
+            );
+
+            given(trackService.rejectTrackApplication(any(), eq(applicationId), eq(request.rejectionReason())))
+                    .willReturn(response);
+
+            mockMvc.perform(post("/api/admin/track-applications/{applicationId}/reject", applicationId)
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 등록 신청 거절 성공"))
+                    .andExpect(jsonPath("$.data.applicationId").value(applicationId))
+                    .andExpect(jsonPath("$.data.rejectionReason").value("오디오 정보가 부족합니다"))
+                    .andDo(document("admin-track-applications-reject",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("rejectionReason").type(STRING).description("거절 사유")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    fieldWithPath("data.applicationId").type(NUMBER).description("신청 ID"),
+                                    fieldWithPath("data.status").type(STRING).description("신청 상태"),
+                                    fieldWithPath("data.reviewedByAdminId").type(NUMBER).description("거절 관리자 ID"),
+                                    fieldWithPath("data.reviewedAt").type(STRING).description("거절 시각"),
+                                    fieldWithPath("data.rejectionReason").type(STRING).description("거절 사유")
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("거절 사유 없이 요청 시 400 반환")
+        void rejectTrackApplication_fail_withoutReason() throws Exception {
+            TrackApplicationRejectRequest request =
+                    new TrackApplicationRejectRequest("");
+
+            mockMvc.perform(post("/api/admin/track-applications/{applicationId}/reject", 10L)
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("admin-track-applications-reject-invalid",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("rejectionReason").type(STRING).description("거절 사유 (값 없음)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("이미 처리된 신청 거절 시 400 반환")
+        void rejectTrackApplication_fail_whenAlreadyProcessed() throws Exception {
+            Long applicationId = 10L;
+            TrackApplicationRejectRequest request =
+                    new TrackApplicationRejectRequest("사유");
+
+            given(trackService.rejectTrackApplication(any(), eq(applicationId), any()))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED
+                    ));
+
+            mockMvc.perform(post("/api/admin/track-applications/{applicationId}/reject", applicationId)
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED.getMessage()
+                    ))
+                    .andDo(document("admin-track-applications-reject-already-processed",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("rejectionReason").type(STRING).description("거절 사유")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 신청 거절 시 404 반환")
+        void rejectTrackApplication_fail_notFound() throws Exception {
+            Long applicationId = 999L;
+            TrackApplicationRejectRequest request =
+                    new TrackApplicationRejectRequest("사유");
+
+            given(trackService.rejectTrackApplication(any(), eq(applicationId), any()))
+                    .willThrow(new BusinessException(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND
+                    ));
+
+            mockMvc.perform(post("/api/admin/track-applications/{applicationId}/reject", applicationId)
+                            .with(csrf().asHeader())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND.getMessage()
+                    ))
+                    .andDo(document("admin-track-applications-reject-not-found",
+                            pathParameters(
+                                    parameterWithName("applicationId").description("신청 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("rejectionReason").type(STRING).description("거절 사유")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    private FieldDescriptor[] baseSuccessResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("응답 메시지")
+        };
+    }
+
+    private FieldDescriptor[] baseErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("에러 메시지")
+        };
+    }
+
+    private FieldDescriptor[] validationErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+        };
+    }
+
+    private FieldDescriptor[] pageResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.page").type(NUMBER).description("현재 페이지"),
+                fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
+                fieldWithPath("data.totalElements").type(NUMBER).description("전체 데이터 수"),
+                fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수")
+        };
+    }
+
+    private FieldDescriptor[] freeTrackApplicationCreateRequestFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("title").type(STRING).description("트랙 제목"),
+                fieldWithPath("lyrics").type(STRING).description("가사"),
+                fieldWithPath("genre").type(STRING).description("장르"),
+                fieldWithPath("audioUrl").type(STRING).description("오디오 URL"),
+                fieldWithPath("durationSec").type(NUMBER).description("재생 시간(초)")
+        };
+    }
+
+    private FieldDescriptor[] officialTrackApplicationCreateRequestFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("artistId").type(NUMBER).description("아티스트 ID"),
+                fieldWithPath("albumId").type(NUMBER).description("앨범 ID"),
+                fieldWithPath("trackNumber").type(NUMBER).description("트랙 번호"),
+                fieldWithPath("title").type(STRING).description("트랙 제목"),
+                fieldWithPath("lyrics").type(STRING).description("가사"),
+                fieldWithPath("genre").type(STRING).description("장르"),
+                fieldWithPath("audioUrl").type(STRING).description("오디오 URL"),
+                fieldWithPath("durationSec").type(NUMBER).description("재생 시간(초)"),
+                fieldWithPath("featuredArtistText").type(STRING).description("피처링 아티스트 정보"),
+                fieldWithPath("publishDelayDays").type(NUMBER).description("공개 예약 일수 (0~7)")
+        };
+    }
+
+    private FieldDescriptor[] trackApplicationResponseFieldsForFreeCreation() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.applicationId").type(NUMBER).description("신청 ID"),
+                fieldWithPath("data.trackType").type(STRING).description("트랙 유형"),
+                fieldWithPath("data.artistId").type(NULL).optional().description("아티스트 ID (자유 창작은 없음)"),
+                fieldWithPath("data.albumId").type(NULL).optional().description("앨범 ID (자유 창작은 없음)"),
+                fieldWithPath("data.title").type(STRING).description("트랙 제목"),
+                fieldWithPath("data.status").type(STRING).description("신청 상태"),
+                fieldWithPath("data.createdAt").type(STRING).description("신청 생성 시각")
+        };
+    }
+
+    private FieldDescriptor[] trackApplicationResponseFieldsForOfficialRelease() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.applicationId").type(NUMBER).description("신청 ID"),
+                fieldWithPath("data.trackType").type(STRING).description("트랙 유형"),
+                fieldWithPath("data.artistId").type(NUMBER).description("아티스트 ID"),
+                fieldWithPath("data.albumId").type(NUMBER).description("앨범 ID"),
+                fieldWithPath("data.title").type(STRING).description("트랙 제목"),
+                fieldWithPath("data.status").type(STRING).description("신청 상태"),
+                fieldWithPath("data.createdAt").type(STRING).description("신청 생성 시각")
+        };
+    }
+}

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -49,7 +48,13 @@ import static org.mockito.Mockito.when;
 /**
  * TrackService의 비즈니스 로직을 검증하는 단위 테스트
  *
- * 자유 창작 트랙 등록 신청 생성 기능을 검증한다.
+ * 자유 창작 트랙 등록 신청 생성 기능 검증
+ * 정식 발매 트랙 등록 신청 생성 기능 검증
+ * 내 트랙 등록 신청 목록 조회 기능 검증
+ * 트랙 등록 신청 상세 조회 기능 검증
+ * 트랙 등록 신청 목록 조회 기능 검증
+ * 트랙 등록 신청 승인 기능 검증
+ * 트랙 등록 신청 거절 기능 검증
  */
 @ExtendWith(MockitoExtension.class)
 class TrackServiceTest {
@@ -1102,7 +1107,7 @@ class TrackServiceTest {
 
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.trackId()).isEqualTo(1000L);
-            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
         }
@@ -1152,7 +1157,7 @@ class TrackServiceTest {
 
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.trackId()).isEqualTo(1000L);
-            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
         }
@@ -1240,7 +1245,7 @@ class TrackServiceTest {
 
             assertThat(response.applicationId()).isEqualTo(applicationId);
             assertThat(response.trackId()).isEqualTo(1000L);
-            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED.name());
+            assertThat(response.status()).isEqualTo(ApplicationStatus.APPROVED);
             assertThat(response.reviewedByAdminId()).isEqualTo(adminId);
             assertThat(response.reviewedAt()).isNotNull();
         }


### PR DESCRIPTION
## 개요

> 트랙 등록 신청 API의 컨트롤러 테스트와 REST Docs 문서화를 추가하고,  
> Artist / Album / Track 신청 응답 DTO의 enum 응답 구조를 정리

## 변경 사항

### 1. Track API REST Docs 문서 추가

- `index.adoc`에 `Track API` 섹션 추가
- 자유 창작 트랙 등록 신청 생성 문서 추가
  - 성공
  - 요청 검증 실패
  - 중복 신청
- 정식 발매 트랙 등록 신청 생성 문서 추가
  - 성공
  - 요청 검증 실패
  - 중복 신청
- 내 트랙 등록 신청 목록 조회 문서 추가
- 트랙 등록 신청 상세 조회 문서 추가
  - 성공
  - 조회 권한 없음
  - 신청 없음
- 관리자 트랙 등록 신청 목록 조회 문서 추가
- 관리자 트랙 등록 신청 승인 문서 추가
  - 성공
  - 이미 처리된 신청
  - 신청 없음
- 관리자 트랙 등록 신청 거절 문서 추가
  - 성공
  - 요청 검증 실패
  - 이미 처리된 신청
  - 신청 없음

### 2. TrackApplicationControllerTest 추가

- `TrackApplicationControllerTest` 추가
- `@WebMvcTest` + `RestDocsSupport` 기반 웹 계층 테스트 구성
- `JwtUtil`, `LastActiveAtFilter` mock 설정 추가
- MockMvc 기반 응답 검증 및 REST Docs 스니펫 생성 구성

### 3. 트랙 등록 신청 생성 API 테스트 추가

- 자유 창작 트랙 등록 신청 API 테스트 추가
  - `POST /api/track-applications/free-creations`
  - 성공
  - 요청 검증 실패
  - 중복 신청 예외

- 정식 발매 트랙 등록 신청 API 테스트 추가
  - `POST /api/track-applications/official-releases`
  - 성공
  - 요청 검증 실패
  - 중복 신청 예외

### 4. 트랙 등록 신청 조회 API 테스트 추가

- 내 트랙 등록 신청 목록 조회 API 테스트 추가
  - `GET /api/track-applications/me`
- 트랙 등록 신청 상세 조회 API 테스트 추가
  - `GET /api/track-applications/{applicationId}`
  - 성공
  - 권한 없음
  - 신청 없음

### 5. 관리자 트랙 등록 신청 처리 API 테스트 추가

- 관리자 트랙 등록 신청 목록 조회 API 테스트 추가
  - `GET /api/admin/track-applications`
  - 상태 필터 / 페이지 / 정렬 파라미터 문서화
- 관리자 트랙 등록 신청 승인 API 테스트 추가
  - `POST /api/admin/track-applications/{applicationId}/approve`
  - 성공
  - 이미 처리된 신청
  - 신청 없음
- 관리자 트랙 등록 신청 거절 API 테스트 추가
  - `POST /api/admin/track-applications/{applicationId}/reject`
  - 성공
  - 요청 검증 실패
  - 이미 처리된 신청
  - 신청 없음

### 6. 트랙 신청 응답/문서 helper 구성

- 공통 응답 필드 helper 추가
  - `baseSuccessResponseFields()`
  - `baseErrorResponseFields()`
  - `validationErrorResponseFields()`
  - `pageResponseFields()`
- 트랙 신청 요청/응답 문서 helper 추가
  - 자유 창작 신청 요청 필드
  - 정식 발매 신청 요청 필드
  - 신청 응답 필드

### 7. Artist / Album / Track 응답 DTO enum 타입 정리

- Artist 신청/상세/목록/거절/승인 응답 DTO의 문자열 응답을 enum 타입으로 변경
  - `ArtistType`
  - `ArtistStatus`
  - `ApplicationStatus`
- Album 신청 승인 응답 DTO의 `status`를 문자열에서 `ApplicationStatus`로 변경
- Track 신청 승인 응답 DTO의 `status`를 문자열에서 `ApplicationStatus`로 변경
- 관련 ControllerTest / ServiceTest assertion을 enum 기준으로 정리

### 8. 기타 정리

- `AlbumDetailResponse` 클래스 주석 추가
- `AlbumServiceTest`, `TrackServiceTest` 클래스 주석 표현 정리

## 변경 유형

- [x] 테스트 (test)
- [x] 문서 (docs)
- [x] 리팩토링 (refactor)

## 테스트 방법

1. `TrackApplicationControllerTest` 실행
2. 자유 창작 / 정식 발매 신청 생성 API의 성공 / 검증 실패 / 중복 신청 케이스 확인
3. 내 신청 목록 / 상세 조회 API의 성공 / 권한 없음 / 신청 없음 케이스 확인
4. 관리자 신청 목록 / 승인 / 거절 API의 성공 / 예외 케이스 확인
5. REST Docs 스니펫 생성 및 `index.adoc` include 구성이 정상인지 확인
6. Artist / Album / Track 관련 ControllerTest / ServiceTest에서 enum 응답 검증이 정상 동작하는지 확인

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 트랙 신청·조회·관리 관련 API 문서 추가(프리/공식 트랙 신청, 목록/상세, 관리자 승인·거절 포함)

* **Improvements**
  * API 응답의 상태·유형 필드가 명확한 Enum 형태로 표현되어 응답 안정성 개선

* **Documentation**
  * 각 엔드포인트별 요청/응답 예시 및 오류 사례(유효성 실패, 중복, 권한 없음, 미존재, 이미 처리 등) 추가

* **Tests**
  * 트랙 관련 컨트롤러·서비스 테스트 대거 추가/수정(생성, 조회, 승인/거절 및 오류 시나리오 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->