### PR TITLE
feat: 공개 조회 가시성 정책 정비 및 앨범·트랙 상세 응답 확장

### DIFF
--- a/src/main/java/com/fivefy/domain/album/entity/Album.java
+++ b/src/main/java/com/fivefy/domain/album/entity/Album.java
@@ -95,6 +95,11 @@ public class Album extends BaseEntity {
         if (status == AlbumStatus.PUBLISHED) {
             throw new BusinessException(AlbumErrorCode.ERR_ALBUM_ALREADY_PUBLISHED);
         }
+
+        if (status != AlbumStatus.UNPUBLISHED) {
+            throw new BusinessException(AlbumErrorCode.ERR_INVALID_ALBUM_STATUS_TRANSITION);
+        }
+
         this.status = AlbumStatus.PUBLISHED;
         this.publishedAt = LocalDateTime.now();
     }
@@ -105,6 +110,11 @@ public class Album extends BaseEntity {
         if (status == AlbumStatus.BLOCKED) {
             throw new BusinessException(AlbumErrorCode.ERR_ALBUM_ALREADY_BLOCKED);
         }
+
+        if (status != AlbumStatus.PUBLISHED) {
+            throw new BusinessException(AlbumErrorCode.ERR_INVALID_ALBUM_STATUS_TRANSITION);
+        }
+
         this.status = AlbumStatus.BLOCKED;
     }
 

