### PR TITLE
feat: 트랙 댓글 기능 구현 및 REST Docs 문서화 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -757,6 +757,108 @@ include::{snippets}/artists-free-creations-get-deleted-artist/response-fields.ad
 
 ---
 
+== Track Comment API
+
+=== 트랙 댓글 작성
+
+include::{snippets}/track-comments-create/http-request.adoc[]
+include::{snippets}/track-comments-create/path-parameters.adoc[]
+include::{snippets}/track-comments-create/request-fields.adoc[]
+include::{snippets}/track-comments-create/http-response.adoc[]
+include::{snippets}/track-comments-create/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/track-comments-create-invalid/http-request.adoc[]
+include::{snippets}/track-comments-create-invalid/path-parameters.adoc[]
+include::{snippets}/track-comments-create-invalid/request-fields.adoc[]
+include::{snippets}/track-comments-create-invalid/http-response.adoc[]
+include::{snippets}/track-comments-create-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 존재하지 않는 트랙
+
+include::{snippets}/track-comments-create-not-found/http-request.adoc[]
+include::{snippets}/track-comments-create-not-found/path-parameters.adoc[]
+include::{snippets}/track-comments-create-not-found/request-fields.adoc[]
+include::{snippets}/track-comments-create-not-found/http-response.adoc[]
+include::{snippets}/track-comments-create-not-found/response-fields.adoc[]
+
+---
+
+=== 트랙 댓글 목록 조회
+
+include::{snippets}/track-comments-get-list/http-request.adoc[]
+include::{snippets}/track-comments-get-list/path-parameters.adoc[]
+include::{snippets}/track-comments-get-list/query-parameters.adoc[]
+include::{snippets}/track-comments-get-list/http-response.adoc[]
+include::{snippets}/track-comments-get-list/response-fields.adoc[]
+
+==== 에러 케이스 - 존재하지 않는 트랙
+
+include::{snippets}/track-comments-get-list-not-found/http-request.adoc[]
+include::{snippets}/track-comments-get-list-not-found/path-parameters.adoc[]
+include::{snippets}/track-comments-get-list-not-found/http-response.adoc[]
+include::{snippets}/track-comments-get-list-not-found/response-fields.adoc[]
+
+---
+
+=== 트랙 댓글 수정
+
+include::{snippets}/track-comments-update/http-request.adoc[]
+include::{snippets}/track-comments-update/path-parameters.adoc[]
+include::{snippets}/track-comments-update/request-fields.adoc[]
+include::{snippets}/track-comments-update/http-response.adoc[]
+include::{snippets}/track-comments-update/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/track-comments-update-invalid/http-request.adoc[]
+include::{snippets}/track-comments-update-invalid/path-parameters.adoc[]
+include::{snippets}/track-comments-update-invalid/request-fields.adoc[]
+include::{snippets}/track-comments-update-invalid/http-response.adoc[]
+include::{snippets}/track-comments-update-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 존재하지 않는 댓글
+
+include::{snippets}/track-comments-update-not-found/http-request.adoc[]
+include::{snippets}/track-comments-update-not-found/path-parameters.adoc[]
+include::{snippets}/track-comments-update-not-found/request-fields.adoc[]
+include::{snippets}/track-comments-update-not-found/http-response.adoc[]
+include::{snippets}/track-comments-update-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 수정 권한 없음
+
+include::{snippets}/track-comments-update-forbidden/http-request.adoc[]
+include::{snippets}/track-comments-update-forbidden/path-parameters.adoc[]
+include::{snippets}/track-comments-update-forbidden/request-fields.adoc[]
+include::{snippets}/track-comments-update-forbidden/http-response.adoc[]
+include::{snippets}/track-comments-update-forbidden/response-fields.adoc[]
+
+---
+
+=== 트랙 댓글 삭제
+
+include::{snippets}/track-comments-delete/http-request.adoc[]
+include::{snippets}/track-comments-delete/path-parameters.adoc[]
+include::{snippets}/track-comments-delete/http-response.adoc[]
+include::{snippets}/track-comments-delete/response-fields.adoc[]
+
+==== 에러 케이스 - 존재하지 않는 댓글
+
+include::{snippets}/track-comments-delete-not-found/http-request.adoc[]
+include::{snippets}/track-comments-delete-not-found/path-parameters.adoc[]
+include::{snippets}/track-comments-delete-not-found/http-response.adoc[]
+include::{snippets}/track-comments-delete-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 삭제 권한 없음
+
+include::{snippets}/track-comments-delete-forbidden/http-request.adoc[]
+include::{snippets}/track-comments-delete-forbidden/path-parameters.adoc[]
+include::{snippets}/track-comments-delete-forbidden/http-response.adoc[]
+include::{snippets}/track-comments-delete-forbidden/response-fields.adoc[]
+
+---
+
 == Playlist API
 
 === 플레이리스트 생성

--- a/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                                 "/api/artists/{artistId}/albums",
                                 "/api/tracks/{trackId}",
                                 "/api/tracks",
-                                "/api/artists/{artistId}/free-creations"
+                                "/api/artists/{artistId}/free-creations",
+                                "/api/tracks/{trackId}/comments"
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())

--- a/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
@@ -1,11 +1,15 @@
 package com.fivefy.domain.track.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackCommentResponse;
 import com.fivefy.domain.track.service.TrackCommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,5 +40,24 @@ public class TrackCommentController {
         return ResponseEntity.status(HttpStatus.CREATED).body(
                 BaseResponse.success(HttpStatus.CREATED, "트랙 댓글 작성 성공", response)
         );
+    }
+
+    /**
+     * 트랙 댓글 목록 조회 API
+     */
+    @GetMapping("/tracks/{trackId}/comments")
+    public ResponseEntity<BaseResponse<PageResponse<TrackCommentResponse>>> getTrackComments(
+            @PathVariable Long trackId,
+            @PageableDefault(
+                    size = 20,
+                    sort = "createdAt",
+                    direction = Sort.Direction.DESC
+            ) Pageable pageable
+    ) {
+        PageResponse<TrackCommentResponse> response =
+                trackCommentService.getTrackComments(trackId, pageable);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(HttpStatus.OK, "트랙 댓글 목록 조회 성공", response));
     }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
@@ -60,4 +60,21 @@ public class TrackCommentController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.success(HttpStatus.OK, "트랙 댓글 목록 조회 성공", response));
     }
+
+    /**
+     * 트랙 댓글 수정 API
+     */
+    @PatchMapping("/tracks/{trackId}/comments/{commentId}")
+    public ResponseEntity<BaseResponse<TrackCommentResponse>> updateTrackComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long trackId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody TrackCommentCreateRequest request
+    ) {
+        TrackCommentResponse response =
+                trackCommentService.updateTrackComment(userId, trackId, commentId, request);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(HttpStatus.OK, "트랙 댓글 수정 성공", response));
+    }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
@@ -77,4 +77,19 @@ public class TrackCommentController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.success(HttpStatus.OK, "트랙 댓글 수정 성공", response));
     }
+
+    /**
+     * 트랙 댓글 삭제 API
+     */
+    @DeleteMapping("/tracks/{trackId}/comments/{commentId}")
+    public ResponseEntity<BaseResponse<Void>> deleteTrackComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long trackId,
+            @PathVariable Long commentId
+    ) {
+        trackCommentService.deleteTrackComment(userId, trackId, commentId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.success(HttpStatus.OK, "트랙 댓글 삭제 성공", null));
+    }
 }

