### PR TITLE
feat: 플레이리스트 soft delete 정책 강화 및 cleanup 자동화 구현

### DIFF
--- a/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
+++ b/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
@@ -16,7 +16,14 @@ import java.util.Objects;
 
 @Getter
 @Entity
-@Table(name = "playlists")
+@Table(
+        name = "playlists",
+        indexes = {
+                @Index(name = "idx_playlist_deleted_at", columnList = "deleted_at"),
+                @Index(name = "idx_playlist_user_deleted_at", columnList = "user_id, deleted_at"),
+                @Index(name = "idx_playlist_user_title_deleted_at", columnList = "user_id, title, deleted_at")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Playlist extends BaseEntity {
 
@@ -30,18 +37,18 @@ public class Playlist extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String title;
 
+    @Column(length = 255)
     private String description;
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     public static Playlist create(Long userId, String title, String description) {
         validateNonNull(userId, "userId");
-        if (title == null || title.isBlank() || title.length() > 100) {
-            throw new BusinessException(PlaylistErrorCode.INVALID_TITLE);
-        }
+        validateTitle(title);
 
         Playlist playlist = new Playlist();
         playlist.userId = userId;
@@ -55,12 +62,11 @@ public class Playlist extends BaseEntity {
         return Objects.equals(this.userId, userId);
     }
 
+    public boolean isDeleted() { return this.deletedAt != null; }
+
     public void update(String title, String description) {
         validateNotDeleted();
-
-        if (title == null || title.isBlank() || title.length() > 100) {
-            throw new BusinessException(PlaylistErrorCode.INVALID_TITLE);
-        }
+        validateTitle(title);
 
         this.title = title;
         this.description = description;
@@ -72,8 +78,14 @@ public class Playlist extends BaseEntity {
     }
 
     private void validateNotDeleted() {
-        if (this.deletedAt != null) {
+        if (isDeleted()) {
             throw new BusinessException(PlaylistErrorCode.ALREADY_DELETED_PLAYLIST);
+        }
+    }
+
+    private static void validateTitle(String title) {
+        if (title == null || title.isBlank() || title.length() > 100) {
+            throw new BusinessException(PlaylistErrorCode.INVALID_TITLE);
         }
     }
 }

--- a/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
+++ b/src/main/java/com/fivefy/domain/playlist/entity/Playlist.java
@@ -18,6 +18,12 @@ import java.util.Objects;
 @Entity
 @Table(
         name = "playlists",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_playlist_user_title_deleted",
+                        columnNames = {"user_id", "title", "deleted"}
+                )
+        },
         indexes = {
                 @Index(name = "idx_playlist_deleted_at", columnList = "deleted_at"),
                 @Index(name = "idx_playlist_user_deleted_at", columnList = "user_id, deleted_at"),
@@ -40,6 +46,9 @@ public class Playlist extends BaseEntity {
     @Column(length = 255)
     private String description;
 
+    @Column(nullable = false)
+    private boolean deleted;
+
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
@@ -54,6 +63,7 @@ public class Playlist extends BaseEntity {
         playlist.userId = userId;
         playlist.title = title;
         playlist.description = description;
+        playlist.deleted = false;
 
         return playlist;
     }
@@ -62,7 +72,7 @@ public class Playlist extends BaseEntity {
         return Objects.equals(this.userId, userId);
     }
 
-    public boolean isDeleted() { return this.deletedAt != null; }
+    public boolean isDeleted() { return this.deleted; }
 
     public void update(String title, String description) {
         validateNotDeleted();
@@ -74,6 +84,7 @@ public class Playlist extends BaseEntity {
 
     public void delete() {
         validateNotDeleted();
+        this.deleted = true;
         this.deletedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/fivefy/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/fivefy/domain/playlist/repository/PlaylistRepository.java
@@ -13,11 +13,11 @@ import java.util.Optional;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
 
-    Page<Playlist> findAllByDeletedAtIsNull(Pageable pageable);
-    Optional<Playlist> findByIdAndDeletedAtIsNull(Long id);
-    boolean existsByUserIdAndTitleAndDeletedAtIsNull(Long userId, String title);
+    Page<Playlist> findAllByDeletedFalse(Pageable pageable);
+    Optional<Playlist> findByIdAndDeletedFalse(Long id);
+    boolean existsByUserIdAndTitleAndDeletedFalse(Long userId, String title);
 
     @Modifying
-    @Query("delete from Playlist p where p.deletedAt is not null and p.deletedAt <= :threshold")
+    @Query("delete from Playlist p where p.deleted = true and p.deletedAt is not null and p.deletedAt <= :threshold")
     int deleteAllSoftDeletedBefore(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/fivefy/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/fivefy/domain/playlist/repository/PlaylistRepository.java
@@ -4,7 +4,11 @@ import com.fivefy.domain.playlist.entity.Playlist;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
@@ -12,4 +16,8 @@ public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
     Page<Playlist> findAllByDeletedAtIsNull(Pageable pageable);
     Optional<Playlist> findByIdAndDeletedAtIsNull(Long id);
     boolean existsByUserIdAndTitleAndDeletedAtIsNull(Long userId, String title);
+
+    @Modifying
+    @Query("delete from Playlist p where p.deletedAt is not null and p.deletedAt <= :threshold")
+    int deleteAllSoftDeletedBefore(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupScheduler.java
+++ b/src/main/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupScheduler.java
@@ -2,6 +2,7 @@ package com.fivefy.domain.playlist.scheduler;
 
 import com.fivefy.domain.playlist.service.PlaylistCleanupService;
 import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ public class PlaylistCleanupScheduler {
     private final PlaylistCleanupService playlistCleanupService;
 
     @Scheduled(cron = "0 0 3 * * *")
+    @SchedulerLock(name = "playlistCleanupScheduler_cleanup", lockAtMostFor = "10m", lockAtLeastFor = "1m")
     public void cleanup() {
         LocalDateTime threshold = LocalDateTime.now().minusDays(30);
         playlistCleanupService.cleanupDeletedPlaylists(threshold);

--- a/src/main/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupScheduler.java
+++ b/src/main/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupScheduler.java
@@ -1,0 +1,21 @@
+package com.fivefy.domain.playlist.scheduler;
+
+import com.fivefy.domain.playlist.service.PlaylistCleanupService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class PlaylistCleanupScheduler {
+
+    private final PlaylistCleanupService playlistCleanupService;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanup() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+        playlistCleanupService.cleanupDeletedPlaylists(threshold);
+    }
+}

--- a/src/main/java/com/fivefy/domain/playlist/service/PlaylistCleanupService.java
+++ b/src/main/java/com/fivefy/domain/playlist/service/PlaylistCleanupService.java
@@ -1,0 +1,21 @@
+package com.fivefy.domain.playlist.service;
+
+import com.fivefy.domain.playlist.repository.PlaylistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaylistCleanupService {
+
+    private final PlaylistRepository playlistRepository;
+
+    @Transactional
+    public int cleanupDeletedPlaylists(LocalDateTime threshold) {
+        return playlistRepository.deleteAllSoftDeletedBefore(threshold);
+    }
+}

--- a/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
@@ -83,12 +83,9 @@ public class PlaylistService {
             throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
         }
 
-        try {
-            playlist.update(request.title(), request.description());
-            return PlaylistResponse.from(playlist);
-        } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
-        }
+        playlist.update(request.title(), request.description());
+
+        return PlaylistResponse.from(playlist);
     }
 
     @Transactional

--- a/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
@@ -12,6 +12,7 @@ import com.fivefy.domain.playlist.repository.PlaylistRepository;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -44,9 +45,12 @@ public class PlaylistService {
                 request.description()
         );
 
-        Playlist savedPlaylist = playlistRepository.save(playlist);
-
-        return PlaylistResponse.from(savedPlaylist);
+        try {
+            Playlist savedPlaylist = playlistRepository.save(playlist);
+            return PlaylistResponse.from(savedPlaylist);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
+        }
     }
 
     public PageResponse<PlaylistResponse> getPlaylists(Pageable pageable) {
@@ -79,9 +83,12 @@ public class PlaylistService {
             throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
         }
 
-        playlist.update(request.title(), request.description());
-
-        return PlaylistResponse.from(playlist);
+        try {
+            playlist.update(request.title(), request.description());
+            return PlaylistResponse.from(playlist);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
+        }
     }
 
     @Transactional
@@ -101,7 +108,7 @@ public class PlaylistService {
 
     private void validateSubscription(Long userId) {
         // 사용자 구독 상태 조회
-        // TRIAL(체험), ACTIVE(유료) 상태인 경우 유효한 구독으로 판단
+        // FREE(체험), ACTIVE(유료) 상태인 경우 유효한 구독으로 판단
         boolean hasValidSubscription = subscriptionRepository.existsByUserIdAndStatusIn(
                 userId,
                 List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)

--- a/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
@@ -35,7 +35,7 @@ public class PlaylistService {
         validateSubscription(userId);
 
         // 중복 제목 여부 검사
-        if (playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title())) {
+        if (playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title())) {
             throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
         }
 
@@ -54,14 +54,14 @@ public class PlaylistService {
     }
 
     public PageResponse<PlaylistResponse> getPlaylists(Pageable pageable) {
-        Page<PlaylistResponse> page = playlistRepository.findAllByDeletedAtIsNull(pageable)
+        Page<PlaylistResponse> page = playlistRepository.findAllByDeletedFalse(pageable)
                 .map(PlaylistResponse::from);
 
         return PageResponse.from(page);
     }
 
     public PlaylistResponse getPlaylist(Long playlistId) {
-        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+        Playlist playlist = playlistRepository.findByIdAndDeletedFalse(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         return PlaylistResponse.from(playlist);
@@ -69,7 +69,7 @@ public class PlaylistService {
 
     @Transactional
     public PlaylistResponse updatePlaylist(Long userId, Long playlistId, PlaylistUpdateRequest request) {
-        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+        Playlist playlist = playlistRepository.findByIdAndDeletedFalse(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         // 본인이 생성한 플레이리스트만 수정 가능
@@ -77,9 +77,9 @@ public class PlaylistService {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN);
         }
 
-        // 제목이 변경된 경우에만 중복 체크
-        if (!playlist.getTitle().equals(request.title()) &&
-                playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title())) {
+        // 제목이 변경된 경우에만 활성 플레이리스트 기준 중복 체크
+        if (!playlist.getTitle().equals(request.title())
+                && playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title())) {
             throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
         }
 
@@ -90,7 +90,7 @@ public class PlaylistService {
 
     @Transactional
     public PlaylistDeleteResponse deletePlaylist(Long userId, Long playlistId) {
-        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+        Playlist playlist = playlistRepository.findByIdAndDeletedFalse(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         // 본인이 생성한 플레이리스트만 삭제 가능

--- a/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
@@ -25,6 +25,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class PlaylistService {
 
+    private static final String PLAYLIST_UNIQUE_CONSTRAINT = "uk_playlist_user_title_deleted";
+
     private final PlaylistRepository playlistRepository;
     private final SubscriptionRepository subscriptionRepository;
 
@@ -49,7 +51,10 @@ public class PlaylistService {
             Playlist savedPlaylist = playlistRepository.save(playlist);
             return PlaylistResponse.from(savedPlaylist);
         } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
+            if (isDuplicatePlaylistTitleException(e)) {
+                throw new BusinessException(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME);
+            }
+            throw e;
         }
     }
 
@@ -101,6 +106,16 @@ public class PlaylistService {
         playlist.delete();
 
         return PlaylistDeleteResponse.from(playlist);
+    }
+
+    private boolean isDuplicatePlaylistTitleException(DataIntegrityViolationException e) {
+        Throwable rootCause = e.getMostSpecificCause();
+
+        if (rootCause != null && rootCause.getMessage() != null) {
+            return rootCause.getMessage().contains(PLAYLIST_UNIQUE_CONSTRAINT);
+        }
+
+        return e.getMessage() != null && e.getMessage().contains(PLAYLIST_UNIQUE_CONSTRAINT);
     }
 
     private void validateSubscription(Long userId) {

--- a/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/fivefy/domain/playlist/service/PlaylistService.java
@@ -115,7 +115,9 @@ public class PlaylistService {
             return rootCause.getMessage().contains(PLAYLIST_UNIQUE_CONSTRAINT);
         }
 
-        return e.getMessage() != null && e.getMessage().contains(PLAYLIST_UNIQUE_CONSTRAINT);
+        String exceptionMessage = e.getMessage();
+        return exceptionMessage != null
+                && exceptionMessage.contains(PLAYLIST_UNIQUE_CONSTRAINT);
     }
 
     private void validateSubscription(Long userId) {

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -33,7 +33,7 @@ public class PlaylistTrackService {
 
     @Transactional
     public PlaylistTrackResponse addTrack(Long userId, Long playlistId, PlaylistTrackCreateRequest request) {
-        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+        Playlist playlist = playlistRepository.findByIdAndDeletedFalse(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         // 본인 플레이리스트만 트랙 추가 가능
@@ -70,7 +70,7 @@ public class PlaylistTrackService {
     }
 
     public List<PlaylistTrackResponse> getTracks(Long userId, Long playlistId) {
-        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+        Playlist playlist = playlistRepository.findByIdAndDeletedFalse(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         // 본인 플레이리스트만 트랙 조회 가능
@@ -86,7 +86,7 @@ public class PlaylistTrackService {
 
     @Transactional
     public void updateTrackOrder(Long userId, Long playlistId, PlaylistTrackOrderUpdateRequest request) {
-        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+        Playlist playlist = playlistRepository.findByIdAndDeletedFalse(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         // 본인 플레이리스트만 트랙 순서 변경 가능
@@ -129,7 +129,7 @@ public class PlaylistTrackService {
 
     @Transactional
     public void deleteTrack(Long userId, Long playlistId, Long trackId) {
-        Playlist playlist = playlistRepository.findByIdAndDeletedAtIsNull(playlistId)
+        Playlist playlist = playlistRepository.findByIdAndDeletedFalse(playlistId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_NOT_FOUND));
 
         // 본인 플레이리스트만 트랙 삭제 가능

--- a/src/test/java/com/fivefy/domain/playlist/entity/PlaylistTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/entity/PlaylistTest.java
@@ -132,6 +132,7 @@ class PlaylistTest {
 
         // then
         assertThat(playlist.getDeletedAt()).isNotNull();
+        assertThat(playlist.isDeleted()).isTrue();
     }
 
     @Test
@@ -145,5 +146,36 @@ class PlaylistTest {
         assertThatThrownBy(playlist::delete)
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(PlaylistErrorCode.ALREADY_DELETED_PLAYLIST.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제된 플레이리스트 수정 시 예외 발생")
+    void update_deleted_playlist() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+        playlist.delete();
+
+        // when & then
+        assertThatThrownBy(() ->
+                playlist.update("newTitle", "newDesc")
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaylistErrorCode.ALREADY_DELETED_PLAYLIST.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제 전 isDeleted는 false, 삭제 후 true")
+    void isDeleted_status_check() {
+        // given
+        Playlist playlist = Playlist.create(1L, "title", "desc");
+
+        // then
+        assertThat(playlist.isDeleted()).isFalse();
+
+        // when
+        playlist.delete();
+
+        // then
+        assertThat(playlist.isDeleted()).isTrue();
     }
 }

--- a/src/test/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupSchedulerTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupSchedulerTest.java
@@ -4,12 +4,14 @@ import com.fivefy.domain.playlist.service.PlaylistCleanupService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,11 +27,20 @@ class PlaylistCleanupSchedulerTest {
     @Test
     @DisplayName("스케줄러 실행 시 30일 지난 soft delete 데이터 정리 호출")
     void cleanup_success() {
+        LocalDateTime before = LocalDateTime.now().minusDays(30);
+
         // when
         playlistCleanupScheduler.cleanup();
 
         // then
+        ArgumentCaptor<LocalDateTime> thresholdCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
         verify(playlistCleanupService, times(1))
-                .cleanupDeletedPlaylists(any(LocalDateTime.class));
+                .cleanupDeletedPlaylists(thresholdCaptor.capture());
+
+        LocalDateTime after = LocalDateTime.now().minusDays(30);
+        LocalDateTime threshold = thresholdCaptor.getValue();
+
+        assertTrue(!threshold.isBefore(before) && !threshold.isAfter(after),
+                "cleanup threshold must be now() - 30 days");
     }
 }

--- a/src/test/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupSchedulerTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/scheduler/PlaylistCleanupSchedulerTest.java
@@ -1,0 +1,35 @@
+package com.fivefy.domain.playlist.scheduler;
+
+import com.fivefy.domain.playlist.service.PlaylistCleanupService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PlaylistCleanupSchedulerTest {
+
+    @InjectMocks
+    private PlaylistCleanupScheduler playlistCleanupScheduler;
+
+    @Mock private PlaylistCleanupService playlistCleanupService;
+
+    @Test
+    @DisplayName("스케줄러 실행 시 30일 지난 soft delete 데이터 정리 호출")
+    void cleanup_success() {
+        // when
+        playlistCleanupScheduler.cleanup();
+
+        // then
+        verify(playlistCleanupService, times(1))
+                .cleanupDeletedPlaylists(any(LocalDateTime.class));
+    }
+}

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistCleanupServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistCleanupServiceTest.java
@@ -1,0 +1,39 @@
+package com.fivefy.domain.playlist.service;
+
+import com.fivefy.domain.playlist.repository.PlaylistRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PlaylistCleanupServiceTest {
+
+    @InjectMocks
+    private PlaylistCleanupService playlistCleanupService;
+
+    @Mock private PlaylistRepository playlistRepository;
+
+    @Test
+    @DisplayName("기준 시각 이전의 soft delete 데이터 정리 성공")
+    void cleanupDeletedPlaylists_success() {
+        // given
+        LocalDateTime threshold = LocalDateTime.of(2026, 4, 1, 0, 0);
+        given(playlistRepository.deleteAllSoftDeletedBefore(threshold)).willReturn(3);
+
+        // when
+        int deletedCount = playlistCleanupService.cleanupDeletedPlaylists(threshold);
+
+        // then
+        assertThat(deletedCount).isEqualTo(3);
+        verify(playlistRepository).deleteAllSoftDeletedBefore(threshold);
+    }
+}

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -175,6 +175,151 @@ class PlaylistServiceTest {
             assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
                     .isInstanceOf(DataIntegrityViolationException.class);
         }
+
+        @Test
+        @DisplayName("rootCause 메시지에 중복 제약조건이 포함되면 중복 제목 예외로 변환한다")
+        void createPlaylist_duplicateTitle_whenRootCauseContainsConstraint() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
+                    .willReturn(false);
+
+            DataIntegrityViolationException exception = mock(DataIntegrityViolationException.class);
+            Throwable rootCause = mock(Throwable.class);
+
+            given(exception.getMostSpecificCause()).willReturn(rootCause);
+            given(rootCause.getMessage()).willReturn("constraint [uk_playlist_user_title_deleted]");
+
+            given(playlistRepository.save(any(Playlist.class))).willThrow(exception);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
+        }
+
+        @Test
+        @DisplayName("rootCause 메시지가 없으면 예외 메시지로 중복 여부를 판단한다")
+        void createPlaylist_duplicateTitle_whenRootCauseMessageIsNull() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
+                    .willReturn(false);
+
+            DataIntegrityViolationException exception = mock(DataIntegrityViolationException.class);
+            Throwable rootCause = mock(Throwable.class);
+
+            given(exception.getMostSpecificCause()).willReturn(rootCause);
+            given(rootCause.getMessage()).willReturn(null);
+            given(exception.getMessage()).willReturn("constraint [uk_playlist_user_title_deleted]");
+
+            given(playlistRepository.save(any(Playlist.class))).willThrow(exception);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
+        }
+
+        @Test
+        @DisplayName("rootCause가 없으면 예외 메시지로 중복 여부를 판단한다")
+        void createPlaylist_duplicateTitle_whenRootCauseIsNull() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
+                    .willReturn(false);
+
+            DataIntegrityViolationException exception = mock(DataIntegrityViolationException.class);
+
+            given(exception.getMostSpecificCause()).willReturn(null);
+            given(exception.getMessage()).willReturn("constraint [uk_playlist_user_title_deleted]");
+
+            given(playlistRepository.save(any(Playlist.class))).willThrow(exception);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
+        }
+
+        @Test
+        @DisplayName("중복 제약조건이 아니면 duplicate 예외로 변환하지 않는다")
+        void createPlaylist_dataIntegrityViolation_notDuplicateConstraint() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
+                    .willReturn(false);
+
+            DataIntegrityViolationException exception = mock(DataIntegrityViolationException.class);
+            Throwable rootCause = mock(Throwable.class);
+
+            given(exception.getMostSpecificCause()).willReturn(rootCause);
+            given(rootCause.getMessage()).willReturn(null);
+            given(exception.getMessage()).willReturn("some other integrity violation");
+
+            given(playlistRepository.save(any(Playlist.class))).willThrow(exception);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+
+        @Test
+        @DisplayName("예외 메시지가 없으면 duplicate 예외로 변환하지 않는다")
+        void createPlaylist_dataIntegrityViolation_whenExceptionMessageIsNull() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
+                    .willReturn(false);
+
+            DataIntegrityViolationException exception = mock(DataIntegrityViolationException.class);
+            Throwable rootCause = mock(Throwable.class);
+
+            given(exception.getMostSpecificCause()).willReturn(rootCause);
+            given(rootCause.getMessage()).willReturn(null);
+            given(exception.getMessage()).willReturn(null);
+
+            given(playlistRepository.save(any(Playlist.class))).willThrow(exception);
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
     }
 
     @Nested

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -126,8 +126,8 @@ class PlaylistServiceTest {
         }
 
         @Test
-        @DisplayName("플레이리스트 저장 중 DB 제약 예외 발생 시 중복 제목 예외로 변환")
-        void createPlaylist_dataIntegrityViolation() {
+        @DisplayName("플레이리스트 저장 중 unique 제약 위반 발생 시 중복 제목 예외로 변환")
+        void createPlaylist_uniqueConstraintViolation() {
             // given
             Long userId = 1L;
             PlaylistCreateRequest request = new PlaylistCreateRequest("중복 제목", "설명");
@@ -141,12 +141,39 @@ class PlaylistServiceTest {
                     .willReturn(false);
 
             given(playlistRepository.save(any(Playlist.class)))
-                    .willThrow(new DataIntegrityViolationException("unique constraint violation"));
+                    .willThrow(new DataIntegrityViolationException(
+                            "could not execute statement; constraint [uk_playlist_user_title_deleted]"
+                    ));
 
             // when & then
             assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
+        }
+
+        @Test
+        @DisplayName("플레이리스트 저장 중 다른 무결성 위반 발생 시 중복 제목 예외로 변환하지 않음")
+        void createPlaylist_otherDataIntegrityViolation() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("정상 제목", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
+                    .willReturn(false);
+
+            given(playlistRepository.save(any(Playlist.class)))
+                    .willThrow(new DataIntegrityViolationException(
+                            "could not execute statement; not-null property references a null or transient value"
+                    ));
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(DataIntegrityViolationException.class);
         }
     }
 

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -166,14 +166,16 @@ class PlaylistServiceTest {
             given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
                     .willReturn(false);
 
-            given(playlistRepository.save(any(Playlist.class)))
-                    .willThrow(new DataIntegrityViolationException(
-                            "could not execute statement; not-null property references a null or transient value"
-                    ));
+            DataIntegrityViolationException exception =
+                    new DataIntegrityViolationException(
+                            "could not execute statement; not-null property references a null value"
+                    );
+
+            given(playlistRepository.save(any(Playlist.class))).willThrow(exception);
 
             // when & then
             assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
-                    .isInstanceOf(DataIntegrityViolationException.class);
+                    .isSameAs(exception);
         }
 
         @Test

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -62,7 +62,7 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(userId, request.title(), request.description());
             ReflectionTestUtils.setField(playlist, "id", 1L);
 
-            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
                     .willReturn(false);
             given(playlistRepository.save(any(Playlist.class))).willReturn(playlist);
 
@@ -76,7 +76,7 @@ class PlaylistServiceTest {
             assertThat(result.description()).isEqualTo("설명");
 
             verify(playlistRepository, times(1))
-                    .existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title());
+                    .existsByUserIdAndTitleAndDeletedFalse(userId, request.title());
             verify(playlistRepository, times(1)).save(any(Playlist.class));
         }
 
@@ -92,7 +92,7 @@ class PlaylistServiceTest {
                     List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
             )).willReturn(true);
 
-            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
                     .willReturn(true);
 
             // when & then
@@ -121,7 +121,7 @@ class PlaylistServiceTest {
                     .hasMessage(PlaylistErrorCode.PLAYLIST_CREATION_SUBSCRIPTION_REQUIRED.getMessage());
 
             verify(playlistRepository, never())
-                    .existsByUserIdAndTitleAndDeletedAtIsNull(anyLong(), anyString());
+                    .existsByUserIdAndTitleAndDeletedFalse(anyLong(), anyString());
             verify(playlistRepository, never()).save(any());
         }
 
@@ -137,7 +137,7 @@ class PlaylistServiceTest {
                     List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
             )).willReturn(true);
 
-            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
                     .willReturn(false);
 
             given(playlistRepository.save(any(Playlist.class)))
@@ -168,7 +168,7 @@ class PlaylistServiceTest {
 
             Page<Playlist> page = new PageImpl<>(List.of(playlist1, playlist2), pageable, 2);
 
-            given(playlistRepository.findAllByDeletedAtIsNull(pageable)).willReturn(page);
+            given(playlistRepository.findAllByDeletedFalse(pageable)).willReturn(page);
 
             // when
             PageResponse<PlaylistResponse> result = playlistService.getPlaylists(pageable);
@@ -197,7 +197,7 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(1L, "내 플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when
@@ -215,7 +215,7 @@ class PlaylistServiceTest {
             // given
             Long playlistId = 1L;
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -240,9 +240,9 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(userId, "기존 제목", "기존 설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
-            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
                     .willReturn(false);
 
             // when
@@ -262,7 +262,7 @@ class PlaylistServiceTest {
             Long playlistId = 1L;
             PlaylistUpdateRequest request = new PlaylistUpdateRequest("수정 제목", "설명");
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -283,7 +283,7 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(otherUserId, "기존 제목", "기존 설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when & then
@@ -292,7 +292,7 @@ class PlaylistServiceTest {
                     .hasMessage(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN.getMessage());
 
             verify(playlistRepository, never())
-                    .existsByUserIdAndTitleAndDeletedAtIsNull(anyLong(), anyString());
+                    .existsByUserIdAndTitleAndDeletedFalse(anyLong(), anyString());
         }
 
         @Test
@@ -306,9 +306,9 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(userId, "기존 제목", "기존 설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
-            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
                     .willReturn(true);
 
             // when & then
@@ -328,7 +328,7 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(userId, "기존 제목", "기존 설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when
@@ -339,7 +339,7 @@ class PlaylistServiceTest {
             assertThat(result.description()).isEqualTo("새 설명");
 
             verify(playlistRepository, never())
-                    .existsByUserIdAndTitleAndDeletedAtIsNull(anyLong(), anyString());
+                    .existsByUserIdAndTitleAndDeletedFalse(anyLong(), anyString());
         }
     }
 
@@ -357,7 +357,7 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(userId, "삭제할 플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when
@@ -376,8 +376,9 @@ class PlaylistServiceTest {
             Long userId = 1L;
             Long playlistId = 1L;
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.empty());
+
 
             // when & then
             assertThatThrownBy(() -> playlistService.deletePlaylist(userId, playlistId))
@@ -396,8 +397,9 @@ class PlaylistServiceTest {
             Playlist playlist = Playlist.create(otherUserId, "남의 플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
+
 
             // when & then
             assertThatThrownBy(() -> playlistService.deletePlaylist(userId, playlistId))
@@ -408,6 +410,7 @@ class PlaylistServiceTest {
         @Test
         @DisplayName("삭제된 플레이리스트 제목은 다시 생성 가능")
         void createPlaylist_success_whenDeletedPlaylistHasSameTitle() {
+            // given
             Long userId = 1L;
             PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
 
@@ -416,7 +419,7 @@ class PlaylistServiceTest {
                     List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
             )).willReturn(true);
 
-            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
                     .willReturn(false);
 
             Playlist playlist = Playlist.create(userId, request.title(), request.description());
@@ -424,8 +427,10 @@ class PlaylistServiceTest {
 
             given(playlistRepository.save(any(Playlist.class))).willReturn(playlist);
 
+            // when
             PlaylistResponse result = playlistService.createPlaylist(userId, request);
 
+            // then
             assertThat(result.title()).isEqualTo("내 플레이리스트");
         }
     }

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -397,6 +397,33 @@ class PlaylistServiceTest {
         }
 
         @Test
+        @DisplayName("중복되지 않은 제목이면 플레이리스트 생성 성공")
+        void createPlaylist_success_whenTitleNotDuplicated() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
+                    .willReturn(false);
+
+            Playlist playlist = Playlist.create(userId, request.title(), request.description());
+            ReflectionTestUtils.setField(playlist, "id", 1L);
+
+            given(playlistRepository.save(any(Playlist.class))).willReturn(playlist);
+
+            // when
+            PlaylistResponse result = playlistService.createPlaylist(userId, request);
+
+            // then
+            assertThat(result.title()).isEqualTo("내 플레이리스트");
+        }
+
+        @Test
         @DisplayName("존재하지 않는 플레이리스트 삭제 시 예외 발생")
         void deletePlaylistNotFound() {
             // given
@@ -427,38 +454,10 @@ class PlaylistServiceTest {
             given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
-
             // when & then
             assertThatThrownBy(() -> playlistService.deletePlaylist(userId, playlistId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage());
-        }
-
-        @Test
-        @DisplayName("삭제된 플레이리스트 제목은 다시 생성 가능")
-        void createPlaylist_success_whenDeletedPlaylistHasSameTitle() {
-            // given
-            Long userId = 1L;
-            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
-
-            given(subscriptionRepository.existsByUserIdAndStatusIn(
-                    userId,
-                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
-            )).willReturn(true);
-
-            given(playlistRepository.existsByUserIdAndTitleAndDeletedFalse(userId, request.title()))
-                    .willReturn(false);
-
-            Playlist playlist = Playlist.create(userId, request.title(), request.description());
-            ReflectionTestUtils.setField(playlist, "id", 1L);
-
-            given(playlistRepository.save(any(Playlist.class))).willReturn(playlist);
-
-            // when
-            PlaylistResponse result = playlistService.createPlaylist(userId, request);
-
-            // then
-            assertThat(result.title()).isEqualTo("내 플레이리스트");
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlist/service/PlaylistServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -122,6 +123,30 @@ class PlaylistServiceTest {
             verify(playlistRepository, never())
                     .existsByUserIdAndTitleAndDeletedAtIsNull(anyLong(), anyString());
             verify(playlistRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("플레이리스트 저장 중 DB 제약 예외 발생 시 중복 제목 예외로 변환")
+        void createPlaylist_dataIntegrityViolation() {
+            // given
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("중복 제목", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+                    .willReturn(false);
+
+            given(playlistRepository.save(any(Playlist.class)))
+                    .willThrow(new DataIntegrityViolationException("unique constraint violation"));
+
+            // when & then
+            assertThatThrownBy(() -> playlistService.createPlaylist(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.DUPLICATE_PLAYLIST_NAME.getMessage());
         }
     }
 
@@ -378,6 +403,30 @@ class PlaylistServiceTest {
             assertThatThrownBy(() -> playlistService.deletePlaylist(userId, playlistId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제된 플레이리스트 제목은 다시 생성 가능")
+        void createPlaylist_success_whenDeletedPlaylistHasSameTitle() {
+            Long userId = 1L;
+            PlaylistCreateRequest request = new PlaylistCreateRequest("내 플레이리스트", "설명");
+
+            given(subscriptionRepository.existsByUserIdAndStatusIn(
+                    userId,
+                    List.of(SubscriptionStatus.FREE, SubscriptionStatus.ACTIVE)
+            )).willReturn(true);
+
+            given(playlistRepository.existsByUserIdAndTitleAndDeletedAtIsNull(userId, request.title()))
+                    .willReturn(false);
+
+            Playlist playlist = Playlist.create(userId, request.title(), request.description());
+            ReflectionTestUtils.setField(playlist, "id", 1L);
+
+            given(playlistRepository.save(any(Playlist.class))).willReturn(playlist);
+
+            PlaylistResponse result = playlistService.createPlaylist(userId, request);
+
+            assertThat(result.title()).isEqualTo("내 플레이리스트");
         }
     }
 }

--- a/src/test/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackServiceTest.java
@@ -60,7 +60,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack savedTrack = PlaylistTrack.create(playlistId, 10L, 1);
             ReflectionTestUtils.setField(savedTrack, "id", 1L);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(trackRepository.existsById(10L))
                     .willReturn(true);
@@ -92,7 +92,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(trackRepository.existsById(10L))
                     .willReturn(false);
@@ -111,7 +111,7 @@ class PlaylistTrackServiceTest {
             Long playlistId = 1L;
             PlaylistTrackCreateRequest request = new PlaylistTrackCreateRequest(10L);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -132,7 +132,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when & then
@@ -152,7 +152,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(trackRepository.existsById(10L))
                     .willReturn(true);
@@ -178,7 +178,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(trackRepository.existsById(10L))
                     .willReturn(true);
@@ -206,7 +206,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(trackRepository.existsById(10L))
                     .willReturn(true);
@@ -234,7 +234,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(trackRepository.existsById(10L))
                     .willReturn(true);
@@ -261,7 +261,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(trackRepository.existsById(10L))
                     .willReturn(true);
@@ -298,7 +298,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
             ReflectionTestUtils.setField(track2, "id", 2L);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(List.of(track1, track2));
@@ -321,7 +321,7 @@ class PlaylistTrackServiceTest {
             Long userId = 1L;
             Long playlistId = 1L;
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -341,7 +341,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when & then
@@ -370,7 +370,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
             PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
@@ -393,7 +393,7 @@ class PlaylistTrackServiceTest {
             Long playlistId = 1L;
             PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 1);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -414,7 +414,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when & then
@@ -437,7 +437,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(List.of(track1, track2));
@@ -462,7 +462,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(List.of(track1, track2));
@@ -487,7 +487,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(List.of(track1, track2));
@@ -516,7 +516,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(List.of(track1, track2));
@@ -544,7 +544,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
             PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
@@ -578,7 +578,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
             PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
@@ -601,7 +601,7 @@ class PlaylistTrackServiceTest {
             Long playlistId = 1L;
             Long trackId = 10L;
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.empty());
 
             // when & then
@@ -622,7 +622,7 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(otherUserId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
 
             // when & then
@@ -645,7 +645,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(List.of(track1, track2));
@@ -671,7 +671,7 @@ class PlaylistTrackServiceTest {
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
             PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
 
-            given(playlistRepository.findByIdAndDeletedAtIsNull(playlistId))
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(new ArrayList<>(List.of(track1, track2, track3)));


### PR DESCRIPTION
## 개요

> 기존 soft delete 정책을 유지하면서,  
일정 기간이 지난 데이터에 대해 hard delete로 정리하는 cleanup 기능을 추가했습니다.  
플레이리스트를 삭제하면 바로 제거하지 않고 일정 기간 유지한 뒤 자동으로 삭제되도록 개선했습니다.

## 변경 사항

### 1. soft delete 정책 강화 및 예외 처리 개선

- Playlist 삭제 시 `deletedAt` 기반 soft delete 유지
- 동일 제목 중복 검증 시 soft delete 데이터는 제외하도록 개선
- 동시성 상황에서도 중복 생성이 발생하지 않도록 DB 유니크 제약조건 보강
  - `(user_id, title, deleted)` 조합으로 유니크 제약조건 적용
  - 서비스 레벨 중복 체크 + DB 제약조건 이중 방어
- DB 제약조건 위반 시 비즈니스 예외로 변환
  - 중복 제목 → `DUPLICATE_PLAYLIST_NAME`

---

### 2. 데이터 정리(cleanup) 기능 추가

- 일정 기간 이전 soft delete 데이터 하드 삭제 쿼리 추가
- cleanup 서비스 구현
  - `threshold` 기준으로 삭제 수행
- 스케줄러 추가
  - 매일 새벽 3시 실행
  - 30일 이전 데이터 정리

---

### 3. 엔티티 개선

- 인덱스 추가
  - `deleted_at`
  - `user_id + deleted_at`
  - `user_id + title + deleted_at`
- 유니크 제약조건 추가
  - `(user_id, title, deleted)`
- `isDeleted()` 메서드 추가
- `validateTitle()` 로직 분리 (중복 제거)
- 컬럼 매핑 명시 (`deleted_at`)
- description 컬럼 길이 명시

---

### 4. 서비스 로직 개선

- 중복 체크 + DB 예외 처리 이중 방어 적용
- DB 예외(DataIntegrityViolationException) → 비즈니스 예외 변환 처리

---

### 5. 테스트 코드 추가 및 보완

- Playlist 엔티티 테스트
  - 삭제 및 상태 검증 (`isDeleted`)
  - 삭제된 상태에서 수정/삭제 제한 검증
- PlaylistService 테스트
  - DB 예외 → 비즈니스 예외 변환 검증
  - soft delete 이후 동일 제목 재생성 검증
- Cleanup 서비스 테스트
  - threshold 기준 삭제 동작 검증
- Cleanup 스케줄러 테스트
  - 스케줄 실행 시 서비스 호출 검증

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> soft delete 및 cleanup 기능 동작을 검증합니다.  
(삭제 → 유지 → 자동 정리 흐름 검증)

### 1. 플레이리스트 삭제
- 삭제 요청 시 실제 삭제가 아닌 `deletedAt`이 설정되는지 확인

### 2. 동일 제목 재생성
- soft delete된 플레이리스트와 동일한 제목으로 생성 가능한지 확인

### 3. 데이터 정리(cleanup)
- 일정 기간 이전 데이터가 정상적으로 삭제되는지 확인

### 4. 스케줄러 동작
- 스케줄러 실행 시 cleanup 서비스가 호출되는지 확인

## 스크린샷
- 테스트 커버리지 (JaCoCo 100%)
<img width="1726" height="428" alt="image" src="https://github.com/user-attachments/assets/a26b47df-c090-4ec6-a035-5c92d771744e" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 30일 이상 soft-deleted 플레이리스트 일괄 삭제 스케줄러(매일 03:00, 분산 락)와 일괄 삭제 기능 추가

* **버그 수정**
  * 중복 플레이리스트 이름 저장 시 사용자 친화적 오류 반환 처리 강화
  * 삭제된 플레이리스트에 대한 업데이트 시 적절한 예외 발생 보장

* **성능**
  * 삭제 관련 조회용 인덱스 및 고유 제약 보강

* **품질**
  * 제목 검증 로직 통합 및 삭제 상태 접근자 추가, 조회 기준을 불리언 삭제 상태로 통일

* **테스트**
  * 스케줄러·서비스·엔티티 관련 단위 테스트 추가 및 기존 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->