--- a/src/main/java/com/fivefy/domain/album/enums/AlbumErrorCode.java
+++ b/src/main/java/com/fivefy/domain/album/enums/AlbumErrorCode.java
@@ -12,6 +12,7 @@ public enum AlbumErrorCode implements ErrorCode {
     ERR_ALBUM_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 앨범입니다"),
     ERR_DELETED_ALBUM_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 앨범은 수정할 수 없습니다"),
     ERR_INVALID_TRACK_COUNT(HttpStatus.BAD_REQUEST, "트랙 수는 0 이상이어야 합니다"),
+    ERR_INVALID_ALBUM_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, "허용되지 않은 앨범 상태 변경입니다"),
     ERR_INVALID_TOTAL_DURATION_SEC(HttpStatus.BAD_REQUEST, "총 재생 시간은 0 이상이어야 합니다");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -167,8 +167,8 @@ public class AlbumService {
     public AlbumDetailResponse getAlbum(Long albumId) {
         Album album = findPublishedAlbum(albumId);
 
-        // 공개 상세 조회에서는 삭제된 아티스트도 노출되면 안 되니까
-        Artist artist = findNotDeletedArtist(album.getArtistId());
+        // 공개 상세 조회에서 노출 가능한 아티스트만 조회
+        Artist artist = findVisibleArtist(album.getArtistId());
 
         // 앨범에 속한 공개 정식 발매 트랙 목록 조회
         List<AlbumTrackResponse> tracks = trackRepository.searchAlbumTracks(albumId).stream()
@@ -197,7 +197,7 @@ public class AlbumService {
 
     // 유저 조회
     private User findUser(Long userId) {
-        return userRepository.findById(userId)
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
     }
 
@@ -213,6 +213,18 @@ public class AlbumService {
 
         if (artist.isDeleted()) {
             throw new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND);
+        }
+
+        return artist;
+    }
+
+    // 공개 조회 가능한 아티스트 조회
+    private Artist findVisibleArtist(Long artistId) {
+        Artist artist = artistRepository.findById(artistId)
+                .orElseThrow(() -> new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND));
+
+        if (artist.isDeleted() || artist.getStatus() != ArtistStatus.ACTIVE) {
+            throw new BusinessException(AlbumErrorCode.ERR_ALBUM_NOT_FOUND);
         }
 
         return artist;

--- a/src/main/java/com/fivefy/domain/artist/entity/Artist.java
+++ b/src/main/java/com/fivefy/domain/artist/entity/Artist.java
@@ -43,10 +43,10 @@ public class Artist extends BaseEntity {
     @Column(name = "artist_type", nullable = false, length = 20)
     private ArtistType artistType;
 
-    @Column(name = "bio", columnDefinition = "TEXT")
+    @Column(name = "bio", length = 1000)
     private String bio;
 
-    @Column(name = "profile_image_url", length = 255)
+    @Column(name = "profile_image_url", length = 256)
     private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
@@ -71,6 +71,8 @@ public class Artist extends BaseEntity {
         validateNonNull(name, "name");
         validateNonNull(artistType, "artistType");
 
+        validateName(name);
+
         Artist artist = new Artist();
 
         artist.ownerUserId = ownerUserId;
@@ -87,6 +89,7 @@ public class Artist extends BaseEntity {
         validateNotDeleted();
 
         if (name != null) {
+            validateName(name);
             this.name = name;
         }
         if (bio != null) {
@@ -122,18 +125,24 @@ public class Artist extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
     }
 
-    public boolean isOwnedBy(Long userId) {
-        validateNonNull(userId, "userId");
-        return this.ownerUserId.equals(userId);
-    }
-
     private void validateNotDeleted() {
         if (this.deletedAt != null) {
-            throw new BusinessException(ArtistErrorCode.ERR_DELETED_ARTIST_CANNOT_BE_UPDATED);
+            throw new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND);
+        }
+    }
+
+    private static void validateName(String name) {
+        if (name.isBlank()) {
+            throw new BusinessException(ArtistErrorCode.ERR_INVALID_ARTIST_NAME);
         }
     }
 
     public boolean isDeleted() {
         return this.deletedAt != null;
+    }
+
+    public boolean isOwnedBy(Long userId) {
+        validateNonNull(userId, "userId");
+        return this.ownerUserId.equals(userId);
     }
 }

--- a/src/main/java/com/fivefy/domain/artist/enums/ArtistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/artist/enums/ArtistErrorCode.java
@@ -9,7 +9,7 @@ public enum ArtistErrorCode implements ErrorCode {
     ERR_ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 아티스트입니다"),
     ERR_ARTIST_ALREADY_ACTIVATED(HttpStatus.BAD_REQUEST, "이미 활성화된 아티스트입니다"),
     ERR_ARTIST_ALREADY_INACTIVE(HttpStatus.BAD_REQUEST, "이미 비활성화된 아티스트입니다"),
-    ERR_DELETED_ARTIST_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 아티스트는 수정할 수 없습니다"),
+    ERR_INVALID_ARTIST_NAME(HttpStatus.BAD_REQUEST, "아티스트 이름은 공백일 수 없습니다"),
     ERR_FORBIDDEN_ARTIST_ACCESS(HttpStatus.FORBIDDEN, "아티스트 소유자만 수정 또는 삭제할 수 있습니다");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/fivefy/domain/artist/enums/ArtistErrorCode.java
+++ b/src/main/java/com/fivefy/domain/artist/enums/ArtistErrorCode.java
@@ -10,7 +10,7 @@ public enum ArtistErrorCode implements ErrorCode {
     ERR_ARTIST_ALREADY_ACTIVATED(HttpStatus.BAD_REQUEST, "이미 활성화된 아티스트입니다"),
     ERR_ARTIST_ALREADY_INACTIVE(HttpStatus.BAD_REQUEST, "이미 비활성화된 아티스트입니다"),
     ERR_DELETED_ARTIST_CANNOT_BE_UPDATED(HttpStatus.BAD_REQUEST, "삭제된 아티스트는 수정할 수 없습니다"),
-    ERR_FORBIDDEN_ARTIST_ACCESS(HttpStatus.FORBIDDEN, "아티스트 소유자만 프로필을 수정할 수 있습니다");
+    ERR_FORBIDDEN_ARTIST_ACCESS(HttpStatus.FORBIDDEN, "아티스트 소유자만 수정 또는 삭제할 수 있습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
@@ -236,7 +236,7 @@ public class ArtistService {
 
     // 유저 조회
     private User findUser(Long userId) {
-        return userRepository.findById(userId)
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
     }
 

--- a/src/main/java/com/fivefy/domain/track/dto/response/TrackDetailResponse.java
+++ b/src/main/java/com/fivefy/domain/track/dto/response/TrackDetailResponse.java
@@ -5,6 +5,7 @@ import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.enums.TrackType;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 트랙 상세 조회 응답 DTO
@@ -25,12 +26,14 @@ public record TrackDetailResponse(
         Long durationSec,
         String featuredArtistText,
         Long playCount,
-        LocalDateTime publishedAt
+        LocalDateTime publishedAt,
+        List<TrackCommentResponse> comments
 ) {
     public static TrackDetailResponse of(
             Track track,
             String artistName,
-            String albumTitle
+            String albumTitle,
+            List<TrackCommentResponse> comments
     ) {
         return new TrackDetailResponse(
                 track.getId(),
@@ -47,7 +50,8 @@ public record TrackDetailResponse(
                 track.getDurationSec(),
                 track.getFeaturedArtistText(),
                 track.getPlayCount(),
-                track.getPublishedAt()
+                track.getPublishedAt(),
+                comments
         );
     }
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepository.java
@@ -4,6 +4,8 @@ import com.fivefy.domain.track.entity.TrackComment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 /**
  * 트랙 댓글 커스텀 리포지토리
  */
@@ -13,4 +15,9 @@ public interface TrackCommentQueryRepository {
      * 트랙 댓글 목록 조회
      */
     Page<TrackComment> getTrackComments(Long trackId, Pageable pageable);
+
+    /**
+     * 트랙 상세 조회용 최신 댓글 목록 조회
+     */
+    List<TrackComment> getRecentTrackComments(Long trackId, int limit);
 }

--- a/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackCommentQueryRepositoryImpl.java
@@ -52,4 +52,20 @@ public class TrackCommentQueryRepositoryImpl implements TrackCommentQueryReposit
 
         return new PageImpl<>(content, pageable, total == null ? 0 : total);
     }
+
+    /**
+     * 트랙 상세 조회용 최신 댓글 목록 조회
+     */
+    @Override
+    public List<TrackComment> getRecentTrackComments(Long trackId, int limit) {
+        return queryFactory
+                .selectFrom(trackComment)
+                .where(
+                        trackComment.trackId.eq(trackId),
+                        trackComment.deletedAt.isNull()
+                )
+                .orderBy(trackComment.createdAt.desc())
+                .limit(limit)
+                .fetch();
+    }
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackCommentService.java
@@ -4,6 +4,8 @@ import com.fivefy.common.dto.response.PageResponse;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.enums.AlbumStatus;
 import com.fivefy.domain.album.repository.AlbumRepository;
+import com.fivefy.domain.artist.entity.Artist;
+import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.dto.request.TrackCommentCreateRequest;
 import com.fivefy.domain.track.dto.response.TrackCommentResponse;
@@ -157,6 +159,22 @@ public class TrackCommentService {
         return track;
     }
 
+    // 공개 조회 가능한 앨범 조회
+    private void findVisibleAlbum(Long albumId) {
+        albumRepository.findById(albumId)
+                .filter(album -> album.getDeletedAt() == null
+                        && album.getStatus() == AlbumStatus.PUBLISHED)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+    }
+
+    // 공개 조회 가능한 아티스트 조회
+    private void findVisibleArtist(Long artistId) {
+        artistRepository.findById(artistId)
+                .filter(artist -> !artist.isDeleted()
+                        && artist.getStatus() == ArtistStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+    }
+
     // 댓글 접근 가능한 트랙 조회
     private void findAccessibleCommentTrack(Long trackId) {
         Track track = findPublishedTrack(trackId);
@@ -184,13 +202,8 @@ public class TrackCommentService {
 
     // 정식 발매 트랙 공개 가능 상태 검증
     private void validateOfficialTrackVisibility(Track track) {
-        albumRepository.findById(track.getAlbumId())
-                .filter(album -> album.getDeletedAt() == null && album.getStatus() == AlbumStatus.PUBLISHED)
-                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
-
-        artistRepository.findById(track.getArtistId())
-                .filter(artist -> !artist.isDeleted())
-                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+        findVisibleAlbum(track.getAlbumId());
+        findVisibleArtist(track.getArtistId());
     }
 
     // 댓글 삭제 권한 검증

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -20,10 +20,7 @@ import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
-import com.fivefy.domain.track.repository.PublicTrackListProjection;
-import com.fivefy.domain.track.repository.TrackApplicationRepository;
-import com.fivefy.domain.track.repository.TrackDetailProjection;
-import com.fivefy.domain.track.repository.TrackRepository;
+import com.fivefy.domain.track.repository.*;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
@@ -49,6 +46,7 @@ public class TrackService {
     private final AlbumRepository albumRepository;
     private final ArtistRepository artistRepository;
     private final TrackRepository trackRepository;
+    private final TrackCommentRepository trackCommentRepository;
 
     /**
      * 자유 창작 트랙 등록 신청
@@ -246,7 +244,13 @@ public class TrackService {
         String artistName = projection == null ? null : projection.artistName();
         String albumTitle = projection == null ? null : projection.albumTitle();
 
-        return TrackDetailResponse.of(track, artistName, albumTitle);
+        List<TrackCommentResponse> comments = trackCommentRepository
+                .getRecentTrackComments(trackId, 5)
+                .stream()
+                .map(TrackCommentResponse::from)
+                .toList();
+
+        return TrackDetailResponse.of(track, artistName, albumTitle, comments);
     }
 
     /**

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -329,6 +329,16 @@ public class TrackService {
         return artist;
     }
 
+    // 공개 조회 가능한 아티스트 조회
+    private void findVisibleArtist(Long artistId) {
+        Artist artist = artistRepository.findById(artistId)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+
+        if (artist.isDeleted() || artist.getStatus() != ArtistStatus.ACTIVE) {
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
+        }
+    }
+
     // 앨범 조회
     private Album findAlbum(Long albumId) {
         return albumRepository.findById(albumId)
@@ -344,6 +354,16 @@ public class TrackService {
         }
 
         return album;
+    }
+
+    // 공개 조회 가능한 앨범 조회
+    private void findVisibleAlbum(Long albumId) {
+        Album album = albumRepository.findById(albumId)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+
+        if (album.getDeletedAt() != null || album.getStatus() != AlbumStatus.PUBLISHED) {
+            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
+        }
     }
 
     // 트랙 등록 신청 조회
@@ -462,17 +482,8 @@ public class TrackService {
 
     // 정식 발매 트랙 공개 가능 상태 검증
     private void validateOfficialTrackVisibility(Track track) {
-        Album album = findAlbum(track.getAlbumId());
-
-        if (album.getDeletedAt() != null || album.getStatus() != AlbumStatus.PUBLISHED) {
-            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
-        }
-
-        Artist artist = findArtist(track.getArtistId());
-
-        if (artist.isDeleted()) {
-            throw new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND);
-        }
+        findVisibleAlbum(track.getAlbumId());
+        findVisibleArtist(track.getArtistId());
     }
 
     // =========================

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -14,6 +14,7 @@ import com.fivefy.domain.album.repository.AlbumApplicationRepository;
 import com.fivefy.domain.album.repository.AlbumRepository;
 import com.fivefy.domain.artist.entity.Artist;
 import com.fivefy.domain.artist.enums.ArtistErrorCode;
+import com.fivefy.domain.artist.enums.ArtistStatus;
 import com.fivefy.domain.artist.enums.ArtistType;
 import com.fivefy.domain.artist.repository.ArtistRepository;
 import com.fivefy.domain.track.entity.Track;
@@ -97,7 +98,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -149,7 +150,7 @@ class AlbumServiceTest {
                     0
             );
 
-            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> albumService.createAlbumApplication(userId, request))
                     .isInstanceOf(BusinessException.class)
@@ -171,7 +172,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
             when(artistRepository.findById(artistId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> albumService.createAlbumApplication(userId, request))
@@ -194,7 +195,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -228,7 +229,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     2L,
@@ -261,7 +262,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -295,7 +296,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -328,7 +329,7 @@ class AlbumServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             Artist artist = Artist.create(
                     userId,
@@ -360,7 +361,7 @@ class AlbumServiceTest {
             Long artistId = 10L;
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             AlbumApplication application1 = AlbumApplication.create(
                     userId,
@@ -403,7 +404,7 @@ class AlbumServiceTest {
             Long userId = 1L;
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
             when(albumApplicationRepository.searchMyAlbumApplications(userId))
                     .thenReturn(List.of());
 
@@ -418,7 +419,7 @@ class AlbumServiceTest {
         void getMyAlbumApplications_fail_whenUserNotFound() {
             Long userId = 1L;
 
-            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> albumService.getMyAlbumApplications(userId))
                     .isInstanceOf(BusinessException.class)
@@ -438,7 +439,7 @@ class AlbumServiceTest {
             Long artistId = 10L;
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             AlbumApplication application = AlbumApplication.create(
                     userId,
@@ -475,7 +476,7 @@ class AlbumServiceTest {
 
             User admin = mock(User.class);
             when(admin.getRole()).thenReturn(UserRole.ADMIN);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(admin));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(admin));
 
             AlbumApplication application = AlbumApplication.create(
                     requesterUserId,
@@ -508,7 +509,7 @@ class AlbumServiceTest {
 
             User user = mock(User.class);
             when(user.getRole()).thenReturn(UserRole.USER);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             AlbumApplication application = AlbumApplication.create(
                     requesterUserId,
@@ -843,6 +844,7 @@ class AlbumServiceTest {
 
             Artist artist = mock(Artist.class);
             when(artist.getName()).thenReturn("아이유");
+            when(artist.getStatus()).thenReturn(ArtistStatus.ACTIVE);
 
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
             when(artistRepository.findById(10L)).thenReturn(Optional.of(artist));
@@ -962,7 +964,7 @@ class AlbumServiceTest {
 
             assertThatThrownBy(() -> albumService.getAlbum(albumId))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessage(ArtistErrorCode.ERR_ARTIST_NOT_FOUND.getMessage());
+                    .hasMessage(AlbumErrorCode.ERR_ALBUM_NOT_FOUND.getMessage());
         }
 
         @Test
@@ -982,6 +984,8 @@ class AlbumServiceTest {
 
             Artist artist = mock(Artist.class);
             when(artist.getName()).thenReturn("아이유");
+            when(artist.isDeleted()).thenReturn(false);
+            when(artist.getStatus()).thenReturn(ArtistStatus.ACTIVE);
 
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
             when(artistRepository.findById(10L)).thenReturn(Optional.of(artist));

--- a/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
@@ -89,7 +89,7 @@ class ArtistServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
             when(artistApplicationRepository.existsActiveApplication(
                     userId,
                     request.requestedName(),
@@ -137,7 +137,7 @@ class ArtistServiceTest {
                     "https://example.com/profile.jpg"
             );
 
-            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> artistService.createArtistApplication(userId, request))
                     .isInstanceOf(BusinessException.class)
@@ -157,7 +157,7 @@ class ArtistServiceTest {
             );
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
             when(artistApplicationRepository.existsActiveApplication(
                     userId,
                     request.requestedName(),
@@ -180,7 +180,7 @@ class ArtistServiceTest {
             Long userId = 1L;
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
             ArtistApplication firstApplication = ArtistApplication.create(
                     userId,
@@ -229,7 +229,7 @@ class ArtistServiceTest {
             Long userId = 1L;
 
             User user = mock(User.class);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
             when(artistApplicationRepository.searchMyArtistApplications(userId))
                     .thenReturn(List.of());
 
@@ -244,7 +244,7 @@ class ArtistServiceTest {
         void getMyArtistApplications_fail_whenUserNotFound() {
             Long userId = 1L;
 
-            when(userRepository.findById(userId)).thenReturn(Optional.empty());
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> artistService.getMyArtistApplications(userId))
                     .isInstanceOf(BusinessException.class)
@@ -282,7 +282,7 @@ class ArtistServiceTest {
 
             when(artistApplicationRepository.findById(applicationId))
                     .thenReturn(java.util.Optional.of(application));
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(java.util.Optional.of(user));
 
             // when
@@ -304,7 +304,7 @@ class ArtistServiceTest {
             assertThat(response.updatedAt()).isEqualTo(LocalDateTime.of(2026, 4, 14, 11, 0, 0));
 
             verify(artistApplicationRepository, times(1)).findById(applicationId);
-            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(userId);
         }
 
         @Test
@@ -333,7 +333,7 @@ class ArtistServiceTest {
 
             when(artistApplicationRepository.findById(applicationId))
                     .thenReturn(java.util.Optional.of(application));
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(java.util.Optional.of(adminUser));
 
             // when
@@ -348,7 +348,7 @@ class ArtistServiceTest {
             assertThat(response.status()).isEqualTo(ApplicationStatus.PENDING);
 
             verify(artistApplicationRepository, times(1)).findById(applicationId);
-            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(userId);
         }
 
         @Test
@@ -371,7 +371,7 @@ class ArtistServiceTest {
 
             when(artistApplicationRepository.findById(applicationId))
                     .thenReturn(java.util.Optional.of(application));
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(java.util.Optional.of(user));
 
             // when & then
@@ -380,7 +380,7 @@ class ArtistServiceTest {
                     .hasMessage(ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_DETAIL_FORBIDDEN.getMessage());
 
             verify(artistApplicationRepository, times(1)).findById(applicationId);
-            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(userId);
         }
 
         @Test
@@ -687,7 +687,7 @@ class ArtistServiceTest {
             Long userId = 1L;
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(java.util.Optional.of(user));
 
             Artist firstArtist = Artist.create(
@@ -741,7 +741,7 @@ class ArtistServiceTest {
             assertThat(response.get(1).createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 14, 10, 0, 0));
             assertThat(response.get(1).updatedAt()).isEqualTo(LocalDateTime.of(2026, 4, 14, 11, 0, 0));
 
-            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(userId);
             verify(artistRepository, times(1)).findMyArtists(userId);
         }
 
@@ -752,7 +752,7 @@ class ArtistServiceTest {
             Long userId = 1L;
 
             User user = mock(User.class);
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
                     .thenReturn(java.util.Optional.of(user));
 
             when(artistRepository.findMyArtists(userId))
@@ -764,7 +764,7 @@ class ArtistServiceTest {
             // then
             assertThat(response).isEmpty();
 
-            verify(userRepository, times(1)).findById(userId);
+            verify(userRepository, times(1)).findByIdAndDeletedAtIsNull(userId);
             verify(artistRepository, times(1)).findMyArtists(userId);
         }
     }

--- a/src/test/java/com/fivefy/domain/track/controller/TrackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/track/controller/TrackControllerTest.java
@@ -8,6 +8,7 @@ import com.fivefy.common.filter.LastActiveAtFilter;
 import com.fivefy.domain.artist.enums.ArtistErrorCode;
 import com.fivefy.domain.track.dto.response.ArtistFreeCreationTrackResponse;
 import com.fivefy.domain.track.dto.response.PublicTrackListResponse;
+import com.fivefy.domain.track.dto.response.TrackCommentResponse;
 import com.fivefy.domain.track.dto.response.TrackDetailResponse;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackType;
@@ -78,7 +79,17 @@ class TrackControllerTest extends RestDocsSupport {
                     230L,
                     "feat. 10cm",
                     1200L,
-                    LocalDateTime.of(2026, 5, 1, 18, 0, 0)
+                    LocalDateTime.of(2026, 5, 1, 18, 0, 0),
+                    List.of(
+                            new TrackCommentResponse(
+                                    10L,
+                                    3L,
+                                    1000L,
+                                    "좋아요",
+                                    LocalDateTime.of(2026, 4, 22, 13, 0, 0),
+                                    LocalDateTime.of(2026, 4, 22, 13, 0, 0)
+                            )
+                    )
             );
 
             given(trackService.getTrack(trackId)).willReturn(response);
@@ -89,6 +100,10 @@ class TrackControllerTest extends RestDocsSupport {
                     .andExpect(jsonPath("$.message").value("트랙 상세 조회 성공"))
                     .andExpect(jsonPath("$.data.trackId").value(trackId))
                     .andExpect(jsonPath("$.data.title").value("밤편지"))
+                    .andExpect(jsonPath("$.data.comments[0].commentId").value(10L))
+                    .andExpect(jsonPath("$.data.comments[0].userId").value(3L))
+                    .andExpect(jsonPath("$.data.comments[0].trackId").value(1000L))
+                    .andExpect(jsonPath("$.data.comments[0].content").value("좋아요"))
                     .andDo(document("tracks-get",
                             pathParameters(
                                     parameterWithName("trackId").description("트랙 ID")
@@ -350,7 +365,14 @@ class TrackControllerTest extends RestDocsSupport {
                 fieldWithPath("data.durationSec").type(NUMBER).description("재생 시간(초)"),
                 fieldWithPath("data.featuredArtistText").type(STRING).description("피처링 아티스트 텍스트").optional(),
                 fieldWithPath("data.playCount").type(NUMBER).description("재생 횟수"),
-                fieldWithPath("data.publishedAt").type(STRING).description("공개 시각")
+                fieldWithPath("data.publishedAt").type(STRING).description("공개 시각"),
+                fieldWithPath("data.comments").type(ARRAY).description("최신 트랙 댓글 목록"),
+                fieldWithPath("data.comments[].commentId").type(NUMBER).description("댓글 ID"),
+                fieldWithPath("data.comments[].userId").type(NUMBER).description("댓글 작성자 ID"),
+                fieldWithPath("data.comments[].trackId").type(NUMBER).description("트랙 ID"),
+                fieldWithPath("data.comments[].content").type(STRING).description("댓글 내용"),
+                fieldWithPath("data.comments[].createdAt").type(STRING).description("댓글 작성 시각"),
+                fieldWithPath("data.comments[].updatedAt").type(STRING).description("댓글 수정 시각")
         };
     }
 

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -15,14 +15,12 @@ import com.fivefy.domain.track.dto.request.OfficialTrackApplicationCreateRequest
 import com.fivefy.domain.track.dto.response.*;
 import com.fivefy.domain.track.entity.Track;
 import com.fivefy.domain.track.entity.TrackApplication;
+import com.fivefy.domain.track.entity.TrackComment;
 import com.fivefy.domain.track.enums.TrackApplicationErrorCode;
 import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.enums.TrackStatus;
 import com.fivefy.domain.track.enums.TrackType;
-import com.fivefy.domain.track.repository.PublicTrackListProjection;
-import com.fivefy.domain.track.repository.TrackApplicationRepository;
-import com.fivefy.domain.track.repository.TrackDetailProjection;
-import com.fivefy.domain.track.repository.TrackRepository;
+import com.fivefy.domain.track.repository.*;
 import com.fivefy.domain.user.entity.User;
 import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
@@ -79,6 +77,9 @@ class TrackServiceTest {
 
     @Mock
     private TrackRepository trackRepository;
+
+    @Mock
+    private TrackCommentRepository trackCommentRepository;
 
     @InjectMocks
     private TrackService trackService;
@@ -1616,6 +1617,17 @@ class TrackServiceTest {
             Long artistId = 10L;
             Long albumId = 100L;
 
+            TrackComment comment = mock(TrackComment.class);
+            when(comment.getId()).thenReturn(10L);
+            when(comment.getUserId()).thenReturn(3L);
+            when(comment.getTrackId()).thenReturn(trackId);
+            when(comment.getContent()).thenReturn("좋아요");
+            when(comment.getCreatedAt()).thenReturn(LocalDateTime.of(2026, 4, 22, 13, 0, 0));
+            when(comment.getUpdatedAt()).thenReturn(LocalDateTime.of(2026, 4, 22, 13, 0, 0));
+
+            when(trackCommentRepository.getRecentTrackComments(trackId, 5))
+                    .thenReturn(List.of(comment));
+
             Track track = Track.createOfficialRelease(
                     1L,
                     artistId,
@@ -1680,6 +1692,11 @@ class TrackServiceTest {
             assertThat(response.featuredArtistText()).isEqualTo("feat. 10cm");
             assertThat(response.playCount()).isEqualTo(1200L);
             assertThat(response.publishedAt()).isEqualTo(LocalDateTime.of(2026, 5, 1, 18, 0, 0));
+            assertThat(response.comments()).hasSize(1);
+            assertThat(response.comments().get(0).commentId()).isEqualTo(10L);
+            assertThat(response.comments().get(0).userId()).isEqualTo(3L);
+            assertThat(response.comments().get(0).trackId()).isEqualTo(trackId);
+            assertThat(response.comments().get(0).content()).isEqualTo("좋아요");
         }
 
         @Test


### PR DESCRIPTION
## 개요

공개 조회 시점의 가시성 정책 정비

- 삭제되거나 비활성화된 아티스트 노출 차단
- 미공개/삭제 앨범이 연결된 정식 발매 트랙 노출 차단
- 앨범 상세에 수록곡 목록 포함
- 트랙 상세에 최신 댓글 목록 포함

추가로 유저 조회를 `findByIdAndDeletedAtIsNull` 기준으로 통일하고, 앨범 상태 전이 검증과 아티스트 이름 검증을 보강

## 변경 사항

### Album 도메인

- Album 엔티티 상태 전이 검증 보강
  - `publish()`는 `UNPUBLISHED -> PUBLISHED`만 허용
  - `block()`은 `PUBLISHED -> BLOCKED`만 허용
  - 허용되지 않은 상태 변경은 `ERR_INVALID_ALBUM_STATUS_TRANSITION` 반환

- `GET /api/albums/{albumId}` 공개 상세 조회 가시성 정책 수정
  - 기존: 삭제되지 않은 아티스트 기준 조회
  - 변경: 삭제되지 않았고 `ACTIVE` 상태인 아티스트만 노출
  - 조건 불만족 시 `ERR_ALBUM_NOT_FOUND`로 일관 처리

- 앨범 상세 응답 보강
  - `AlbumDetailResponse`에 `tracks` 필드 추가
  - `AlbumTrackResponse` DTO 추가
  - 앨범에 속한 공개 정식 발매 트랙을 trackNumber 오름차순으로 포함

### Artist 도메인

- Artist 엔티티 검증 보강
  - 생성/수정 시 이름 공백 검증 추가
  - `ERR_INVALID_ARTIST_NAME` 에러 코드 추가
  - 삭제 엔티티 접근 시 내부 검증을 `ERR_ARTIST_NOT_FOUND` 기준으로 정리

- Artist 컬럼 제약 정리
  - `bio` 길이 1000
  - `profileImageUrl` 길이 256

- 권한 에러 메시지 정리
  - `ERR_FORBIDDEN_ARTIST_ACCESS` 메시지를 수정/삭제 공통 의미로 확장

### Track 도메인

- `GET /api/tracks/{trackId}` 상세 조회 응답 보강
  - `TrackDetailResponse`에 최신 댓글 목록 `comments` 추가
  - 최신 댓글 5개를 별도 조회 후 포함

- 트랙 상세 공개 정책 정비
  - 정식 발매 트랙은 트랙 자체 공개 상태만으로 노출하지 않음
  - 연결된 앨범이 삭제되지 않았고 `PUBLISHED` 상태인지 재검증
  - 연결된 아티스트가 삭제되지 않았고 `ACTIVE` 상태인지 재검증
  - 조건 불만족 시 `ERR_TRACK_NOT_FOUND` 반환

- 공개 조회용 가시성 helper 정리
  - `findVisibleAlbum()`
  - `findVisibleArtist()`
  - 정식 발매 트랙 공개 검증 로직에서 공통 사용

### Track Comment 도메인

- 트랙 상세 조회용 최근 댓글 조회 기능 추가
  - `TrackCommentQueryRepository#getRecentTrackComments(Long trackId, int limit)`
  - 삭제되지 않은 댓글만 `createdAt DESC` 기준 조회

- TrackCommentService 공개 가시성 검증 정리
  - 정식 발매 트랙 댓글 접근 시 공개 가능한 앨범/아티스트 검증 로직을 helper로 분리
  - TrackService와 동일한 공개 정책 기준 유지

### 공통 조회 정책 정리

- AlbumService, ArtistService의 유저 조회를 `findByIdAndDeletedAtIsNull` 기준으로 통일
- 삭제 유저는 조회 성공으로 처리하지 않도록 정리

### 테스트 반영

- AlbumServiceTest
  - 삭제 유저 조회 기준 변경 반영
  - 공개 가능한 아티스트 조건(`ACTIVE`) 반영
  - 아티스트 비노출 시 `ERR_ALBUM_NOT_FOUND` 기준으로 수정
  - 앨범 수록곡 포함 응답 검증 유지

- ArtistServiceTest
  - 유저 조회 메서드 변경 반영
  - 관련 verify/assertion 수정

- TrackServiceTest
  - 트랙 상세 조회 시 최신 댓글 포함 검증 추가
  - 자유 창작 트랙 상세 조회 검증 유지
  - 정식 발매 트랙의 앨범 삭제 / 미공개 / 아티스트 삭제 케이스 검증 유지 및 보강

- TrackControllerTest
  - 트랙 상세 응답에 `comments` 필드 검증 추가
  - REST Docs response field에 최신 댓글 목록 반영

## 변경 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [x] 테스트 코드 작성 / 수정

## 테스트 방법

```bash
./gradlew test --tests "com.fivefy.domain.album.service.AlbumServiceTest"
./gradlew test --tests "com.fivefy.domain.artist.service.ArtistServiceTest"
./gradlew test --tests "com.fivefy.domain.track.service.TrackServiceTest"
./gradlew test --tests "com.fivefy.domain.track.controller.TrackControllerTest"
```
- 공개 앨범 상세 조회 시 비활성/삭제 아티스트 차단 확인

- 앨범 상세 응답의 수록곡 목록 포함 확인

- 트랙 상세 조회 시 최신 댓글 5개 포함 확인

- 정식 발매 트랙 상세 조회 시 앨범/아티스트 공개 조건 재검증 확인

- 삭제 유저 조회 차단 기준 반영 확인

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 트랙 상세 정보에 최근 댓글 표시 추가

* **개선 사항**
  * 앨범 발행/차단 작업 시 더 엄격한 상태 검증 강화
  * 아티스트 프로필 이름 유효성 검사 추가
  * 삭제된 사용자 및 아티스트에 대한 오류 처리 개선
  * 공개 앨범 상세 조회 시 활성 상태 아티스트만 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->