### PR TITLE
test: Notification 도메인 Service/Controller 단위테스트 추가

### DIFF
--- a/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
@@ -1,8 +1,10 @@
 package com.fivefy.domain.notification.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.notification.dto.response.NotificationGetResponse;
 import com.fivefy.domain.notification.enums.NotificationChannel;
+import com.fivefy.domain.notification.enums.NotificationErrorCode;
 import com.fivefy.domain.notification.enums.NotificationStatus;
 import com.fivefy.domain.notification.enums.NotificationType;
 import com.fivefy.domain.notification.service.NotificationService;
@@ -25,10 +27,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(NotificationController.class)
 @AutoConfigureMockMvc(addFilters = false)
@@ -46,6 +50,7 @@ class NotificationControllerTest {
     @MockitoBean
     private StringRedisTemplate stringRedisTemplate;
 
+    private static final Long USER_ID = 1L;
     private static final Long NOTIFICATION_ID = 10L;
 
     private NotificationGetResponse makeResponse() {
@@ -128,6 +133,130 @@ class NotificationControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("읽지 않은 알림 수 조회 성공"))
                     .andExpect(jsonPath("$.data").value(5));
+        }
+    }
+
+    @Nested
+    @DisplayName("단건 읽음 처리")
+    class MarkAsRead {
+
+        @Test
+        @DisplayName("읽음 처리 성공 시 200을 반환한다")
+        void markAsRead_returns200() throws Exception {
+            // given
+            doNothing().when(notificationService).markAsRead(any(), eq(NOTIFICATION_ID));
+
+            // when & then
+            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("알림 읽음 처리 성공"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림 읽음 처리 시 404를 반환한다")
+        void markAsRead_notFound_returns404() throws Exception {
+            // given
+            doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND))
+                    .when(notificationService).markAsRead(any(), eq(NOTIFICATION_ID));
+
+            // when & then
+            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("다른 유저의 알림 읽음 처리 시 403을 반환한다")
+        void markAsRead_unauthorized_returns403() throws Exception {
+            // given
+            doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED))
+                    .when(notificationService).markAsRead(any(), eq(NOTIFICATION_ID));
+
+            // when & then
+            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 읽음 처리")
+    class MarkAllAsRead {
+
+        @Test
+        @DisplayName("전체 읽음 처리 성공 시 200을 반환한다")
+        void markAllAsRead_returns200() throws Exception {
+            // given
+            doNothing().when(notificationService).markAllAsRead(any());
+
+            // when & then
+            mockMvc.perform(patch("/api/notifications/read-all"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("전체 알림 읽음 처리 성공"));
+        }
+    }
+
+    @Nested
+    @DisplayName("단건 알림 삭제")
+    class DeleteNotification {
+
+        @Test
+        @DisplayName("단건 삭제 성공 시 200을 반환한다")
+        void deleteNotification_returns200() throws Exception {
+            // given
+            doNothing().when(notificationService).deleteNotification(any(), eq(NOTIFICATION_ID));
+
+            // when & then
+            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("알림 삭제 성공"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림 삭제 시 404를 반환한다")
+        void deleteNotification_notFound_returns404() throws Exception {
+            // given
+            doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND))
+                    .when(notificationService).deleteNotification(any(), eq(NOTIFICATION_ID));
+
+            // when & then
+            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage()));
+        }
+
+        @Test
+        @DisplayName("다른 유저의 알림 삭제 시 403을 반환한다")
+        void deleteNotification_unauthorized_returns403() throws Exception {
+            // given
+            doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED))
+                    .when(notificationService).deleteNotification(any(), eq(NOTIFICATION_ID));
+
+            // when & then
+            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 알림 삭제")
+    class DeleteAllNotifications {
+
+        @Test
+        @DisplayName("전체 삭제 성공 시 200을 반환한다")
+        void deleteAllNotifications_returns200() throws Exception {
+            // given
+            doNothing().when(notificationService).deleteAllNotifications(any());
+
+            // when & then
+            mockMvc.perform(delete("/api/notifications"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("전체 알림 삭제 성공"));
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
@@ -78,7 +78,8 @@ class NotificationControllerTest {
             // when & then
             mockMvc.perform(get("/api/notifications/subscribe")
                             .accept(MediaType.TEXT_EVENT_STREAM))
-                    .andExpect(status().isOk());
+                            .andExpect(status().isOk())
+                            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM));
         }
     }
 