--- a/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackCommentController.java
@@ -1,0 +1,40 @@
+package com.fivefy.domain.track.controller;
+
+import com.fivefy.common.dto.response.BaseResponse;
+import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackCommentResponse;
+import com.fivefy.domain.track.service.TrackCommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 트랙 댓글 도메인 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class TrackCommentController {
+
+    private final TrackCommentService trackCommentService;
+
+    /**
+     * 트랙 댓글 작성 API
+     */
+    @PostMapping("/tracks/{trackId}/comments")
+    public ResponseEntity<BaseResponse<TrackCommentResponse>> createTrackComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long trackId,
+            @Valid @RequestBody TrackCommentCreateRequest request
+    ) {
+        TrackCommentResponse response =
+                trackCommentService.createTrackComment(userId, trackId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                BaseResponse.success(HttpStatus.CREATED, "트랙 댓글 작성 성공", response)
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/controller/TrackController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackController.java
@@ -12,7 +12,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * 트랙 도메인 컨트롤러

--- a/src/main/java/com/fivefy/domain/track/dto/request/TrackCommentCreateRequest.java
+++ b/src/main/java/com/fivefy/domain/track/dto/request/TrackCommentCreateRequest.java
@@ -1,0 +1,14 @@
+package com.fivefy.domain.track.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 트랙 댓글 작성 요청 DTO
+ */
+public record TrackCommentCreateRequest(
+        @NotBlank(message = "댓글 내용은 필수입니다")
+        @Size(max = 1000, message = "댓글은 1000자 이하여야 합니다")
+        String content
+) {
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackCommentPageResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackCommentPageResponse.java
@@ -1,0 +1,25 @@
+package com.fivefy.domain.track.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 트랙 댓글 목록 조회 응답 DTO
+ */
+public record TrackCommentPageResponse(
+        List<Comment> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+
+    public record Comment(
+            Long commentId,
+            Long userId,
+            String content,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackCommentResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackCommentResponse.java
@@ -1,0 +1,32 @@
+package com.fivefy.domain.track.dto.response;
+
+import com.fivefy.domain.track.entity.TrackComment;
+
+import java.time.LocalDateTime;
+
+/**
+ * 트랙 댓글 작성 응답 DTO
+ */
+public record TrackCommentResponse(
+        Long commentId,
+        Long userId,
+        Long trackId,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    /**
+     * TrackComment 엔티티 → 응답 DTO 변환
+     */
+    public static TrackCommentResponse from(TrackComment trackComment) {
+        return new TrackCommentResponse(
+                trackComment.getId(),
+                trackComment.getUserId(),
+                trackComment.getTrackId(),
+                trackComment.getContent(),
+                trackComment.getCreatedAt(),
+                trackComment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackCommentResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackCommentResponse.java
@@ -15,7 +15,6 @@ public record TrackCommentResponse(
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
-
     /**
      * TrackComment 엔티티 → 응답 DTO 변환
      */

--- a/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
@@ -35,7 +35,7 @@ public class TrackComment extends BaseEntity {
     @Column(name = "track_id", nullable = false)
     private Long trackId;
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "content", nullable = false, length = 1000)
     private String content;
 
     @LastModifiedDate

--- a/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
@@ -3,7 +3,6 @@ package com.fivefy.domain.track.entity;
 import com.fivefy.common.entity.BaseEntity;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.track.enums.TrackCommentErrorCode;
-import com.fivefy.domain.track.enums.TrackCommentStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -39,10 +38,6 @@ public class TrackComment extends BaseEntity {
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private TrackCommentStatus status;
-
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
@@ -55,18 +50,21 @@ public class TrackComment extends BaseEntity {
         validateNonNull(trackId, "trackId");
         validateNonNull(content, "content");
 
+        validateContentLength(content);
+
         TrackComment comment = new TrackComment();
         comment.userId = userId;
         comment.trackId = trackId;
         comment.content = content;
-        comment.status = TrackCommentStatus.PUBLISHED;
 
         return comment;
     }
 
     public void updateContent(String content) {
         validateNonNull(content, "content");
+
         validateNotDeleted();
+        validateContentLength(content);
 
         this.content = content;
     }
@@ -87,6 +85,12 @@ public class TrackComment extends BaseEntity {
     private void validateNotDeleted() {
         if (this.deletedAt != null) {
             throw new BusinessException(TrackCommentErrorCode.ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED);
+        }
+    }
+
+    private static void validateContentLength(String content) {
+        if (content.length() > 1000) {
+            throw new BusinessException(TrackCommentErrorCode.ERR_INVALID_TRACK_COMMENT_LENGTH);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
@@ -6,9 +6,13 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum TrackCommentErrorCode implements ErrorCode {
-    ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 트랙 댓글은 수정할 수 없습니다"),
-    ERR_TRACK_COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 트랫 댓글입니다");
-
+    ERR_TRACK_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다"),
+    ERR_TRACK_COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 댓글입니다"),
+    ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 댓글은 수정할 수 없습니다"),
+    ERR_FORBIDDEN_TRACK_COMMENT_UPDATE(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정할 수 있습니다"),
+    ERR_FORBIDDEN_TRACK_COMMENT_DELETE(HttpStatus.FORBIDDEN, "작성자 또는 관리자만 댓글을 삭제할 수 있습니다"),
+    ERR_TRACK_COMMENT_NOT_WRITABLE(HttpStatus.BAD_REQUEST, "댓글을 작성할 수 없는 트랙입니다"),
+    ERR_INVALID_TRACK_COMMENT_LENGTH(HttpStatus.BAD_REQUEST, "댓글은 1000자 이하여야 합니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum TrackCommentErrorCode implements ErrorCode {
-    ERR_TRACK_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글이 존재하지 않습니다"),
+    ERR_TRACK_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다"),
     ERR_TRACK_COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 댓글입니다"),
     ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 댓글은 수정할 수 없습니다"),
     ERR_FORBIDDEN_TRACK_COMMENT_UPDATE(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정할 수 있습니다"),

--- a/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackCommentErrorCode.java
@@ -11,7 +11,6 @@ public enum TrackCommentErrorCode implements ErrorCode {
     ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 댓글은 수정할 수 없습니다"),
     ERR_FORBIDDEN_TRACK_COMMENT_UPDATE(HttpStatus.FORBIDDEN, "작성자만 댓글을 수정할 수 있습니다"),
     ERR_FORBIDDEN_TRACK_COMMENT_DELETE(HttpStatus.FORBIDDEN, "작성자 또는 관리자만 댓글을 삭제할 수 있습니다"),
-    ERR_TRACK_COMMENT_NOT_WRITABLE(HttpStatus.BAD_REQUEST, "댓글을 작성할 수 없는 트랙입니다"),
     ERR_INVALID_TRACK_COMMENT_LENGTH(HttpStatus.BAD_REQUEST, "댓글은 1000자 이하여야 합니다");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/fivefy/domain/track/enums/TrackCommentStatus.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackCommentStatus.java
@@ -1,6 +1,0 @@
-package com.fivefy.domain.track.enums;
-
-public enum TrackCommentStatus {
-
-    PUBLISHED // 게시됨
-}

--- a/src/main/java/com/fivefy/domain/track/enums/TrackErrorCode.java
+++ b/src/main/java/com/fivefy/domain/track/enums/TrackErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum TrackErrorCode implements ErrorCode {
-    ERR_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지않는 트랙입니다"),
+    ERR_TRACK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 트랙입니다"),
     ERR_TRACK_ALREADY_PUBLISHED(HttpStatus.BAD_REQUEST, "이미 공개된 트랙입니다"),
     ERR_TRACK_ALREADY_BLOCKED(HttpStatus.BAD_REQUEST, "이미 차단된 트랙입니다"),
     ERR_TRACK_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 트랙입니다"),

--- a/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepository.java
@@ -1,0 +1,16 @@
+package com.fivefy.domain.track.repository;
+
+import com.fivefy.domain.track.entity.TrackComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * 트랙 댓글 커스텀 리포지토리
+ */
+public interface TrackCommentQueryRepository {
+
+    /**
+     * 트랙 댓글 목록 조회
+     */
+    Page<TrackComment> getTrackComments(Long trackId, Pageable pageable);
+}

--- a/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepositoryImpl.java
@@ -3,10 +3,10 @@ package com.fivefy.domain.track.repository;
 import com.fivefy.domain.track.entity.TrackComment;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 

--- a/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.fivefy.domain.track.repository;
+
+import com.fivefy.domain.track.entity.TrackComment;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.fivefy.domain.track.entity.QTrackComment.trackComment;
+
+/**
+ * TrackComment Querydsl 구현체
+ */
+@Repository
+@RequiredArgsConstructor
+public class TrackCommentQueryRepositoryImpl implements TrackCommentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 트랙 댓글 목록 조회
+     */
+    @Override
+    public Page<TrackComment> getTrackComments(Long trackId, Pageable pageable) {
+
+        // 특정 트랙의 삭제되지 않은 댓글을 최신순으로 조회
+        List<TrackComment> content = queryFactory
+                .selectFrom(trackComment)
+                .where(
+                        trackComment.trackId.eq(trackId),
+                        trackComment.deletedAt.isNull()
+                )
+                // 최신순 정렬
+                .orderBy(trackComment.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 전체 개수 조회 (PageResponse 생성용)
+        Long total = queryFactory
+                .select(trackComment.count())
+                .from(trackComment)
+                .where(
+                        trackComment.trackId.eq(trackId),
+                        trackComment.deletedAt.isNull()
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/repository/TrackCommentRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackCommentRepository.java
@@ -3,5 +3,5 @@ package com.fivefy.domain.track.repository;
 import com.fivefy.domain.track.entity.TrackComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TrackCommentRepository extends JpaRepository<TrackComment, Long> {
+public interface TrackCommentRepository extends JpaRepository<TrackComment, Long>, TrackCommentQueryRepository {
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -159,14 +159,12 @@ public class TrackCommentService {
     }
 
     // 댓글 접근 가능한 트랙 조회
-    private Track findAccessibleCommentTrack(Long trackId) {
+    private void findAccessibleCommentTrack(Long trackId) {
         Track track = findPublishedTrack(trackId);
 
         if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
             validateOfficialTrackVisibility(track);
         }
-
-        return track;
     }
 
 

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -85,6 +85,9 @@ public class TrackCommentService {
             Long commentId,
             TrackCommentCreateRequest request
     ) {
+        // 유저 조회
+        User user = findUser(userId);
+
         // 트랙 접근 가능 여부 검증
         findAccessibleCommentTrack(trackId);
 
@@ -92,7 +95,7 @@ public class TrackCommentService {
         TrackComment comment = findTrackComment(trackId, commentId);
 
         // 작성자 검증
-        if (!comment.getUserId().equals(userId)) {
+        if (!comment.isWrittenBy(user.getId())) {
             throw new BusinessException(TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_UPDATE);
         }
 

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -17,6 +17,7 @@ import com.fivefy.domain.track.repository.TrackCommentRepository;
 import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -92,12 +93,6 @@ public class TrackCommentService {
                 .orElseThrow(() -> new BusinessException(
                         TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND));
 
-        // 삭제된 댓글 수정 불가
-        if (comment.getDeletedAt() != null) {
-            throw new BusinessException(
-                    TrackCommentErrorCode.ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED);
-        }
-
         // 작성자 검증
         if (!comment.getUserId().equals(userId)) {
             throw new BusinessException(TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_UPDATE);
@@ -107,6 +102,33 @@ public class TrackCommentService {
         comment.updateContent(request.content());
 
         return TrackCommentResponse.from(comment);
+    }
+
+    /**
+     * 트랙 댓글 삭제
+     */
+    @Transactional
+    public void deleteTrackComment(
+            Long userId,
+            Long trackId,
+            Long commentId
+    ) {
+        // 댓글 접근 가능한 트랙 조회
+        findAccessibleCommentTrack(trackId);
+
+        // 유저 조회
+        User user = findUser(userId);
+
+        // 댓글 조회
+        TrackComment comment = trackCommentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(
+                        TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND));
+
+        // 작성자 또는 관리자만 삭제 가능
+        validateCommentDeleteAccess(user, comment);
+
+        // 댓글 삭제
+        comment.softDelete();
     }
 
     // =========================
@@ -136,6 +158,18 @@ public class TrackCommentService {
         return track;
     }
 
+    // 댓글 접근 가능한 트랙 조회
+    private Track findAccessibleCommentTrack(Long trackId) {
+        Track track = findPublishedTrack(trackId);
+
+        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
+            validateOfficialTrackVisibility(track);
+        }
+
+        return track;
+    }
+
+
     // =========================
     // 검증
     // =========================
@@ -151,14 +185,15 @@ public class TrackCommentService {
                 .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
     }
 
-    // 댓글 접근 가능한 트랙 조회
-    private Track findAccessibleCommentTrack(Long trackId) {
-        Track track = findPublishedTrack(trackId);
+    // 댓글 삭제 권한 검증
+    private void validateCommentDeleteAccess(User user, TrackComment comment) {
+        boolean isWriter = comment.isWrittenBy(user.getId());
+        boolean isAdmin = user.getRole() == UserRole.ADMIN;
 
-        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
-            validateOfficialTrackVisibility(track);
+        if (!isWriter && !isAdmin) {
+            throw new BusinessException(
+                    TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_DELETE
+            );
         }
-
-        return track;
     }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.track.service;
 
+import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
 import com.fivefy.domain.album.enums.AlbumErrorCode;
@@ -22,6 +23,7 @@ import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,18 +49,39 @@ public class TrackCommentService {
             Long trackId,
             TrackCommentCreateRequest request
     ) {
+        // 댓글 작성 유저 존재 확인
         findUser(userId);
 
-        Track track = findTrack(trackId);
+        Track track = findPublishedTrack(trackId);
 
-        // 현재 조회 가능한 트랙에만 댓글 작성 허용
-        validateTrackCommentWritable(track);
+        // 정식 발매 트랙은 연관 앨범/아티스트 공개 가능 상태까지 검증
+        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
+            validateOfficialTrackVisibility(track);
+        }
 
         TrackComment savedComment = trackCommentRepository.save(
                 TrackComment.create(userId, trackId, request.content())
         );
 
         return TrackCommentResponse.from(savedComment);
+    }
+
+    /**
+     * 트랙 댓글 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<TrackCommentResponse> getTrackComments(Long trackId, Pageable pageable) {
+        Track track = findPublishedTrack(trackId);
+
+        // 정식 발매 트랙은 연관 앨범/아티스트 공개 가능 상태까지 검증
+        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
+            validateOfficialTrackVisibility(track);
+        }
+
+        return PageResponse.from(
+                trackCommentRepository.getTrackComments(trackId, pageable)
+                        .map(TrackCommentResponse::from)
+        );
     }
 
     // =========================
@@ -77,6 +100,17 @@ public class TrackCommentService {
                 .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
     }
 
+    // 공개 가능한 트랙 조회
+    private Track findPublishedTrack(Long trackId) {
+        Track track = findTrack(trackId);
+
+        if (track.getDeletedAt() != null || track.getStatus() != TrackStatus.PUBLISHED) {
+            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
+        }
+
+        return track;
+    }
+
     // 앨범 조회
     private Album findAlbum(Long albumId) {
         return albumRepository.findById(albumId)
@@ -93,20 +127,8 @@ public class TrackCommentService {
     // 검증
     // =========================
 
-    // 댓글 작성 가능한 트랙인지 검증
-    private void validateTrackCommentWritable(Track track) {
-        if (track.getDeletedAt() != null || track.getStatus() != TrackStatus.PUBLISHED) {
-            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
-        }
-
-        // 정식 발매 트랙은 연관 앨범/아티스트 공개 가능 상태까지 확인
-        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
-            validateOfficialReleaseTrackCommentWritable(track);
-        }
-    }
-
-    // 정식 발매 트랙 댓글 작성 가능 상태 검증
-    private void validateOfficialReleaseTrackCommentWritable(Track track) {
+    // 정식 발매 트랙 공개 가능 상태 검증
+    private void validateOfficialTrackVisibility(Track track) {
         Album album = findAlbum(track.getAlbumId());
 
         if (album.getDeletedAt() != null || album.getStatus() != AlbumStatus.PUBLISHED) {

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -3,17 +3,14 @@ package com.fivefy.domain.track.service;
 import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
-import com.fivefy.domain.album.enums.AlbumErrorCode;
 import com.fivefy.domain.album.enums.AlbumStatus;
 import com.fivefy.domain.album.repository.AlbumRepository;
 import com.fivefy.domain.artist.entity.Artist;
-import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackCommentResponse;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackComment;
-import com.fivefy.domain.track.enums.TrackCommentErrorCode;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
@@ -23,6 +20,7 @@ import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,9 +76,10 @@ public class TrackCommentService {
             validateOfficialTrackVisibility(track);
         }
 
+        Page<TrackComment> page = trackCommentRepository.getTrackComments(trackId, pageable);
+
         return PageResponse.from(
-                trackCommentRepository.getTrackComments(trackId, pageable)
-                        .map(TrackCommentResponse::from)
+                page.map(TrackCommentResponse::from)
         );
     }
 
@@ -105,22 +104,10 @@ public class TrackCommentService {
         Track track = findTrack(trackId);
 
         if (track.getDeletedAt() != null || track.getStatus() != TrackStatus.PUBLISHED) {
-            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
         }
 
         return track;
-    }
-
-    // 앨범 조회
-    private Album findAlbum(Long albumId) {
-        return albumRepository.findById(albumId)
-                .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND));
-    }
-
-    // 아티스트 조회
-    private Artist findArtist(Long artistId) {
-        return artistRepository.findById(artistId)
-                .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND));
     }
 
     // =========================
@@ -129,16 +116,12 @@ public class TrackCommentService {
 
     // 정식 발매 트랙 공개 가능 상태 검증
     private void validateOfficialTrackVisibility(Track track) {
-        Album album = findAlbum(track.getAlbumId());
+        albumRepository.findById(track.getAlbumId())
+                .filter(album -> album.getDeletedAt() == null && album.getStatus() == AlbumStatus.PUBLISHED)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
 
-        if (album.getDeletedAt() != null || album.getStatus() != AlbumStatus.PUBLISHED) {
-            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
-        }
-
-        Artist artist = findArtist(track.getArtistId());
-
-        if (artist.isDeleted()) {
-            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
-        }
+        artistRepository.findById(track.getArtistId())
+                .filter(artist -> !artist.isDeleted())
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
     }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -73,6 +73,39 @@ public class TrackCommentService {
         );
     }
 
+    /**
+     * 트랙 댓글 수정
+     */
+    @Transactional
+    public TrackCommentResponse updateTrackComment(
+            Long userId,
+            Long trackId,
+            Long commentId,
+            TrackCommentCreateRequest request
+    ) {
+        // 트랙 접근 가능 여부 검증
+        findAccessibleCommentTrack(trackId);
+
+        // 댓글 조회
+        TrackComment comment = trackCommentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+
+        // 삭제된 댓글 수정 불가
+        if (comment.getDeletedAt() != null) {
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
+        }
+
+        // 작성자 검증
+        if (!comment.getUserId().equals(userId)) {
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
+        }
+
+        // 댓글 내용 수정
+        comment.updateContent(request.content());
+
+        return TrackCommentResponse.from(comment);
+    }
+
     // =========================
     // 조회
     // =========================

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -2,10 +2,8 @@ package com.fivefy.domain.track.service;
 
 import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.album.entity.Album;
 import com.fivefy.domain.album.enums.AlbumStatus;
 import com.fivefy.domain.album.repository.AlbumRepository;
-import com.fivefy.domain.artist.entity.Artist;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackCommentResponse;
@@ -50,12 +48,8 @@ public class TrackCommentService {
         // 댓글 작성 유저 존재 확인
         findUser(userId);
 
-        Track track = findPublishedTrack(trackId);
-
-        // 정식 발매 트랙은 연관 앨범/아티스트 공개 가능 상태까지 검증
-        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
-            validateOfficialTrackVisibility(track);
-        }
+        // 댓글 접근 가능한 트랙 조회
+        findAccessibleCommentTrack(trackId);
 
         TrackComment savedComment = trackCommentRepository.save(
                 TrackComment.create(userId, trackId, request.content())
@@ -69,12 +63,8 @@ public class TrackCommentService {
      */
     @Transactional(readOnly = true)
     public PageResponse<TrackCommentResponse> getTrackComments(Long trackId, Pageable pageable) {
-        Track track = findPublishedTrack(trackId);
-
-        // 정식 발매 트랙은 연관 앨범/아티스트 공개 가능 상태까지 검증
-        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
-            validateOfficialTrackVisibility(track);
-        }
+        // 댓글 접근 가능한 트랙 조회
+        findAccessibleCommentTrack(trackId);
 
         Page<TrackComment> page = trackCommentRepository.getTrackComments(trackId, pageable);
 
@@ -123,5 +113,16 @@ public class TrackCommentService {
         artistRepository.findById(track.getArtistId())
                 .filter(artist -> !artist.isDeleted())
                 .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+    }
+
+    // 댓글 접근 가능한 트랙 조회
+    private Track findAccessibleCommentTrack(Long trackId) {
+        Track track = findPublishedTrack(trackId);
+
+        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
+            validateOfficialTrackVisibility(track);
+        }
+
+        return track;
     }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -9,6 +9,7 @@ import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackCommentResponse;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackComment;
+import com.fivefy.domain.track.enums.TrackCommentErrorCode;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
@@ -88,16 +89,18 @@ public class TrackCommentService {
 
         // 댓글 조회
         TrackComment comment = trackCommentRepository.findById(commentId)
-                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(
+                        TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND));
 
         // 삭제된 댓글 수정 불가
         if (comment.getDeletedAt() != null) {
-            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
+            throw new BusinessException(
+                    TrackCommentErrorCode.ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED);
         }
 
         // 작성자 검증
         if (!comment.getUserId().equals(userId)) {
-            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
+            throw new BusinessException(TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_UPDATE);
         }
 
         // 댓글 내용 수정

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -88,10 +88,8 @@ public class TrackCommentService {
         // 트랙 접근 가능 여부 검증
         findAccessibleCommentTrack(trackId);
 
-        // 댓글 조회
-        TrackComment comment = trackCommentRepository.findById(commentId)
-                .orElseThrow(() -> new BusinessException(
-                        TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND));
+        // 트랙 댓글 조회
+        TrackComment comment = findTrackComment(trackId, commentId);
 
         // 작성자 검증
         if (!comment.getUserId().equals(userId)) {
@@ -119,10 +117,8 @@ public class TrackCommentService {
         // 유저 조회
         User user = findUser(userId);
 
-        // 댓글 조회
-        TrackComment comment = trackCommentRepository.findById(commentId)
-                .orElseThrow(() -> new BusinessException(
-                        TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND));
+        // 트랙 댓글 조회
+        TrackComment comment = findTrackComment(trackId, commentId);
 
         // 작성자 또는 관리자만 삭제 가능
         validateCommentDeleteAccess(user, comment);
@@ -167,6 +163,17 @@ public class TrackCommentService {
         }
     }
 
+    // 트랙 댓글 조회
+    private TrackComment findTrackComment(Long trackId, Long commentId) {
+        TrackComment comment = trackCommentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(
+                        TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND));
+
+        validateCommentTrack(trackId, comment);
+
+        return comment;
+    }
+
 
     // =========================
     // 검증
@@ -192,6 +199,13 @@ public class TrackCommentService {
             throw new BusinessException(
                     TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_DELETE
             );
+        }
+    }
+
+    // 댓글이 해당 트랙에 속하는지 검증
+    private void validateCommentTrack(Long trackId, TrackComment comment) {
+        if (!comment.getTrackId().equals(trackId)) {
+            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -1,0 +1,122 @@
+package com.fivefy.domain.track.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.entity.Album;
+import com.fivefy.domain.album.enums.AlbumErrorCode;
+import com.fivefy.domain.album.enums.AlbumStatus;
+import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistErrorCode;
+import com.fivefy.domain.artist.repository.ArtistRepository;
+import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackCommentResponse;
+import com.fivefy.domain.track.entity.Track;
+import com.fivefy.domain.track.entity.TrackComment;
+import com.fivefy.domain.track.enums.TrackCommentErrorCode;
+import com.fivefy.domain.track.enums.TrackErrorCode;
+import com.fivefy.domain.track.enums.TrackStatus;
+import com.fivefy.domain.track.enums.TrackType;
+import com.fivefy.domain.track.repository.TrackCommentRepository;
+import com.fivefy.domain.track.repository.TrackRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 트랙 댓글 도메인 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class TrackCommentService {
+
+    private final TrackCommentRepository trackCommentRepository;
+    private final TrackRepository trackRepository;
+    private final UserRepository userRepository;
+    private final AlbumRepository albumRepository;
+    private final ArtistRepository artistRepository;
+
+    /**
+     * 트랙 댓글 작성
+     */
+    @Transactional
+    public TrackCommentResponse createTrackComment(
+            Long userId,
+            Long trackId,
+            TrackCommentCreateRequest request
+    ) {
+        findUser(userId);
+
+        Track track = findTrack(trackId);
+
+        // 현재 조회 가능한 트랙에만 댓글 작성 허용
+        validateTrackCommentWritable(track);
+
+        TrackComment savedComment = trackCommentRepository.save(
+                TrackComment.create(userId, trackId, request.content())
+        );
+
+        return TrackCommentResponse.from(savedComment);
+    }
+
+    // =========================
+    // 조회
+    // =========================
+
+    // 유저 조회
+    private User findUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
+    }
+
+    // 트랙 조회
+    private Track findTrack(Long trackId) {
+        return trackRepository.findById(trackId)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+    }
+
+    // 앨범 조회
+    private Album findAlbum(Long albumId) {
+        return albumRepository.findById(albumId)
+                .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND));
+    }
+
+    // 아티스트 조회
+    private Artist findArtist(Long artistId) {
+        return artistRepository.findById(artistId)
+                .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND));
+    }
+
+    // =========================
+    // 검증
+    // =========================
+
+    // 댓글 작성 가능한 트랙인지 검증
+    private void validateTrackCommentWritable(Track track) {
+        if (track.getDeletedAt() != null || track.getStatus() != TrackStatus.PUBLISHED) {
+            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
+        }
+
+        // 정식 발매 트랙은 연관 앨범/아티스트 공개 가능 상태까지 확인
+        if (track.getTrackType() == TrackType.OFFICIAL_RELEASE) {
+            validateOfficialReleaseTrackCommentWritable(track);
+        }
+    }
+
+    // 정식 발매 트랙 댓글 작성 가능 상태 검증
+    private void validateOfficialReleaseTrackCommentWritable(Track track) {
+        Album album = findAlbum(track.getAlbumId());
+
+        if (album.getDeletedAt() != null || album.getStatus() != AlbumStatus.PUBLISHED) {
+            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
+        }
+
+        Artist artist = findArtist(track.getArtistId());
+
+        if (artist.isDeleted()) {
+            throw new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_WRITABLE);
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/track/controller/TrackCommentControllerTest.java
+++ b/src/test/java/com/fivefy/domain/track/controller/TrackCommentControllerTest.java
@@ -1,0 +1,557 @@
+package com.fivefy.domain.track.controller;
+
+import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.common.filter.LastActiveAtFilter;
+import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackCommentResponse;
+import com.fivefy.domain.track.enums.TrackCommentErrorCode;
+import com.fivefy.domain.track.enums.TrackErrorCode;
+import com.fivefy.domain.track.service.TrackCommentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * TrackCommentController 웹 계층 테스트 및 REST Docs 문서화
+ */
+@WebMvcTest(TrackCommentController.class)
+class TrackCommentControllerTest extends RestDocsSupport {
+
+    @MockitoBean
+    private TrackCommentService trackCommentService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private LastActiveAtFilter lastActiveAtFilter;
+
+    @Nested
+    @WithMockUser
+    @DisplayName("트랙 댓글 작성 API")
+    class CreateTrackComment {
+
+        @Test
+        @DisplayName("트랙 댓글 작성 성공")
+        void createTrackComment_success() throws Exception {
+            Long trackId = 1L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("댓글입니다");
+
+            TrackCommentResponse response = new TrackCommentResponse(
+                    10L,
+                    1L,
+                    trackId,
+                    "댓글입니다",
+                    LocalDateTime.of(2026, 4, 21, 12, 0, 0),
+                    LocalDateTime.of(2026, 4, 21, 12, 0, 0)
+            );
+
+            given(trackCommentService.createTrackComment(eq(1L), eq(trackId), any(TrackCommentCreateRequest.class)))
+                    .willReturn(response);
+
+            mockMvc.perform(post("/api/tracks/{trackId}/comments", trackId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 댓글 작성 성공"))
+                    .andExpect(jsonPath("$.data.commentId").value(10L))
+                    .andExpect(jsonPath("$.data.userId").value(1L))
+                    .andExpect(jsonPath("$.data.trackId").value(trackId))
+                    .andExpect(jsonPath("$.data.content").value("댓글입니다"))
+                    .andDo(document("track-comments-create",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    trackCommentResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 작성 시 요청 검증 실패하면 400 반환")
+        void createTrackComment_fail_validation() throws Exception {
+            Long trackId = 1L;
+
+            mockMvc.perform(post("/api/tracks/{trackId}/comments", trackId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader())
+                            .contentType(APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "content": ""
+                                    }
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("track-comments-create-invalid",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용 (값 없음)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 작성 시 존재하지 않는 트랙이면 404 반환")
+        void createTrackComment_fail_notFound() throws Exception {
+            Long trackId = 999L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("댓글입니다");
+
+            given(trackCommentService.createTrackComment(eq(1L), eq(trackId), any(TrackCommentCreateRequest.class)))
+                    .willThrow(new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+
+            mockMvc.perform(post("/api/tracks/{trackId}/comments", trackId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage()
+                    ))
+                    .andDo(document("track-comments-create-not-found",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser
+    @DisplayName("트랙 댓글 목록 조회 API")
+    class GetTrackComments {
+
+        @Test
+        @DisplayName("트랙 댓글 목록 조회 성공")
+        void getTrackComments_success() throws Exception {
+            Long trackId = 1L;
+
+            TrackCommentResponse content = new TrackCommentResponse(
+                    10L,
+                    1L,
+                    trackId,
+                    "댓글입니다",
+                    LocalDateTime.of(2026, 4, 21, 12, 0, 0),
+                    LocalDateTime.of(2026, 4, 21, 12, 0, 0)
+            );
+
+            PageResponse<TrackCommentResponse> response = PageResponse.from(
+                    new PageImpl<>(List.of(content), PageRequest.of(0, 20), 1)
+            );
+
+            given(trackCommentService.getTrackComments(eq(trackId), any()))
+                    .willReturn(response);
+
+            mockMvc.perform(get("/api/tracks/{trackId}/comments", trackId)
+                            .param("page", "0")
+                            .param("size", "20")
+                            .param("sort", "createdAt,desc"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 댓글 목록 조회 성공"))
+                    .andExpect(jsonPath("$.data.content[0].commentId").value(10L))
+                    .andExpect(jsonPath("$.data.page").value(0))
+                    .andExpect(jsonPath("$.data.size").value(20))
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andDo(document("track-comments-get-list",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID")
+                            ),
+                            queryParameters(
+                                    parameterWithName("page").optional().description("페이지 번호"),
+                                    parameterWithName("size").optional().description("페이지 크기"),
+                                    parameterWithName("sort").optional().description("정렬 조건")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    trackCommentListResponseFields()
+                            ).and(
+                                    pageResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 목록 조회 시 존재하지 않는 트랙이면 404 반환")
+        void getTrackComments_fail_notFound() throws Exception {
+            Long trackId = 999L;
+
+            given(trackCommentService.getTrackComments(eq(trackId), any()))
+                    .willThrow(new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+
+            mockMvc.perform(get("/api/tracks/{trackId}/comments", trackId))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage()
+                    ))
+                    .andDo(document("track-comments-get-list-not-found",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser
+    @DisplayName("트랙 댓글 수정 API")
+    class UpdateTrackComment {
+
+        @Test
+        @DisplayName("트랙 댓글 수정 성공")
+        void updateTrackComment_success() throws Exception {
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글입니다");
+
+            TrackCommentResponse response = new TrackCommentResponse(
+                    commentId,
+                    1L,
+                    trackId,
+                    "수정된 댓글입니다",
+                    LocalDateTime.of(2026, 4, 21, 12, 0, 0),
+                    LocalDateTime.of(2026, 4, 21, 13, 0, 0)
+            );
+
+            given(trackCommentService.updateTrackComment(eq(1L), eq(trackId), eq(commentId), any(TrackCommentCreateRequest.class)))
+                    .willReturn(response);
+
+            mockMvc.perform(patch("/api/tracks/{trackId}/comments/{commentId}", trackId, commentId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 댓글 수정 성공"))
+                    .andExpect(jsonPath("$.data.commentId").value(commentId))
+                    .andExpect(jsonPath("$.data.content").value("수정된 댓글입니다"))
+                    .andDo(document("track-comments-update",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID"),
+                                    parameterWithName("commentId").description("댓글 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    trackCommentResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 수정 시 요청 검증 실패하면 400 반환")
+        void updateTrackComment_fail_validation() throws Exception {
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            mockMvc.perform(patch("/api/tracks/{trackId}/comments/{commentId}", trackId, commentId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader())
+                            .contentType(APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "content": ""
+                                    }
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("track-comments-update-invalid",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID"),
+                                    parameterWithName("commentId").description("댓글 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용 (값 없음)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 수정 시 존재하지 않는 댓글이면 404 반환")
+        void updateTrackComment_fail_notFound() throws Exception {
+            Long trackId = 1L;
+            Long commentId = 999L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글입니다");
+
+            given(trackCommentService.updateTrackComment(eq(1L), eq(trackId), eq(commentId), any(TrackCommentCreateRequest.class)))
+                    .willThrow(new BusinessException(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND));
+
+            mockMvc.perform(patch("/api/tracks/{trackId}/comments/{commentId}", trackId, commentId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND.getMessage()
+                    ))
+                    .andDo(document("track-comments-update-not-found",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID"),
+                                    parameterWithName("commentId").description("댓글 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 수정 시 권한이 없으면 403 반환")
+        void updateTrackComment_fail_forbidden() throws Exception {
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글입니다");
+
+            given(trackCommentService.updateTrackComment(eq(1L), eq(trackId), eq(commentId), any(TrackCommentCreateRequest.class)))
+                    .willThrow(new BusinessException(TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_UPDATE));
+
+            mockMvc.perform(patch("/api/tracks/{trackId}/comments/{commentId}", trackId, commentId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader())
+                            .contentType(APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_UPDATE.getMessage()
+                    ))
+                    .andDo(document("track-comments-update-forbidden",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID"),
+                                    parameterWithName("commentId").description("댓글 ID")
+                            ),
+                            requestFields(
+                                    fieldWithPath("content").type(STRING).description("댓글 내용")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    @Nested
+    @WithMockUser
+    @DisplayName("트랙 댓글 삭제 API")
+    class DeleteTrackComment {
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 성공")
+        void deleteTrackComment_success() throws Exception {
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            mockMvc.perform(delete("/api/tracks/{trackId}/comments/{commentId}", trackId, commentId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true))
+                    .andExpect(jsonPath("$.message").value("트랙 댓글 삭제 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist())
+                    .andDo(document("track-comments-delete",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID"),
+                                    parameterWithName("commentId").description("댓글 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 시 존재하지 않는 댓글이면 404 반환")
+        void deleteTrackComment_fail_notFound() throws Exception {
+            Long trackId = 1L;
+            Long commentId = 999L;
+
+            willThrow(new BusinessException(
+                    TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND
+            )).given(trackCommentService).deleteTrackComment(eq(1L), eq(trackId), eq(commentId));
+
+            mockMvc.perform(delete("/api/tracks/{trackId}/comments/{commentId}", trackId, commentId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader()))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND.getMessage()
+                    ))
+                    .andDo(document("track-comments-delete-not-found",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID"),
+                                    parameterWithName("commentId").description("댓글 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 시 권한이 없으면 403 반환")
+        void deleteTrackComment_fail_forbidden() throws Exception {
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            willThrow(new BusinessException(
+                    TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_DELETE
+            )).given(trackCommentService).deleteTrackComment(eq(1L), eq(trackId), eq(commentId));
+
+            mockMvc.perform(delete("/api/tracks/{trackId}/comments/{commentId}", trackId, commentId)
+                            .with(authentication(new UsernamePasswordAuthenticationToken(1L, null, List.of())))
+                            .with(csrf().asHeader()))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.message").value(
+                            TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_DELETE.getMessage()
+                    ))
+                    .andDo(document("track-comments-delete-forbidden",
+                            pathParameters(
+                                    parameterWithName("trackId").description("트랙 ID"),
+                                    parameterWithName("commentId").description("댓글 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
+        }
+    }
+
+    private FieldDescriptor[] baseSuccessResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("응답 메시지")
+        };
+    }
+
+    private FieldDescriptor[] baseErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("에러 메시지")
+        };
+    }
+
+    private FieldDescriptor[] validationErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+        };
+    }
+
+    private FieldDescriptor[] pageResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.page").type(NUMBER).description("현재 페이지"),
+                fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
+                fieldWithPath("data.totalElements").type(NUMBER).description("전체 데이터 수"),
+                fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수")
+        };
+    }
+
+    private FieldDescriptor[] trackCommentResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.commentId").type(NUMBER).description("댓글 ID"),
+                fieldWithPath("data.userId").type(NUMBER).description("댓글 작성자 ID"),
+                fieldWithPath("data.trackId").type(NUMBER).description("트랙 ID"),
+                fieldWithPath("data.content").type(STRING).description("댓글 내용"),
+                fieldWithPath("data.createdAt").type(STRING).description("댓글 작성 시각"),
+                fieldWithPath("data.updatedAt").type(STRING).description("댓글 수정 시각")
+        };
+    }
+
+    private FieldDescriptor[] trackCommentListResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.content").type(ARRAY).description("트랙 댓글 목록"),
+                fieldWithPath("data.content[].commentId").type(NUMBER).description("댓글 ID"),
+                fieldWithPath("data.content[].userId").type(NUMBER).description("댓글 작성자 ID"),
+                fieldWithPath("data.content[].trackId").type(NUMBER).description("트랙 ID"),
+                fieldWithPath("data.content[].content").type(STRING).description("댓글 내용"),
+                fieldWithPath("data.content[].createdAt").type(STRING).description("댓글 작성 시각"),
+                fieldWithPath("data.content[].updatedAt").type(STRING).description("댓글 수정 시각")
+        };
+    }
+}

--- a/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
@@ -20,6 +20,7 @@ import com.fivefy.domain.track.repository.TrackCommentRepository;
 import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -358,7 +359,6 @@ class TrackCommentServiceTest {
             TrackComment comment = mock(TrackComment.class);
             when(comment.getUserId()).thenReturn(userId);
             when(comment.getTrackId()).thenReturn(trackId);
-            when(comment.getDeletedAt()).thenReturn(null);
 
             when(trackCommentRepository.findById(commentId))
                     .thenReturn(Optional.of(comment));
@@ -384,7 +384,11 @@ class TrackCommentServiceTest {
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
 
-            stubPublishedFreeCreationTrack(trackId);
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
 
             when(trackCommentRepository.findById(commentId))
                     .thenReturn(Optional.empty());
@@ -406,10 +410,15 @@ class TrackCommentServiceTest {
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
 
-            stubPublishedFreeCreationTrack(trackId);
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
 
-            TrackComment comment = mock(TrackComment.class);
-            when(comment.getDeletedAt()).thenReturn(LocalDateTime.now());
+            TrackComment comment = TrackComment.create(userId, trackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
+            ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.now());
 
             when(trackCommentRepository.findById(commentId))
                     .thenReturn(Optional.of(comment));
@@ -431,11 +440,13 @@ class TrackCommentServiceTest {
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
 
-            stubPublishedFreeCreationTrack(trackId);
-
-            TrackComment comment = mock(TrackComment.class);
-            when(comment.getUserId()).thenReturn(999L); // 다른 사용자
-            when(comment.getDeletedAt()).thenReturn(null);
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+            TrackComment comment = TrackComment.create(999L, trackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
 
             when(trackCommentRepository.findById(commentId))
                     .thenReturn(Optional.of(comment));
@@ -470,18 +481,167 @@ class TrackCommentServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("트랙 댓글 삭제")
+    class DeleteTrackComment {
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 성공 - 작성자")
+        void deleteTrackComment_success_writer() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+            when(user.getId()).thenReturn(userId);
+            when(user.getRole()).thenReturn(UserRole.USER);
+
+            // 공개된 자유 창작 트랙 조회 mock 구성
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = TrackComment.create(userId, trackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            trackCommentService.deleteTrackComment(userId, trackId, commentId);
+
+            assertThat(comment.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 성공 - 관리자")
+        void deleteTrackComment_success_admin() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+            when(user.getId()).thenReturn(userId);
+            when(user.getRole()).thenReturn(UserRole.ADMIN);
+
+            // 공개된 자유 창작 트랙 조회 mock 구성
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = TrackComment.create(999L, trackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            trackCommentService.deleteTrackComment(userId, trackId, commentId);
+
+            assertThat(comment.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 실패 - 댓글 없음")
+        void deleteTrackComment_fail_whenCommentNotFound() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    trackCommentService.deleteTrackComment(userId, trackId, commentId)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 실패 - 권한 없음")
+        void deleteTrackComment_fail_whenForbidden() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+            when(user.getId()).thenReturn(userId);
+            when(user.getRole()).thenReturn(UserRole.USER);
+
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+            TrackComment comment = TrackComment.create(999L, trackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            assertThatThrownBy(() ->
+                    trackCommentService.deleteTrackComment(userId, trackId, commentId)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_DELETE.getMessage());
+        }
+
+        @Test
+        @DisplayName("트랙 댓글 삭제 실패 - 이미 삭제된 댓글")
+        void deleteTrackComment_fail_whenAlreadyDeleted() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+            when(user.getId()).thenReturn(userId);
+            when(user.getRole()).thenReturn(UserRole.USER);
+
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+
+            TrackComment comment = TrackComment.create(userId, trackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
+            ReflectionTestUtils.setField(comment, "deletedAt", LocalDateTime.now());
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            assertThatThrownBy(() ->
+                    trackCommentService.deleteTrackComment(userId, trackId, commentId)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_TRACK_COMMENT_ALREADY_DELETED.getMessage());
+        }
+    }
+
     // 공개된 자유 창작 트랙 조회 mock 구성
-    private Track stubPublishedFreeCreationTrack(Long trackId) {
+    private void stubPublishedFreeCreationTrack(Long trackId) {
         Track track = mock(Track.class);
         when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
         when(track.getDeletedAt()).thenReturn(null);
         when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
         when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
-        return track;
     }
 
     // 공개된 정식 발매 트랙 조회 mock 구성
-    private Track stubPublishedOfficialReleaseTrack(Long trackId, Long artistId, Long albumId) {
+    private void stubPublishedOfficialReleaseTrack(Long trackId, Long artistId, Long albumId) {
         Track track = mock(Track.class);
         when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
         when(track.getDeletedAt()).thenReturn(null);
@@ -489,7 +649,6 @@ class TrackCommentServiceTest {
         when(track.getTrackType()).thenReturn(TrackType.OFFICIAL_RELEASE);
         when(track.getArtistId()).thenReturn(artistId);
         when(track.getAlbumId()).thenReturn(albumId);
-        return track;
     }
 
     // 공개된 앨범 조회 mock 구성
@@ -520,6 +679,4 @@ class TrackCommentServiceTest {
 
         when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
     }
-
-
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
@@ -1,10 +1,17 @@
 package com.fivefy.domain.track.service;
 
+import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.album.entity.Album;
+import com.fivefy.domain.album.enums.AlbumStatus;
 import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackCommentResponse;
 import com.fivefy.domain.track.entity.Track;
+import com.fivefy.domain.track.entity.TrackComment;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
@@ -13,7 +20,6 @@ import com.fivefy.domain.track.repository.TrackRepository;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,7 +27,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,11 +43,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * TrackCommentService의 비즈니스 로직을 검증하는 단위 테스트
+ *
+ * 트랙 댓글 작성 기능 검증
+ * 트랙 댓글 목록 조회 기능 검증
+ */
 @ExtendWith(MockitoExtension.class)
 class TrackCommentServiceTest {
-
-    @InjectMocks
-    private TrackCommentService trackCommentService;
 
     @Mock
     private TrackCommentRepository trackCommentRepository;
@@ -51,14 +67,8 @@ class TrackCommentServiceTest {
     @Mock
     private ArtistRepository artistRepository;
 
-    private User user;
-    private Track track;
-
-    @BeforeEach
-    void setUp() {
-        user = mock(User.class);
-        track = mock(Track.class);
-    }
+    @InjectMocks
+    private TrackCommentService trackCommentService;
 
     @Nested
     @DisplayName("트랙 댓글 작성")
@@ -69,59 +79,314 @@ class TrackCommentServiceTest {
         void createTrackComment_success() {
             Long userId = 1L;
             Long trackId = 1L;
-            TrackCommentCreateRequest request = new TrackCommentCreateRequest("댓글입니다");
 
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("댓글입니다");
+
+            User user = mock(User.class);
             when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(Optional.of(user));
 
-            when(trackRepository.findById(trackId))
-                    .thenReturn(Optional.of(track));
+            // 공개된 자유 창작 트랙 조회 mock 구성
+            stubPublishedFreeCreationTrack(trackId);
 
-            when(track.getDeletedAt()).thenReturn(null);
-            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
-            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
-
-            when(trackCommentRepository.save(any()))
+            when(trackCommentRepository.save(any(TrackComment.class)))
                     .thenAnswer(invocation -> invocation.getArgument(0));
 
             TrackCommentResponse response =
                     trackCommentService.createTrackComment(userId, trackId, request);
 
-            assertThat(response).isNotNull();
             assertThat(response.content()).isEqualTo("댓글입니다");
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.trackId()).isEqualTo(trackId);
+        }
+
+        @Test
+        @DisplayName("정식 발매 트랙 댓글 작성 성공")
+        void createTrackComment_success_whenOfficialRelease() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("댓글입니다");
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            // 공개된 정식 발매 트랙 조회 mock 구성
+            stubPublishedOfficialReleaseTrack(trackId, artistId, albumId);
+            // 공개된 앨범 조회 mock 구성
+            stubPublishedAlbum(albumId, artistId);
+            // 삭제되지 않은 아티스트 조회 mock 구성
+            stubNotDeletedArtist(artistId);
+
+            when(trackCommentRepository.save(any(TrackComment.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            TrackCommentResponse response =
+                    trackCommentService.createTrackComment(userId, trackId, request);
+
+            assertThat(response.content()).isEqualTo("댓글입니다");
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.trackId()).isEqualTo(trackId);
         }
 
         @Test
         @DisplayName("존재하지 않는 유저면 트랙 댓글 작성 실패")
-        void createTrackComment_fail_userNotFound() {
+        void createTrackComment_fail_whenUserNotFound() {
             Long userId = 1L;
             Long trackId = 1L;
-            TrackCommentCreateRequest request = new TrackCommentCreateRequest("댓글입니다");
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("댓글입니다");
 
             when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(Optional.empty());
 
             assertThatThrownBy(() ->
                     trackCommentService.createTrackComment(userId, trackId, request)
-            ).hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
         }
 
         @Test
         @DisplayName("존재하지 않는 트랙이면 트랙 댓글 작성 실패")
-        void createTrackComment_fail_trackNotFound() {
+        void createTrackComment_fail_whenTrackNotFound() {
             Long userId = 1L;
             Long trackId = 1L;
-            TrackCommentCreateRequest request = new TrackCommentCreateRequest("댓글입니다");
 
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("댓글입니다");
+
+            User user = mock(User.class);
             when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(Optional.of(user));
 
-            when(trackRepository.findById(trackId))
-                    .thenReturn(Optional.empty());
+            when(trackRepository.findById(trackId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() ->
                     trackCommentService.createTrackComment(userId, trackId, request)
-            ).hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("비공개 트랙이면 트랙 댓글 작성 실패")
+        void createTrackComment_fail_whenTrackUnpublished() {
+            Long userId = 1L;
+            Long trackId = 1L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("댓글입니다");
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.UNPUBLISHED);
+
+            assertThatThrownBy(() ->
+                    trackCommentService.createTrackComment(userId, trackId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
         }
     }
+
+    @Nested
+    @DisplayName("트랙 댓글 목록 조회")
+    class GetTrackComments {
+
+        @Test
+        @DisplayName("FREE_CREATION 트랙 댓글 목록 조회 성공")
+        void getTrackComments_success_whenFreeCreation() {
+            Long trackId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+
+            // 공개된 자유 창작 트랙 조회 mock 구성
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = mock(TrackComment.class);
+            when(comment.getId()).thenReturn(1L);
+            when(comment.getUserId()).thenReturn(10L);
+            when(comment.getTrackId()).thenReturn(trackId);
+            when(comment.getContent()).thenReturn("댓글");
+            when(comment.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 4, 21, 12, 0, 0));
+            when(comment.getUpdatedAt()).thenReturn(LocalDateTime.of(2026, 4, 21, 12, 0, 0));
+
+            Page<TrackComment> page = new PageImpl<>(List.of(comment), pageable, 1);
+
+            when(trackCommentRepository.getTrackComments(trackId, pageable))
+                    .thenReturn(page);
+
+            PageResponse<TrackCommentResponse> response =
+                    trackCommentService.getTrackComments(trackId, pageable);
+
+            assertThat(response.content()).hasSize(1);
+            assertThat(response.content().get(0).commentId()).isEqualTo(1L);
+            assertThat(response.content().get(0).userId()).isEqualTo(10L);
+            assertThat(response.content().get(0).trackId()).isEqualTo(trackId);
+            assertThat(response.content().get(0).content()).isEqualTo("댓글");
+            assertThat(response.page()).isEqualTo(0);
+            assertThat(response.size()).isEqualTo(20);
+            assertThat(response.totalElements()).isEqualTo(1);
+            assertThat(response.totalPages()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("OFFICIAL_RELEASE 트랙 댓글 목록 조회 성공")
+        void getTrackComments_success_whenOfficialRelease() {
+            Long trackId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+            Pageable pageable = PageRequest.of(0, 20);
+
+            // 공개된 정식 발매 트랙 조회 mock 구성
+            stubPublishedOfficialReleaseTrack(trackId, artistId, albumId);
+            // 공개된 앨범 조회 mock 구성
+            stubPublishedAlbum(albumId, artistId);
+            // 삭제되지 않은 아티스트 조회 mock 구성
+            stubNotDeletedArtist(artistId);
+
+            when(trackCommentRepository.getTrackComments(trackId, pageable))
+                    .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+            PageResponse<TrackCommentResponse> response =
+                    trackCommentService.getTrackComments(trackId, pageable);
+
+            assertThat(response.content()).isEmpty();
+            assertThat(response.page()).isEqualTo(0);
+            assertThat(response.size()).isEqualTo(20);
+            assertThat(response.totalElements()).isZero();
+            assertThat(response.totalPages()).isZero();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 트랙이면 트랙 댓글 목록 조회 실패")
+        void getTrackComments_fail_whenTrackNotFound() {
+            Long trackId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+
+            when(trackRepository.findById(trackId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    trackCommentService.getTrackComments(trackId, pageable)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("비공개 트랙이면 트랙 댓글 목록 조회 실패")
+        void getTrackComments_fail_whenTrackUnpublished() {
+            Long trackId = 1L;
+            Pageable pageable = PageRequest.of(0, 20);
+
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.UNPUBLISHED);
+
+            assertThatThrownBy(() ->
+                    trackCommentService.getTrackComments(trackId, pageable)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("정식 발매 트랙인데 미공개 앨범이면 트랙 댓글 목록 조회 실패")
+        void getTrackComments_fail_whenOfficialReleaseAlbumUnpublished() {
+            Long trackId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
+            Pageable pageable = PageRequest.of(0, 20);
+
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.OFFICIAL_RELEASE);
+            when(track.getAlbumId()).thenReturn(albumId);
+
+            Album album = Album.create(
+                    artistId,
+                    "Palette",
+                    "정규 앨범",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
+            ReflectionTestUtils.setField(album, "status", AlbumStatus.UNPUBLISHED);
+
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+
+            assertThatThrownBy(() ->
+                    trackCommentService.getTrackComments(trackId, pageable)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+    }
+
+    // 공개된 자유 창작 트랙 조회 mock 구성
+    private Track stubPublishedFreeCreationTrack(Long trackId) {
+        Track track = mock(Track.class);
+        when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+        when(track.getDeletedAt()).thenReturn(null);
+        when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+        when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+        return track;
+    }
+
+    // 공개된 정식 발매 트랙 조회 mock 구성
+    private Track stubPublishedOfficialReleaseTrack(Long trackId, Long artistId, Long albumId) {
+        Track track = mock(Track.class);
+        when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+        when(track.getDeletedAt()).thenReturn(null);
+        when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+        when(track.getTrackType()).thenReturn(TrackType.OFFICIAL_RELEASE);
+        when(track.getArtistId()).thenReturn(artistId);
+        when(track.getAlbumId()).thenReturn(albumId);
+        return track;
+    }
+
+    // 공개된 앨범 조회 mock 구성
+    private void stubPublishedAlbum(Long albumId, Long artistId) {
+        Album album = Album.create(
+                artistId,
+                "Palette",
+                "정규 앨범",
+                "https://example.com/cover.jpg",
+                null
+        );
+        ReflectionTestUtils.setField(album, "id", albumId);
+        album.publish();
+
+        when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
+    }
+
+    // 삭제되지 않은 아티스트 조회 mock 구성
+    private void stubNotDeletedArtist(Long artistId) {
+        Artist artist = Artist.create(
+                1L,
+                "아이유",
+                ArtistType.SOLO,
+                "가수",
+                "https://example.com/artist.jpg"
+        );
+        ReflectionTestUtils.setField(artist, "id", artistId);
+
+        when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+    }
+
+
 }

--- a/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
@@ -1,0 +1,127 @@
+package com.fivefy.domain.track.service;
+
+import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.artist.repository.ArtistRepository;
+import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
+import com.fivefy.domain.track.dto.response.TrackCommentResponse;
+import com.fivefy.domain.track.entity.Track;
+import com.fivefy.domain.track.enums.TrackErrorCode;
+import com.fivefy.domain.track.enums.TrackStatus;
+import com.fivefy.domain.track.enums.TrackType;
+import com.fivefy.domain.track.repository.TrackCommentRepository;
+import com.fivefy.domain.track.repository.TrackRepository;
+import com.fivefy.domain.user.entity.User;
+import com.fivefy.domain.user.enums.UserErrorCode;
+import com.fivefy.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TrackCommentServiceTest {
+
+    @InjectMocks
+    private TrackCommentService trackCommentService;
+
+    @Mock
+    private TrackCommentRepository trackCommentRepository;
+
+    @Mock
+    private TrackRepository trackRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AlbumRepository albumRepository;
+
+    @Mock
+    private ArtistRepository artistRepository;
+
+    private User user;
+    private Track track;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        track = mock(Track.class);
+    }
+
+    @Nested
+    @DisplayName("트랙 댓글 작성")
+    class CreateTrackComment {
+
+        @Test
+        @DisplayName("트랙 댓글 작성 성공")
+        void createTrackComment_success() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            TrackCommentCreateRequest request = new TrackCommentCreateRequest("댓글입니다");
+
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            when(trackRepository.findById(trackId))
+                    .thenReturn(Optional.of(track));
+
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.PUBLISHED);
+            when(track.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+
+            when(trackCommentRepository.save(any()))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            TrackCommentResponse response =
+                    trackCommentService.createTrackComment(userId, trackId, request);
+
+            assertThat(response).isNotNull();
+            assertThat(response.content()).isEqualTo("댓글입니다");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 트랙 댓글 작성 실패")
+        void createTrackComment_fail_userNotFound() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            TrackCommentCreateRequest request = new TrackCommentCreateRequest("댓글입니다");
+
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    trackCommentService.createTrackComment(userId, trackId, request)
+            ).hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 트랙이면 트랙 댓글 작성 실패")
+        void createTrackComment_fail_trackNotFound() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            TrackCommentCreateRequest request = new TrackCommentCreateRequest("댓글입니다");
+
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            when(trackRepository.findById(trackId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    trackCommentService.createTrackComment(userId, trackId, request)
+            ).hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
@@ -353,12 +353,19 @@ class TrackCommentServiceTest {
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
 
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+            when(user.getId()).thenReturn(userId);
+
             // 공개된 자유 창작 트랙 조회 mock 구성
             stubPublishedFreeCreationTrack(trackId);
 
             TrackComment comment = mock(TrackComment.class);
+            when(comment.isWrittenBy(userId)).thenReturn(true);
             when(comment.getUserId()).thenReturn(userId);
             when(comment.getTrackId()).thenReturn(trackId);
+            when(comment.getContent()).thenReturn("수정된 댓글");
 
             when(trackCommentRepository.findById(commentId))
                     .thenReturn(Optional.of(comment));
@@ -383,6 +390,10 @@ class TrackCommentServiceTest {
 
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
 
             Track track = mock(Track.class);
             when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
@@ -409,6 +420,11 @@ class TrackCommentServiceTest {
 
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+            when(user.getId()).thenReturn(userId);
 
             Track track = mock(Track.class);
             when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
@@ -440,6 +456,10 @@ class TrackCommentServiceTest {
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
 
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
             Track track = mock(Track.class);
             when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
             when(track.getDeletedAt()).thenReturn(null);
@@ -468,6 +488,10 @@ class TrackCommentServiceTest {
             TrackCommentCreateRequest request =
                     new TrackCommentCreateRequest("수정된 댓글");
 
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
             Track track = mock(Track.class);
             when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
             when(track.getDeletedAt()).thenReturn(null);
@@ -478,6 +502,36 @@ class TrackCommentServiceTest {
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("다른 트랙의 댓글이면 수정 실패")
+        void updateTrackComment_fail_whenCommentBelongsToAnotherTrack() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long anotherTrackId = 999L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글");
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = TrackComment.create(userId, anotherTrackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            assertThatThrownBy(() ->
+                    trackCommentService.updateTrackComment(userId, trackId, commentId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND.getMessage());
         }
     }
 
@@ -628,6 +682,33 @@ class TrackCommentServiceTest {
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(TrackCommentErrorCode.ERR_TRACK_COMMENT_ALREADY_DELETED.getMessage());
+        }
+
+        @Test
+        @DisplayName("다른 트랙의 댓글이면 삭제 실패")
+        void deleteTrackComment_fail_whenCommentBelongsToAnotherTrack() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long anotherTrackId = 999L;
+            Long commentId = 10L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = TrackComment.create(userId, anotherTrackId, "댓글입니다");
+            ReflectionTestUtils.setField(comment, "id", commentId);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            assertThatThrownBy(() ->
+                    trackCommentService.deleteTrackComment(userId, trackId, commentId)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND.getMessage());
         }
     }
 

--- a/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackCommentServiceTest.java
@@ -12,6 +12,7 @@ import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackCommentResponse;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackComment;
+import com.fivefy.domain.track.enums.TrackCommentErrorCode;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
@@ -331,6 +332,138 @@ class TrackCommentServiceTest {
 
             assertThatThrownBy(() ->
                     trackCommentService.getTrackComments(trackId, pageable)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("트랙 댓글 수정")
+    class UpdateTrackComment {
+
+        @Test
+        @DisplayName("트랙 댓글 수정 성공")
+        void updateTrackComment_success() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글");
+
+            // 공개된 자유 창작 트랙 조회 mock 구성
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = mock(TrackComment.class);
+            when(comment.getUserId()).thenReturn(userId);
+            when(comment.getTrackId()).thenReturn(trackId);
+            when(comment.getDeletedAt()).thenReturn(null);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            // 수정 동작 mock
+            when(comment.getContent()).thenReturn("수정된 댓글");
+
+            TrackCommentResponse response =
+                    trackCommentService.updateTrackComment(userId, trackId, commentId, request);
+
+            assertThat(response.content()).isEqualTo("수정된 댓글");
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.trackId()).isEqualTo(trackId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 댓글이면 수정 실패")
+        void updateTrackComment_fail_whenCommentNotFound() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글");
+
+            stubPublishedFreeCreationTrack(trackId);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    trackCommentService.updateTrackComment(userId, trackId, commentId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_TRACK_COMMENT_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제된 댓글이면 수정 실패")
+        void updateTrackComment_fail_whenDeletedComment() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글");
+
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = mock(TrackComment.class);
+            when(comment.getDeletedAt()).thenReturn(LocalDateTime.now());
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            assertThatThrownBy(() ->
+                    trackCommentService.updateTrackComment(userId, trackId, commentId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_DELETED_TRACK_COMMENT_CANNOT_BE_UPDATED.getMessage());
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 수정 실패")
+        void updateTrackComment_fail_whenNotOwner() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글");
+
+            stubPublishedFreeCreationTrack(trackId);
+
+            TrackComment comment = mock(TrackComment.class);
+            when(comment.getUserId()).thenReturn(999L); // 다른 사용자
+            when(comment.getDeletedAt()).thenReturn(null);
+
+            when(trackCommentRepository.findById(commentId))
+                    .thenReturn(Optional.of(comment));
+
+            assertThatThrownBy(() ->
+                    trackCommentService.updateTrackComment(userId, trackId, commentId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackCommentErrorCode.ERR_FORBIDDEN_TRACK_COMMENT_UPDATE.getMessage());
+        }
+
+        @Test
+        @DisplayName("비공개 트랙이면 수정 실패")
+        void updateTrackComment_fail_whenTrackUnpublished() {
+            Long userId = 1L;
+            Long trackId = 1L;
+            Long commentId = 10L;
+
+            TrackCommentCreateRequest request =
+                    new TrackCommentCreateRequest("수정된 댓글");
+
+            Track track = mock(Track.class);
+            when(trackRepository.findById(trackId)).thenReturn(Optional.of(track));
+            when(track.getDeletedAt()).thenReturn(null);
+            when(track.getStatus()).thenReturn(TrackStatus.UNPUBLISHED);
+
+            assertThatThrownBy(() ->
+                    trackCommentService.updateTrackComment(userId, trackId, commentId, request)
             )
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(TrackErrorCode.ERR_TRACK_NOT_FOUND.getMessage());


### PR DESCRIPTION
## 개요
- 공개된 트랙 기준 댓글 작성·목록 조회·수정·삭제 API 추가  
- 작성자/관리자 권한 정책, 공개 상태 검증, REST Docs 문서화 반영  

## 변경 사항

### 기능 구현
- API 추가
  - `POST /api/tracks/{trackId}/comments`
  - `GET /api/tracks/{trackId}/comments`
  - `PATCH /api/tracks/{trackId}/comments/{commentId}`
  - `DELETE /api/tracks/{trackId}/comments/{commentId}`
- DTO 추가/수정
  - TrackCommentCreateRequest 추가
  - TrackCommentResponse 추가
  - 댓글 목록 응답을 `PageResponse<TrackCommentResponse>` 구조로 반환
- 서비스 로직 구성
  - 댓글 작성 시 유저 존재 여부 확인 후 공개 가능한 트랙 대상만 생성 처리
  - 댓글 목록 조회 시 공개 가능한 트랙 대상만 페이징 조회 처리
  - 댓글 수정 시 댓글 존재 여부 확인 후 작성자 본인만 수정 가능하도록 검증 처리
  - 댓글 삭제 시 댓글 존재 여부 확인 후 작성자 또는 관리자만 삭제 가능하도록 검증 처리
  - 정식 발매 트랙은 트랙 공개 상태뿐 아니라 앨범 공개 상태, 아티스트 삭제 여부까지 함께 검증 처리

### 조회 계층 구성
- TrackCommentQueryRepository / TrackCommentQueryRepositoryImpl 추가
- Querydsl 기반 댓글 목록 조회 구성
- `trackId`, `deletedAt is null` 조건으로 필터링 후 `createdAt desc` 기준 정렬 적용
- 페이징 조회와 전체 개수 조회 분리 구성

### 정책 및 권한
- 공개되지 않았거나 삭제된 트랙은 댓글 접근 불가 정책 반영
- `OFFICIAL_RELEASE` 트랙은 공개 앨범 + 삭제되지 않은 아티스트 기준으로만 댓글 접근 허용
- 댓글 수정 권한은 작성자 본인만 허용
- 댓글 삭제 권한은 작성자 또는 ADMIN만 허용
- 댓글 길이 1000자 초과 검증 추가
- SecurityConfig에 `GET /api/tracks/{trackId}/comments` 공개 접근 경로 추가

### 도메인 및 예외 정리
- TrackComment 상태 enum 제거
- TrackComment 엔티티 내부에 댓글 길이 검증 추가
- TrackCommentErrorCode 정리
  - 댓글 없음
  - 이미 삭제된 댓글
  - 삭제된 댓글 수정 불가
  - 수정 권한 없음
  - 삭제 권한 없음
  - 댓글 길이 초과
- TrackErrorCode의 트랙 없음 메시지 문구 정리

### 테스트 및 문서화
- TrackCommentServiceTest 추가
  - 댓글 작성/목록 조회/수정/삭제 성공 케이스 검증
  - 유저 없음, 트랙 없음, 비공개 트랙, 권한 없음, 이미 삭제된 댓글 등 실패 케이스 검증
  - 자유 창작 / 정식 발매 트랙 분기 검증
- TrackCommentControllerTest 추가
  - 작성/목록 조회/수정/삭제 성공 케이스 검증
  - 요청 검증 실패, 존재하지 않는 트랙/댓글, 권한 없음 케이스 문서화
- `index.adoc`에 Track Comment API 섹션 추가
  - 성공/에러 케이스 스니펫 연결
  - 작성, 목록 조회, 수정, 삭제 문서 구성 반영

## 변경 유형
- [x] 새로운 기능 추가  
- [x] 테스트 코드 추가  
- [x] 문서 수정  

## 테스트 방법
```bash
./gradlew test --tests "com.fivefy.domain.track.service.TrackCommentServiceTest"
./gradlew test --tests "com.fivefy.domain.track.controller.TrackCommentControllerTest"
```

주요 확인 시나리오
- 공개된 자유 창작 트랙 댓글 작성/조회/수정/삭제 확인  
- 공개된 정식 발매 트랙 댓글 작성/조회 가능 여부 확인  
- 존재하지 않는 트랙 또는 댓글 요청 시 예외 응답 확인  
- 댓글 수정 시 작성자만 허용되는지 확인  
- 댓글 삭제 시 작성자 또는 관리자만 허용되는지 확인  
- 댓글 길이 및 빈 값 요청 검증 확인  
- REST Docs 스니펫 및 `index.adoc` 연동 여부 확인  

## 체크리스트
- [x] 코드 자체 리뷰 완료  
- [x] 테스트 코드 작성 / 확인  
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 트랙 댓글 API 추가: 댓글 생성, 조회(페이지네이션 기본 20, 최신순), 수정, 삭제 지원
  * 댓글 작성 시 내용 필수 및 최대 1000자 제한 적용
  * 작성자 전용 수정 권한 및 작성자/관리자 삭제 권한 적용
  * 인증 없이 트랙 댓글 목록 조회 가능

* **문서**
  * Track Comment API 문서 및 요청/응답 예제·오류 사례 추가

* **테스트**
  * 컨트롤러·서비스 단위 테스트 추가(성공·실패 경로 포함)

* **버그 수정**
  * 트랙 관련 오류 메시지 일부 표기 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->