### PR TITLE
chore: Skip asciidoctor during JAR build step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,7 +40,7 @@ jobs:
 
       # CI에서 이미 테스트 통과 → 테스트 스킵
       - name: Build JAR
-        run: ./gradlew bootJar -x test --no-daemon
+        run: ./gradlew bootJar -x test -x asciidoctor --no-daemon
 
       # 배포 환경 결정 + 환경별 시크릿 분기
       - name: Set deploy environment


### PR DESCRIPTION
CI 파이프라인에서 test를 진행하기 때문에 CD 파이프라인에서는 test를 스킵한다. 하지만 test를 스킵하여 Rest Docs 스니펫 디렉토리가 존재하지 않는다. 이로 인해 asciidoctor task 에러 발생. 이를 해결하기 위해 asciidoctor또한 CD 라인에서는 스킵하는게 맞다고 판단하여 수정.

## 개요

> CD 파이프라인의 JAR 빌드 단계에서 asciidoctor 스킵

## 변경 사항

- CI 파이프라인에서 test를 진행하기 때문에 CD 파이프라인에서는 test를 스킵한다. 하지만 test를 스킵하여 Rest Docs 스니펫 디렉토리가 존재하지 않는다. 이로 인해 asciidoctor task 에러 발생. 이를 해결하기 위해 asciidoctor또한 CD 라인에서는 스킵하는게 맞다고 판단하여 수정.

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [x] 기타 (chore)

## 체크리스트

- [ ] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 배포 파이프라인의 빌드 프로세스 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->