### PR TITLE
fix: NCP Object Storage 업로드 시 AccessDenied 오류 해결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,8 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.NCP_SECRET_KEY }}
-          AWS_DEFAULT_REGION: kr
+          AWS_DEFAULT_REGION: kr-standard
+          AWS_REQUEST_CHECKSUM_CALCULATION: WHEN_REQUIRED
         run: |
           DEPLOY_ENV=${{ steps.env.outputs.name }}
           aws configure set default.s3.multipart_threshold 200MB


### PR DESCRIPTION
## 개요

> NCP Object Storage 업로드 시 AccessDenied 오류 해결

## 변경 사항

- AWS CLI 최신 버전의 체크섬 헤더 규격 불일치 문제 해결
- GitHub Actions 워크플로우에 AWS_REQUEST_CHECKSUM_CALCULATION 환경 변수 추가

## 변경 유형

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [x] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 환경 설정을 최신화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->