--- a/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,133 @@
+package com.fivefy.domain.notification.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.domain.notification.dto.response.NotificationGetResponse;
+import com.fivefy.domain.notification.enums.NotificationChannel;
+import com.fivefy.domain.notification.enums.NotificationStatus;
+import com.fivefy.domain.notification.enums.NotificationType;
+import com.fivefy.domain.notification.service.NotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotificationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private StringRedisTemplate stringRedisTemplate;
+
+    private static final Long NOTIFICATION_ID = 10L;
+
+    private NotificationGetResponse makeResponse() {
+        return new NotificationGetResponse(
+                NOTIFICATION_ID,
+                NotificationType.NEW_FOLLOWER,
+                "테스트 알림",
+                NotificationStatus.SENT,
+                NotificationChannel.IN_APP,
+                null,
+                LocalDateTime.now()
+        );
+    }
+
+    @Nested
+    @DisplayName("SSE 구독")
+    class Subscribe {
+
+        @Test
+        @DisplayName("구독 요청 시 200과 text/event-stream을 반환한다")
+        void subscribe_returns200() throws Exception {
+            // given
+            given(notificationService.subscribe(any())).willReturn(new SseEmitter());
+
+            // when & then
+            mockMvc.perform(get("/api/notifications/subscribe")
+                            .accept(MediaType.TEXT_EVENT_STREAM))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 목록 조회")
+    class GetAllNotification {
+
+        @Test
+        @DisplayName("알림 목록 조회 성공 시 200을 반환한다")
+        void getAllNotification_returns200() throws Exception {
+            // given
+            Page<NotificationGetResponse> page = new PageImpl<>(
+                    List.of(makeResponse()), PageRequest.of(0, 20), 1);
+            given(notificationService.getNotifications(any(), any())).willReturn(page);
+
+            // when & then
+            mockMvc.perform(get("/api/notifications"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("알림 목록 조회 성공"))
+                    .andExpect(jsonPath("$.data.content[0].id").value(NOTIFICATION_ID))
+                    .andExpect(jsonPath("$.data.content[0].type").value("NEW_FOLLOWER"))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+
+        @Test
+        @DisplayName("알림이 없으면 빈 목록을 반환한다")
+        void getAllNotification_empty_returnsEmptyList() throws Exception {
+            // given
+            given(notificationService.getNotifications(any(), any())).willReturn(Page.empty());
+
+            // when & then
+            mockMvc.perform(get("/api/notifications"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("읽지 않은 알림 수 조회")
+    class GetUnreadCount {
+
+        @Test
+        @DisplayName("읽지 않은 알림 수 조회 성공 시 200을 반환한다")
+        void getUnreadCount_returns200() throws Exception {
+            // given
+            given(notificationService.getUnreadCount(any())).willReturn(5L);
+
+            // when & then
+            mockMvc.perform(get("/api/notifications/unread-count"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("읽지 않은 알림 수 조회 성공"))
+                    .andExpect(jsonPath("$.data").value(5));
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
@@ -4,6 +4,7 @@ import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.notification.dto.response.NotificationGetResponse;
 import com.fivefy.domain.notification.entity.Notification;
 import com.fivefy.domain.notification.enums.NotificationChannel;
+import com.fivefy.domain.notification.enums.NotificationErrorCode;
 import com.fivefy.domain.notification.enums.NotificationStatus;
 import com.fivefy.domain.notification.enums.NotificationType;
 import com.fivefy.domain.notification.repository.NotificationRepository;
@@ -49,6 +50,8 @@ class NotificationServiceTest {
     private NotificationService notificationService;
 
     private static final Long USER_ID = 1L;
+    private static final Long OTHER_USER_ID = 2L;
+    private static final Long NOTIFICATION_ID = 10L;
 
     private Notification makeNotification(Long userId) {
         return Notification.create(userId, "테스트 알림", NotificationType.NEW_FOLLOWER, NotificationChannel.IN_APP);
@@ -167,6 +170,115 @@ class NotificationServiceTest {
             assertThatThrownBy(() -> notificationService.getNotifications(USER_ID, PageRequest.of(0, 20)))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("읽음 처리")
+    class MarkAsRead {
+
+        @Test
+        @DisplayName("단건 읽음 처리 성공 시 readAt이 설정된다")
+        void markAsRead_success() {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            given(notificationRepository.findById(NOTIFICATION_ID)).willReturn(Optional.of(notification));
+
+            // when
+            notificationService.markAsRead(USER_ID, NOTIFICATION_ID);
+
+            // then
+            assertThat(notification.isRead()).isTrue();
+            assertThat(notification.getReadAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림 읽음 처리 시 예외가 발생한다")
+        void markAsRead_notFound_throwsException() {
+            // given
+            given(notificationRepository.findById(any())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.markAsRead(USER_ID, NOTIFICATION_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("다른 유저의 알림 읽음 처리 시 예외가 발생한다")
+        void markAsRead_unauthorized_throwsException() {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            given(notificationRepository.findById(NOTIFICATION_ID)).willReturn(Optional.of(notification));
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.markAsRead(OTHER_USER_ID, NOTIFICATION_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage());
+        }
+
+        @Test
+        @DisplayName("전체 읽음 처리 시 markAllAsRead가 호출된다")
+        void markAllAsRead_success() {
+            // when
+            notificationService.markAllAsRead(USER_ID);
+
+            // then
+            verify(notificationRepository).markAllAsRead(USER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 삭제")
+    class DeleteNotification {
+
+        @Test
+        @DisplayName("단건 삭제 성공 시 delete가 호출된다")
+        void deleteNotification_success() {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            given(notificationRepository.findById(NOTIFICATION_ID)).willReturn(Optional.of(notification));
+
+            // when
+            notificationService.deleteNotification(USER_ID, NOTIFICATION_ID);
+
+            // then
+            verify(notificationRepository).delete(notification);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림 삭제 시 예외가 발생한다")
+        void deleteNotification_notFound_throwsException() {
+            // given
+            given(notificationRepository.findById(any())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.deleteNotification(USER_ID, NOTIFICATION_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("다른 유저의 알림 삭제 시 예외가 발생한다")
+        void deleteNotification_unauthorized_throwsException() {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            given(notificationRepository.findById(NOTIFICATION_ID)).willReturn(Optional.of(notification));
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.deleteNotification(OTHER_USER_ID, NOTIFICATION_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage());
+        }
+
+        @Test
+        @DisplayName("전체 삭제 시 deleteAllByUserId가 호출된다")
+        void deleteAllNotifications_success() {
+            // when
+            notificationService.deleteAllNotifications(USER_ID);
+
+            // then
+            verify(notificationRepository).deleteAllByUserId(USER_ID);
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
@@ -73,6 +73,7 @@ class NotificationServiceTest {
             // then
             assertThat(emitter).isNotNull();
             verify(sseEmitterRepository).save(eq(USER_ID), any(SseEmitter.class));
+            verify(notificationRepository).countByUserIdAndReadAtIsNull(USER_ID);
         }
     }
 

--- a/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,172 @@
+package com.fivefy.domain.notification.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.notification.dto.response.NotificationGetResponse;
+import com.fivefy.domain.notification.entity.Notification;
+import com.fivefy.domain.notification.enums.NotificationChannel;
+import com.fivefy.domain.notification.enums.NotificationStatus;
+import com.fivefy.domain.notification.enums.NotificationType;
+import com.fivefy.domain.notification.repository.NotificationRepository;
+import com.fivefy.domain.notification.repository.SseEmitterRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private SseEmitterRepository sseEmitterRepository;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private static final Long USER_ID = 1L;
+
+    private Notification makeNotification(Long userId) {
+        return Notification.create(userId, "테스트 알림", NotificationType.NEW_FOLLOWER, NotificationChannel.IN_APP);
+    }
+
+    @Nested
+    @DisplayName("SSE 구독")
+    class Subscribe {
+
+        @Test
+        @DisplayName("구독 시 SseEmitter를 저장하고 초기 이벤트를 전송한다")
+        void subscribe_savesEmitterAndSendsConnectEvent() throws Exception {
+            // given
+            given(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).willReturn(3L);
+
+            // when
+            SseEmitter emitter = notificationService.subscribe(USER_ID);
+
+            // then
+            assertThat(emitter).isNotNull();
+            verify(sseEmitterRepository).save(eq(USER_ID), any(SseEmitter.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 발송")
+    class Send {
+
+        @Test
+        @DisplayName("SSE 미연결 상태에서 알림 저장 시 QUEUED 상태를 유지한다")
+        void send_noConnection_savesAsQueued() {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            given(notificationRepository.save(any())).willReturn(notification);
+            given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of());
+
+            // when
+            notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
+
+            // then
+            verify(notificationRepository, times(1)).save(any()); // 첫 저장만 호출
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.QUEUED);
+        }
+
+        @Test
+        @DisplayName("SSE 연결된 상태에서 전송 성공 시 SENT 상태로 저장된다")
+        void send_withConnection_marksAsSent() throws Exception {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            SseEmitter mockEmitter = mock(SseEmitter.class);
+
+            given(notificationRepository.save(any())).willReturn(notification);
+            given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of(mockEmitter));
+
+            // when
+            notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
+
+            // then
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.SENT);
+            verify(notificationRepository, times(2)).save(any()); // 첫 저장 + SENT 업데이트
+        }
+
+        @Test
+        @DisplayName("SSE 전송 실패 시 FAILED 상태로 저장하고 emitter를 제거한다")
+        void send_ioException_marksAsFailedAndDeletesEmitter() throws Exception {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            SseEmitter mockEmitter = mock(SseEmitter.class);
+
+            given(notificationRepository.save(any())).willReturn(notification);
+            given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of(mockEmitter));
+            doThrow(new IOException("전송 실패")).when(mockEmitter).send(any(SseEmitter.SseEventBuilder.class));
+
+            // when
+            notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
+
+            // then
+            assertThat(notification.getStatus()).isEqualTo(NotificationStatus.FAILED);
+            verify(notificationRepository, times(2)).save(any()); // 첫 저장 + FAILED 업데이트
+            verify(sseEmitterRepository).delete(eq(USER_ID), eq(mockEmitter));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 목록 조회")
+    class GetNotifications {
+
+        @Test
+        @DisplayName("알림 목록을 페이징하여 반환한다")
+        void getNotifications_returnsPage() {
+            // given
+            User mockUser = mock(User.class);
+            given(mockUser.getId()).willReturn(USER_ID);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(mockUser));
+
+            Notification notification = makeNotification(USER_ID);
+            Pageable pageable = PageRequest.of(0, 20);
+            Page<Notification> page = new PageImpl<>(List.of(notification), pageable, 1);
+            given(notificationRepository.findAllByUserId(USER_ID, pageable)).willReturn(page);
+
+            // when
+            Page<NotificationGetResponse> result = notificationService.getNotifications(USER_ID, pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getTotalElements()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저 조회 시 예외가 발생한다")
+        void getNotifications_userNotFound_throwsException() {
+            // given
+            given(userRepository.findById(any())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.getNotifications(USER_ID, PageRequest.of(0, 20)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 개요
알림 도메인 단위 테스트를 추가합니다.
NotificationService와 NotificationController의 핵심 로직과 예외 케이스를 검증합니다.

## 변경 사항
- `NotificationServiceTest` 추가
  - SSE 구독 시 emitter 저장 및 초기 이벤트 전송 검증
  - 미연결/연결/전송실패 상태별 QUEUED/SENT/FAILED 저장 검증
  - 알림 목록 페이징 조회 및 유저 없음 예외 검증
  - 단건/전체 읽음 처리, 알림 없음/권한 없음 예외 검증
  - 단건/전체 삭제, 알림 없음/권한 없음 예외 검증
- `NotificationControllerTest` 추가
  - SSE 구독, 알림 목록 조회, 읽지 않은 수 조회 검증
  - 단건/전체 읽음 처리 성공, 404/403 예외 검증
  - 단건/전체 삭제 성공, 404/403 예외 검증

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 알림 시스템에 대한 포괄적인 테스트 추가
  * SSE 구독과 이벤트 스트림 응답 검증
  * 알림 목록 조회(페이징 포함) 및 읽지 않은 수 조회 검증
  * 단일/전체 읽음 처리 및 단건/전체 삭제 흐름 검증
  * 발송 성공·실패 시 상태 전환 및 예외 상황(미존재·권한) 처리 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->