### PR TITLE
feat: 앨범 상세 조회에 수록곡 포함 및 트랙 공개 조건 검증 강화

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -721,8 +721,6 @@ include::{snippets}/tracks-get-not-found/http-request.adoc[]
 include::{snippets}/tracks-get-not-found/http-response.adoc[]
 include::{snippets}/tracks-get-not-found/response-fields.adoc[]
 
----
-
 ==== 에러 케이스 - 비공개 트랙
 
 include::{snippets}/tracks-get-unpublished/http-request.adoc[]

--- a/src/main/java/com/fivefy/domain/album/dto/response/AlbumDetailResponse.java
+++ b/src/main/java/com/fivefy/domain/album/dto/response/AlbumDetailResponse.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.album.dto.response;
 import com.fivefy.domain.album.entity.Album;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 앨범 상세 조회 응답 DTO
@@ -16,9 +17,13 @@ public record AlbumDetailResponse(
         String coverImageUrl,
         Long trackCount,
         Long totalDurationSec,
-        LocalDateTime publishedAt
+        LocalDateTime publishedAt,
+        List<AlbumTrackResponse> tracks
 ) {
-    public static AlbumDetailResponse of(Album album, String artistName) {
+    public static AlbumDetailResponse of(
+            Album album,
+            String artistName,
+            List<AlbumTrackResponse> tracks) {
         return new AlbumDetailResponse(
                 album.getId(),
                 album.getArtistId(),
@@ -28,7 +33,8 @@ public record AlbumDetailResponse(
                 album.getCoverImageUrl(),
                 album.getTrackCount(),
                 album.getTotalDurationSec(),
-                album.getPublishedAt()
+                album.getPublishedAt(),
+                tracks
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/album/dto/response/AlbumTrackResponse.java
+++ b/src/main/java/com/fivefy/domain/album/dto/response/AlbumTrackResponse.java
@@ -1,0 +1,22 @@
+package com.fivefy.domain.album.dto.response;
+
+import com.fivefy.domain.track.entity.Track;
+
+/**
+ * 앨범 수록곡 응답 DTO
+ */
+public record AlbumTrackResponse(
+        Long trackId,
+        Long trackNumber,
+        String title,
+        Long durationSec
+) {
+    public static AlbumTrackResponse from(Track track) {
+        return new AlbumTrackResponse(
+                track.getId(),
+                track.getTrackNumber(),
+                track.getTitle(),
+                track.getDurationSec()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -16,6 +16,7 @@ import com.fivefy.domain.artist.entity.Artist;
 import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
+import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
@@ -40,6 +41,7 @@ public class AlbumService {
     private final AlbumRepository albumRepository;
     private final ArtistRepository artistRepository;
     private final UserRepository userRepository;
+    private final TrackRepository trackRepository;
 
     /**
      * 앨범 등록 신청 생성
@@ -168,7 +170,12 @@ public class AlbumService {
         // 공개 상세 조회에서는 삭제된 아티스트도 노출되면 안 되니까
         Artist artist = findNotDeletedArtist(album.getArtistId());
 
-        return AlbumDetailResponse.of(album, artist.getName());
+        // 앨범에 속한 공개 정식 발매 트랙 목록 조회
+        List<AlbumTrackResponse> tracks = trackRepository.searchAlbumTracks(albumId).stream()
+                .map(AlbumTrackResponse::from)
+                .toList();
+
+        return AlbumDetailResponse.of(album, artist.getName(), tracks);
     }
 
     /**

--- a/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepository.java
@@ -4,6 +4,8 @@ import com.fivefy.domain.track.entity.Track;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 /**
  * Track Querydsl 전용 Repository
  */
@@ -23,4 +25,9 @@ public interface TrackQueryRepository {
      * 아티스트별 자유 창작 트랙 목록 조회
      */
     Page<Track> searchArtistFreeCreations(Long ownerUserId, Pageable pageable);
+
+    /**
+     * 앨범 수록곡 목록 조회
+     */
+    List<Track> searchAlbumTracks(Long albumId);
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepositoryImpl.java
@@ -130,4 +130,24 @@ public class TrackQueryRepositoryImpl implements TrackQueryRepository {
 
         return new PageImpl<>(content, pageable, total == null ? 0 : total);
     }
+
+    /**
+     * 앨범 수록곡 목록 조회
+     */
+    @Override
+    public List<Track> searchAlbumTracks(Long albumId) {
+
+        // 해당 앨범에 속한 공개 정식 발매 트랙만 조회
+        return queryFactory
+                .selectFrom(track)
+                .where(
+                        track.albumId.eq(albumId),
+                        track.trackType.eq(TrackType.OFFICIAL_RELEASE),
+                        track.status.eq(TrackStatus.PUBLISHED),
+                        track.deletedAt.isNull()
+                )
+                // 앨범 수록 순서대로 정렬
+                .orderBy(track.trackNumber.asc())
+                .fetch();
+    }
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepositoryImpl.java
@@ -72,7 +72,14 @@ public class TrackQueryRepositoryImpl implements TrackQueryRepository {
                 .leftJoin(album).on(track.albumId.eq(album.id))
                 .where(
                         track.deletedAt.isNull(),
-                        track.status.eq(TrackStatus.PUBLISHED)
+                        track.status.eq(TrackStatus.PUBLISHED),
+                        track.trackType.eq(TrackType.FREE_CREATION)
+                                .or(
+                                        track.trackType.eq(TrackType.OFFICIAL_RELEASE)
+                                                .and(album.deletedAt.isNull())
+                                                .and(album.status.eq(com.fivefy.domain.album.enums.AlbumStatus.PUBLISHED))
+                                                .and(artist.deletedAt.isNull())
+                                )
                 )
                 // 최신 공개순 정렬 (명세 기준)
                 .orderBy(track.publishedAt.desc())
@@ -85,9 +92,18 @@ public class TrackQueryRepositoryImpl implements TrackQueryRepository {
         Long total = queryFactory
                 .select(track.count())
                 .from(track)
+                .leftJoin(artist).on(track.artistId.eq(artist.id))
+                .leftJoin(album).on(track.albumId.eq(album.id))
                 .where(
                         track.deletedAt.isNull(),
-                        track.status.eq(TrackStatus.PUBLISHED)
+                        track.status.eq(TrackStatus.PUBLISHED),
+                        track.trackType.eq(TrackType.FREE_CREATION)
+                                .or(
+                                        track.trackType.eq(TrackType.OFFICIAL_RELEASE)
+                                                .and(album.deletedAt.isNull())
+                                                .and(album.status.eq(com.fivefy.domain.album.enums.AlbumStatus.PUBLISHED))
+                                                .and(artist.deletedAt.isNull())
+                                )
                 )
                 .fetchOne();
 

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -5,6 +5,7 @@ import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
 import com.fivefy.domain.album.enums.AlbumErrorCode;
+import com.fivefy.domain.album.enums.AlbumStatus;
 import com.fivefy.domain.album.repository.AlbumRepository;
 import com.fivefy.domain.artist.entity.Artist;
 import com.fivefy.domain.artist.enums.ArtistErrorCode;
@@ -234,6 +235,12 @@ public class TrackService {
     @Transactional(readOnly = true)
     public TrackDetailResponse getTrack(Long trackId) {
         Track track = findPublishedTrack(trackId);
+
+        // 정식 발매 트랙은 연관 앨범/아티스트 공개 가능 상태까지 검증
+        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
+            validateOfficialTrackVisibility(track);
+        }
+
         TrackDetailProjection projection = trackRepository.findTrackDetailById(trackId);
 
         String artistName = projection == null ? null : projection.artistName();
@@ -446,6 +453,21 @@ public class TrackService {
             throw new BusinessException(
                     TrackApplicationErrorCode.ERR_TRACK_APPLICATION_DETAIL_FORBIDDEN
             );
+        }
+    }
+
+    // 정식 발매 트랙 공개 가능 상태 검증
+    private void validateOfficialTrackVisibility(Track track) {
+        Album album = findAlbum(track.getAlbumId());
+
+        if (album.getDeletedAt() != null || album.getStatus() != AlbumStatus.PUBLISHED) {
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
+        }
+
+        Artist artist = findArtist(track.getArtistId());
+
+        if (artist.isDeleted()) {
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
         }
     }
 

--- a/src/test/java/com/fivefy/domain/album/controller/AlbumControllerTest.java
+++ b/src/test/java/com/fivefy/domain/album/controller/AlbumControllerTest.java
@@ -639,7 +639,11 @@ class AlbumControllerTest extends RestDocsSupport {
                     "https://example.com/album.jpg",
                     10L,
                     2100L,
-                    LocalDateTime.of(2026, 5, 1, 18, 0, 0)
+                    LocalDateTime.of(2026, 5, 1, 18, 0, 0),
+                    List.of(
+                            new AlbumTrackResponse(1000L, 1L, "이름에게", 245L),
+                            new AlbumTrackResponse(1001L, 2L, "밤편지", 230L)
+                    )
             );
 
             given(albumService.getAlbum(albumId)).willReturn(response);
@@ -650,6 +654,8 @@ class AlbumControllerTest extends RestDocsSupport {
                     .andExpect(jsonPath("$.message").value("앨범 상세 조회 성공"))
                     .andExpect(jsonPath("$.data.albumId").value(albumId))
                     .andExpect(jsonPath("$.data.artistName").value("아이유"))
+                    .andExpect(jsonPath("$.data.tracks[0].trackId").value(1000L))
+                    .andExpect(jsonPath("$.data.tracks[0].trackNumber").value(1L))
                     .andDo(document("albums-get",
                             pathParameters(
                                     parameterWithName("albumId").description("앨범 ID")
@@ -835,7 +841,12 @@ class AlbumControllerTest extends RestDocsSupport {
                 fieldWithPath("data.coverImageUrl").type(STRING).description("커버 이미지 URL"),
                 fieldWithPath("data.trackCount").type(NUMBER).description("트랙 수"),
                 fieldWithPath("data.totalDurationSec").type(NUMBER).description("총 재생 시간(초)"),
-                fieldWithPath("data.publishedAt").type(STRING).description("공개 시각")
+                fieldWithPath("data.publishedAt").type(STRING).description("공개 시각"),
+                fieldWithPath("data.tracks").type(ARRAY).description("수록곡 목록"),
+                fieldWithPath("data.tracks[].trackId").type(NUMBER).description("트랙 ID"),
+                fieldWithPath("data.tracks[].trackNumber").type(NUMBER).description("트랙 번호"),
+                fieldWithPath("data.tracks[].title").type(STRING).description("트랙 제목"),
+                fieldWithPath("data.tracks[].durationSec").type(NUMBER).description("재생 시간(초)")
         };
     }
 

--- a/src/test/java/com/fivefy/domain/album/controller/AlbumSecurityTest.java
+++ b/src/test/java/com/fivefy/domain/album/controller/AlbumSecurityTest.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.album.controller;
 import com.fivefy.common.config.security.*;
 import com.fivefy.common.filter.LastActiveAtFilter;
 import com.fivefy.domain.album.dto.response.AlbumDetailResponse;
+import com.fivefy.domain.album.dto.response.AlbumTrackResponse;
 import com.fivefy.domain.album.dto.response.ArtistAlbumListResponse;
 import com.fivefy.domain.album.service.AlbumService;
 import org.junit.jupiter.api.DisplayName;
@@ -57,7 +58,11 @@ class AlbumSecurityTest {
                             "https://example.com/album.jpg",
                             10L,
                             2100L,
-                            LocalDateTime.of(2026, 5, 1, 18, 0, 0)
+                            LocalDateTime.of(2026, 5, 1, 18, 0, 0),
+                            List.of(
+                                    new AlbumTrackResponse(1000L, 1L, "이름에게", 245L),
+                                    new AlbumTrackResponse(1001L, 2L, "밤편지", 230L)
+                            )
                     )
             );
 

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -16,6 +16,8 @@ import com.fivefy.domain.artist.entity.Artist;
 import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
+import com.fivefy.domain.track.entity.Track;
+import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
@@ -69,6 +71,9 @@ class AlbumServiceTest {
 
     @Mock
     private AlbumRepository albumRepository;
+
+    @Mock
+    private TrackRepository trackRepository;
 
     @InjectMocks
     private AlbumService albumService;
@@ -842,10 +847,34 @@ class AlbumServiceTest {
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
             when(artistRepository.findById(10L)).thenReturn(Optional.of(artist));
 
+            Track track1 = mock(Track.class);
+            when(track1.getId()).thenReturn(100L);
+            when(track1.getTrackNumber()).thenReturn(1L);
+            when(track1.getTitle()).thenReturn("이름에게");
+            when(track1.getDurationSec()).thenReturn(245L);
+
+            Track track2 = mock(Track.class);
+            when(track2.getId()).thenReturn(101L);
+            when(track2.getTrackNumber()).thenReturn(2L);
+            when(track2.getTitle()).thenReturn("밤편지");
+            when(track2.getDurationSec()).thenReturn(230L);
+
+            when(trackRepository.searchAlbumTracks(albumId))
+                    .thenReturn(List.of(track1, track2));
+
             AlbumDetailResponse response = albumService.getAlbum(albumId);
 
             assertThat(response.albumId()).isEqualTo(albumId);
             assertThat(response.artistName()).isEqualTo("아이유");
+            assertThat(response.tracks()).hasSize(2);
+            assertThat(response.tracks().get(0).trackId()).isEqualTo(100L);
+            assertThat(response.tracks().get(0).trackNumber()).isEqualTo(1L);
+            assertThat(response.tracks().get(0).title()).isEqualTo("이름에게");
+            assertThat(response.tracks().get(0).durationSec()).isEqualTo(245L);
+            assertThat(response.tracks().get(1).trackId()).isEqualTo(101L);
+            assertThat(response.tracks().get(1).trackNumber()).isEqualTo(2L);
+            assertThat(response.tracks().get(1).title()).isEqualTo("밤편지");
+            assertThat(response.tracks().get(1).durationSec()).isEqualTo(230L);
         }
 
         @Test
@@ -934,6 +963,35 @@ class AlbumServiceTest {
             assertThatThrownBy(() -> albumService.getAlbum(albumId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("수록곡이 없어도 앨범 상세 조회 성공")
+        void getAlbum_success_whenTracksEmpty() {
+            Long albumId = 1L;
+
+            Album album = Album.create(
+                    10L,
+                    "Palette",
+                    "정규 앨범",
+                    "url",
+                    null
+            );
+            album.publish();
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            Artist artist = mock(Artist.class);
+            when(artist.getName()).thenReturn("아이유");
+
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+            when(artistRepository.findById(10L)).thenReturn(Optional.of(artist));
+            when(trackRepository.searchAlbumTracks(albumId)).thenReturn(List.of());
+
+            AlbumDetailResponse response = albumService.getAlbum(albumId);
+
+            assertThat(response.albumId()).isEqualTo(albumId);
+            assertThat(response.artistName()).isEqualTo("아이유");
+            assertThat(response.tracks()).isEmpty();
         }
     }
 

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -1639,6 +1639,27 @@ class TrackServiceTest {
             ReflectionTestUtils.setField(track, "playCount", 1200L);
 
             when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            Album album = Album.create(
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            album.publish();
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            Artist artist = Artist.create(
+                    1L,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
             when(trackRepository.findTrackDetailById(trackId))
                     .thenReturn(new TrackDetailProjection("아이유", "Palette"));
 
@@ -1659,6 +1680,46 @@ class TrackServiceTest {
             assertThat(response.featuredArtistText()).isEqualTo("feat. 10cm");
             assertThat(response.playCount()).isEqualTo(1200L);
             assertThat(response.publishedAt()).isEqualTo(LocalDateTime.of(2026, 5, 1, 18, 0, 0));
+        }
+
+        @Test
+        @DisplayName("자유 창작 트랙 상세 조회 성공")
+        void getTrack_success_whenFreeCreation() {
+            Long trackId = 2L;
+
+            Track track = Track.createFreeCreation(
+                    1L,
+                    "밤편지 AI 버전",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio-free.mp3",
+                    210L
+            );
+            ReflectionTestUtils.setField(track, "id", trackId);
+            ReflectionTestUtils.setField(
+                    track,
+                    "publishedAt",
+                    LocalDateTime.of(2026, 5, 2, 12, 0, 0)
+            );
+            ReflectionTestUtils.setField(track, "playCount", 300L);
+
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(trackRepository.findTrackDetailById(trackId)).thenReturn(null);
+
+            TrackDetailResponse response = trackService.getTrack(trackId);
+
+            assertThat(response.trackId()).isEqualTo(trackId);
+            assertThat(response.trackType()).isEqualTo(TrackType.FREE_CREATION);
+            assertThat(response.artistId()).isNull();
+            assertThat(response.artistName()).isNull();
+            assertThat(response.albumId()).isNull();
+            assertThat(response.albumTitle()).isNull();
+            assertThat(response.trackNumber()).isNull();
+            assertThat(response.title()).isEqualTo("밤편지 AI 버전");
+            assertThat(response.audioUrl()).isEqualTo("https://example.com/audio-free.mp3");
+            assertThat(response.durationSec()).isEqualTo(210L);
+            assertThat(response.playCount()).isEqualTo(300L);
+            assertThat(response.publishedAt()).isEqualTo(LocalDateTime.of(2026, 5, 2, 12, 0, 0));
         }
 
         @Test
@@ -1721,6 +1782,147 @@ class TrackServiceTest {
             ReflectionTestUtils.setField(track, "id", trackId);
 
             when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+
+            assertThatThrownBy(() -> trackService.getTrack(trackId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("정식 발매 트랙 상세 조회 시 삭제된 앨범이면 실패")
+        void getTrack_fail_whenOfficialTrackAlbumDeleted() {
+            Long trackId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            Track track = Track.createOfficialRelease(
+                    1L,
+                    artistId,
+                    albumId,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    null
+            );
+            track.publish();
+            ReflectionTestUtils.setField(track, "id", trackId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+            ReflectionTestUtils.setField(
+                    album,
+                    "deletedAt",
+                    LocalDateTime.of(2026, 5, 2, 12, 0, 0)
+            );
+
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+
+            assertThatThrownBy(() -> trackService.getTrack(trackId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("정식 발매 트랙 상세 조회 시 미공개 앨범이면 실패")
+        void getTrack_fail_whenOfficialTrackAlbumNotPublished() {
+            Long trackId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            Track track = Track.createOfficialRelease(
+                    1L,
+                    artistId,
+                    albumId,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    null
+            );
+            track.publish();
+            ReflectionTestUtils.setField(track, "id", trackId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+
+            assertThatThrownBy(() -> trackService.getTrack(trackId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("정식 발매 트랙 상세 조회 시 삭제된 아티스트면 실패")
+        void getTrack_fail_whenOfficialTrackArtistDeleted() {
+            Long trackId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            Track track = Track.createOfficialRelease(
+                    1L,
+                    artistId,
+                    albumId,
+                    1L,
+                    "밤편지",
+                    "가사",
+                    "BALLAD",
+                    "https://example.com/audio.mp3",
+                    230L,
+                    "feat. 10cm",
+                    null
+            );
+            track.publish();
+            ReflectionTestUtils.setField(track, "id", trackId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            album.publish();
+            ReflectionTestUtils.setField(album, "id", albumId);
+
+            Artist artist = Artist.create(
+                    1L,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+            ReflectionTestUtils.setField(
+                    artist,
+                    "deletedAt",
+                    LocalDateTime.of(2026, 5, 2, 12, 0, 0)
+            );
+
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
 
             assertThatThrownBy(() -> trackService.getTrack(trackId))
                     .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## 개요

> 앨범 상세 조회 응답에 수록곡 목록을 포함하고,  
> 트랙 조회 시 정식 발매 트랙의 공개 가능 조건(앨범/아티스트 상태)을 강화

## 변경 사항

### 1. 앨범 상세 조회 응답 확장

- `AlbumDetailResponse`에 수록곡 목록 필드 추가
  - `List<AlbumTrackResponse> tracks`
- `AlbumTrackResponse` DTO 신규 추가
  - trackId, trackNumber, title, durationSec 포함
- 앨범 상세 조회 시 수록곡 정보 함께 반환하도록 구조 변경

### 2. 앨범 수록곡 조회 Querydsl 추가

- `TrackQueryRepository`
  - `searchAlbumTracks(Long albumId)` 메서드 추가
- `TrackQueryRepositoryImpl`
  - 앨범에 속한 공개 정식 발매 트랙 조회 로직 구현
  - 조건
    - `OFFICIAL_RELEASE`
    - `PUBLISHED`
    - `deletedAt IS NULL`
  - 정렬
    - `trackNumber ASC`

### 3. AlbumService 로직 확장

- `getAlbum()` 수정
  - 기존: 앨범 + 아티스트 정보만 반환
  - 변경: 앨범 + 아티스트 + 수록곡 목록 포함
- 수록곡 조회 흐름
  - `trackRepository.searchAlbumTracks(albumId)`
  - → `AlbumTrackResponse.from()` 매핑

### 4. 공개 트랙 목록 조회 정책 강화

- `searchPublicTracks()` 조건 강화
  - 기존: 단순 PUBLISHED + not deleted
  - 변경:
    - FREE_CREATION → 그대로 허용
    - OFFICIAL_RELEASE →
      - 앨범 삭제 X
      - 앨범 PUBLISHED
      - 아티스트 삭제 X
- count 쿼리에도 동일 조건 반영 (정합성 유지)

### 5. 트랙 상세 조회 정책 강화

- `TrackService.getTrack()`에 검증 로직 추가
- 정식 발매 트랙의 경우 추가 검증 수행
  - 앨범 존재 및 삭제 여부
  - 앨범 PUBLISHED 여부
  - 아티스트 삭제 여부
- 조건 미충족 시 `ERR_TRACK_NOT_FOUND` 처리

### 6. 테스트 코드 보강

#### Album
- 수록곡 포함 응답 검증 추가
- 수록곡 없는 경우(empty list) 케이스 추가

#### Track
- 자유 창작 트랙 상세 조회 성공 케이스 추가
- 정식 발매 트랙 검증 실패 케이스 추가
  - 앨범 삭제
  - 앨범 미공개
  - 아티스트 삭제

### 7. REST Docs 수정

- 트랙 상세 조회 문서 구분 개선 (`---` 제거)

## 변경 유형

- [x] 기능 추가 (feat)
- [x] 리팩토링 (refactor)
- [x] 테스트 (test)
- [x] 문서 (docs)

## 테스트 방법

```text
1. GET /api/albums/{albumId} 호출 시 수록곡 목록 포함 여부 확인
2. 수록곡이 없는 경우 빈 배열 반환 확인
3. GET /api/tracks/{trackId} 호출 시 정식 발매 트랙의 앨범/아티스트 상태 검증 확인
4. 삭제된 앨범 / 미공개 앨범 / 삭제된 아티스트일 경우 ERR_TRACK_NOT_FOUND 확인
5. 자유 창작 트랙 조회 시 연관 정보 없이 정상 조회 확인
6. 공개 트랙 목록 조회 시 OFFICIAL_RELEASE 조건 필터링 정상 동작 확인
7. AlbumServiceTest / TrackServiceTest 실행 후 모든 케이스 통과 확인
```

## 체크리스트

- [x] 코드 자체 리뷰 완료

- [x] 테스트 코드 작성 / 확인

- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 앨범 상세 조회 시 해당 앨범의 공개 트랙 목록이 응답에 포함됩니다.

* **버그 수정**
  * 트랙 조회 시 앨범 및 아티스트의 공개 상태를 검증하여 접근 제어를 강화했습니다.

* **테스트**
  * 새 기능과 상태 검증 로직에 대한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->