### PR TITLE
refactor: PlaylistTrack 순서 변경 로직을 부분 재정렬 방식으로 개선

### DIFF
--- a/src/main/java/com/fivefy/domain/playlisttrack/repository/PlaylistTrackRepository.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/repository/PlaylistTrackRepository.java
@@ -12,4 +12,10 @@ public interface PlaylistTrackRepository extends JpaRepository<PlaylistTrack, Lo
     Optional<PlaylistTrack> findByPlaylistIdAndTrackId(Long playlistId, Long trackId);
     boolean existsByPlaylistIdAndTrackId(Long playlistId, Long trackId);
     int countByPlaylistId(Long playlistId);
+    // 특정 구간의 트랙 조회 (순서 변경 시 영향 범위만 조회하기 위함)
+    // ex) 2 -> 4 이동 시, 3~4 위치 트랙만 조회하여 부분 재정렬에 사용
+    List<PlaylistTrack> findByPlaylistIdAndPositionBetweenOrderByPositionAsc(Long playlistId, int startPosition, int endPosition);
+    // 특정 위치 이후의 트랙 조회 (삭제 후 뒤에 있는 트랙을 앞으로 당기기 위함)
+    // ex) 3번 트랙 삭제 시, 4번 이후 트랙들을 조회하여 position -1 처리
+    List<PlaylistTrack> findByPlaylistIdAndPositionGreaterThanOrderByPositionAsc(Long playlistId, int position);
 }

--- a/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
+++ b/src/main/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackService.java
@@ -94,13 +94,16 @@ public class PlaylistTrackService {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_UPDATE_FORBIDDEN);
         }
 
+        // 현재 플레이리스트의 트랙 목록 조회 (순서 기준)
         List<PlaylistTrack> playlistTracks = playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId);
 
+        // 이동 대상 트랙 조회
         PlaylistTrack target = playlistTracks.stream()
                 .filter(playlistTrack -> playlistTrack.getTrackId().equals(request.trackId()))
                 .findFirst()
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND));
 
+        int oldPosition = target.getPosition();
         int newPosition = request.position();
 
         // 이동할 위치는 1 ~ 트랙 개수 범위여야 함
@@ -109,19 +112,17 @@ public class PlaylistTrackService {
         }
 
         // 현재 위치와 같으면 변경할 필요 없음
-        if (target.getPosition().equals(newPosition)) {
+        if (oldPosition == newPosition) {
             return;
         }
 
-        // 기존 위치에서 제거한 뒤, 요청한 위치에 다시 넣음
-        playlistTracks.remove(target);
-        playlistTracks.add(newPosition - 1, target);
-
         try {
-            // 변경된 순서대로 position 재정렬
-            reorderPositions(playlistTracks);
-        // DB 유니크 제약조건 충돌 발생 시,
-        // 어떤 제약조건이 깨졌는지(constraint name)를 기준으로 예외 구분
+            // 이동 방향에 따라 영향 범위만 부분 재정렬
+            if (oldPosition < newPosition) {
+                moveDown(playlistId, target, oldPosition, newPosition);
+            } else {
+                moveUp(playlistId, target, oldPosition, newPosition);
+            }
         } catch (DataIntegrityViolationException e) {
             throw handlePlaylistTrackConstraintException(e);
         }
@@ -137,54 +138,100 @@ public class PlaylistTrackService {
             throw new BusinessException(PlaylistErrorCode.PLAYLIST_DELETE_FORBIDDEN);
         }
 
-        List<PlaylistTrack> playlistTracks = playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId);
-
-        PlaylistTrack target = playlistTracks.stream()
-                .filter(playlistTrack -> playlistTrack.getTrackId().equals(trackId))
-                .findFirst()
+        // 삭제 대상 트랙 조회
+        PlaylistTrack target = playlistTrackRepository.findByPlaylistIdAndTrackId(playlistId, trackId)
                 .orElseThrow(() -> new BusinessException(PlaylistErrorCode.PLAYLIST_TRACK_NOT_FOUND));
 
-        // 삭제 대상 트랙을 목록과 DB에서 제거
-        playlistTracks.remove(target);
+        int deletedPosition = target.getPosition();
+
+        // 트랙 삭제
         playlistTrackRepository.delete(target);
 
         try {
-            // position 충돌 방지를 위해 삭제를 먼저 DB에 반영
+            // 삭제를 먼저 DB에 반영 (position 충돌 방지)
             playlistTrackRepository.flush();
-            // 변경된 순서대로 position 재정렬
-            reorderPositions(playlistTracks);
+
+            // 삭제된 위치 이후 트랙만 조회하여 position을 한 칸씩 앞으로 당김
+            List<PlaylistTrack> affectedTracks =
+                    playlistTrackRepository.findByPlaylistIdAndPositionGreaterThanOrderByPositionAsc(
+                            playlistId, deletedPosition
+                    );
+
+            for (PlaylistTrack track : affectedTracks) {
+                track.updatePosition(track.getPosition() - 1);
+            }
+
+            playlistTrackRepository.flush();
         } catch (DataIntegrityViolationException e) {
             throw handlePlaylistTrackConstraintException(e);
         }
     }
 
     /**
-     * position 중복 방지를 위해
-     * 모든 값을 음수로 변경 후 flush,
-     * 이후 1부터 순서대로 다시 할당
+     * 아래로 이동 (oldPosition < newPosition)
+     * 예: 2 -> 4
+     * - target: 2 → 4 이동
+     * - 3, 4 위치 트랙들은 각각 1칸씩 앞으로 이동 (3→2, 4→3)
      */
-    private void reorderPositions(List<PlaylistTrack> playlistTracks) {
-        // 임시로 음수 position 부여 (중복 방지)
-        for (int i = 0; i < playlistTracks.size(); i++) {
-            playlistTracks.get(i).moveToTemporaryPosition(-(i + 1));
+    private void moveDown(Long playlistId, PlaylistTrack target, int oldPosition, int newPosition) {
+        List<PlaylistTrack> affectedTracks =
+                playlistTrackRepository.findByPlaylistIdAndPositionBetweenOrderByPositionAsc(
+                        playlistId, oldPosition + 1, newPosition
+                );
+
+        // 충돌 방지를 위해 영향 범위 + target을 임시 음수로 변경
+        target.moveToTemporaryPosition(-oldPosition);
+        for (PlaylistTrack track : affectedTracks) {
+            track.moveToTemporaryPosition(-track.getPosition());
         }
 
-        // 변경된 음수 position을 DB에 먼저 반영
         playlistTrackRepository.flush();
 
-        // position을 1부터 순서대로 다시 부여
-        for (int i = 0; i < playlistTracks.size(); i++) {
-            playlistTracks.get(i).updatePosition(i + 1);
+        // affected 트랙: 한 칸씩 앞으로 이동
+        for (PlaylistTrack track : affectedTracks) {
+            int originalPosition = -track.getPosition();
+            track.updatePosition(originalPosition - 1);
         }
 
-        // 최종 position 반영
+        // target: 요청 위치로 이동
+        target.updatePosition(newPosition);
+
         playlistTrackRepository.flush();
     }
 
     /**
-     * DB 유니크 제약조건 위반 시 constraint 이름을 기반으로
-     * 적절한 비즈니스 예외 변환
+     * 위로 이동
+     * 예: 4 -> 2
+     * - target: 4 -> 2
+     * - 2, 3 위치 트랙들은 각각 1칸씩 뒤로 이동 (2→3, 3→4)
      */
+    private void moveUp(Long playlistId, PlaylistTrack target, int oldPosition, int newPosition) {
+        List<PlaylistTrack> affectedTracks =
+                playlistTrackRepository.findByPlaylistIdAndPositionBetweenOrderByPositionAsc(
+                        playlistId, newPosition, oldPosition - 1
+                );
+
+        // 충돌 방지를 위해 영향 범위 + target을 임시 음수로 변경
+        target.moveToTemporaryPosition(-oldPosition);
+        for (PlaylistTrack track : affectedTracks) {
+            track.moveToTemporaryPosition(-track.getPosition());
+        }
+
+        playlistTrackRepository.flush();
+
+        // affected 트랙: 한 칸씩 뒤로 이동
+        for (PlaylistTrack track : affectedTracks) {
+            int originalPosition = -track.getPosition();
+            track.updatePosition(originalPosition + 1);
+        }
+
+        // target: 요청 위치로 이동
+        target.updatePosition(newPosition);
+
+        playlistTrackRepository.flush();
+    }
+
+    // DB 유니크 제약조건 위반 시 constraint 이름을 기반으로 적절한 비즈니스 예외 변환
     private BusinessException handlePlaylistTrackConstraintException(DataIntegrityViolationException e) {
         String constraintName = extractConstraintName(e);
 

--- a/src/test/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playlisttrack/service/PlaylistTrackServiceTest.java
@@ -374,6 +374,8 @@ class PlaylistTrackServiceTest {
                     .willReturn(Optional.of(playlist));
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
                     .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
+            given(playlistTrackRepository.findByPlaylistIdAndPositionBetweenOrderByPositionAsc(playlistId, 1, 2))
+                    .willReturn(List.of(track1, track2));
 
             // when
             playlistTrackService.updateTrackOrder(userId, playlistId, request);
@@ -382,6 +384,7 @@ class PlaylistTrackServiceTest {
             assertThat(track3.getPosition()).isEqualTo(1);
             assertThat(track1.getPosition()).isEqualTo(2);
             assertThat(track2.getPosition()).isEqualTo(3);
+
             verify(playlistTrackRepository, times(2)).flush();
         }
 
@@ -557,6 +560,72 @@ class PlaylistTrackServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT.getMessage());
         }
+
+        @Test
+        @DisplayName("트랙 순서를 아래로 이동하면 영향 범위만 앞으로 당겨진다")
+        void updateTrackOrderMoveDownSuccess() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 3);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+            PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
+
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
+
+            // 1 -> 3 이동이므로 영향 범위는 2 ~ 3
+            given(playlistTrackRepository.findByPlaylistIdAndPositionBetweenOrderByPositionAsc(playlistId, 2, 3))
+                    .willReturn(List.of(track2, track3));
+
+            // when
+            playlistTrackService.updateTrackOrder(userId, playlistId, request);
+
+            // then
+            assertThat(track1.getPosition()).isEqualTo(3);
+            assertThat(track2.getPosition()).isEqualTo(1);
+            assertThat(track3.getPosition()).isEqualTo(2);
+
+            verify(playlistTrackRepository, times(2)).flush();
+        }
+
+        @Test
+        @DisplayName("트랙 순서 아래 이동 중 position 충돌 시 예외 발생")
+        void updateTrackOrderMoveDownPositionConflict() {
+            // given
+            Long userId = 1L;
+            Long playlistId = 1L;
+            PlaylistTrackOrderUpdateRequest request = new PlaylistTrackOrderUpdateRequest(10L, 3);
+
+            Playlist playlist = Playlist.create(userId, "플리", "설명");
+            ReflectionTestUtils.setField(playlist, "id", playlistId);
+
+            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
+            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
+            PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
+
+            given(playlistRepository.findByIdAndDeletedFalse(playlistId))
+                    .willReturn(Optional.of(playlist));
+            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
+                    .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
+            given(playlistTrackRepository.findByPlaylistIdAndPositionBetweenOrderByPositionAsc(playlistId, 2, 3))
+                    .willReturn(List.of(track2, track3));
+
+            doThrow(constraintViolationException("uk_playlist_track_playlist_position"))
+                    .when(playlistTrackRepository).flush();
+
+            // when & then
+            assertThatThrownBy(() -> playlistTrackService.updateTrackOrder(userId, playlistId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaylistErrorCode.PLAYLIST_TRACK_POSITION_CONFLICT.getMessage());
+        }
     }
 
     @Nested
@@ -574,22 +643,22 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
             PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
 
             given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
-            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
-                    .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
+            given(playlistTrackRepository.findByPlaylistIdAndTrackId(playlistId, trackId))
+                    .willReturn(Optional.of(track2));
+            given(playlistTrackRepository.findByPlaylistIdAndPositionGreaterThanOrderByPositionAsc(playlistId, 2))
+                    .willReturn(List.of(track3));
 
             // when
             playlistTrackService.deleteTrack(userId, playlistId, trackId);
 
             // then
             verify(playlistTrackRepository).delete(track2);
-            verify(playlistTrackRepository, times(3)).flush();
-            assertThat(track1.getPosition()).isEqualTo(1);
+            verify(playlistTrackRepository, times(2)).flush();
             assertThat(track3.getPosition()).isEqualTo(2);
         }
 
@@ -642,13 +711,10 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
-            PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
-
             given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
-            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
-                    .willReturn(List.of(track1, track2));
+            given(playlistTrackRepository.findByPlaylistIdAndTrackId(playlistId, trackId))
+                    .willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> playlistTrackService.deleteTrack(userId, playlistId, trackId))
@@ -667,14 +733,12 @@ class PlaylistTrackServiceTest {
             Playlist playlist = Playlist.create(userId, "플리", "설명");
             ReflectionTestUtils.setField(playlist, "id", playlistId);
 
-            PlaylistTrack track1 = PlaylistTrack.create(playlistId, 10L, 1);
             PlaylistTrack track2 = PlaylistTrack.create(playlistId, 20L, 2);
-            PlaylistTrack track3 = PlaylistTrack.create(playlistId, 30L, 3);
 
             given(playlistRepository.findByIdAndDeletedFalse(playlistId))
                     .willReturn(Optional.of(playlist));
-            given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(playlistId))
-                    .willReturn(new ArrayList<>(List.of(track1, track2, track3)));
+            given(playlistTrackRepository.findByPlaylistIdAndTrackId(playlistId, trackId))
+                    .willReturn(Optional.of(track2));
 
             doThrow(constraintViolationException("uk_playlist_track_playlist_position"))
                     .when(playlistTrackRepository).flush();


### PR DESCRIPTION
## 개요

> 기존 PlaylistTrack 순서 변경 로직은 트랙 이동 시 전체 position을 재정렬하는 방식으로 동작했습니다.  
이를 개선하여 영향 범위만 갱신하는 부분 재정렬 방식으로 변경하고,  
불필요한 DB update를 줄이도록 최적화했습니다.

## 변경 사항

### 1. 순서 변경 로직 개선

- 기존: 전체 트랙 재정렬 방식
- 변경: 이동 구간만 갱신하는 부분 재정렬 방식 적용
- 이동 방향에 따라 분기 처리
  - 아래로 이동 (`moveDown`)
  - 위로 이동 (`moveUp`)

---

### 2. 유니크 제약 충돌 처리 개선

- `(playlist_id, position)` 유니크 제약으로 인한 충돌 방지
- 기존: 전체 트랙을 음수로 변경 후 재정렬
- 변경: 영향 범위 트랙만 임시 음수 position 적용

---

### 3. 삭제 로직 개선

- 기존: 삭제 후 전체 재정렬
- 변경: 삭제된 위치 이후 트랙만 앞으로 이동
- 불필요한 전체 update 제거

---

### 4. Repository 쿼리 추가

- 특정 구간의 트랙 조회 (순서 변경 시 영향 범위만 조회)
  - `findByPlaylistIdAndPositionBetweenOrderByPositionAsc`
- 특정 위치 이후 트랙 조회 (삭제 후 뒤쪽 트랙 당김)
  - `findByPlaylistIdAndPositionGreaterThanOrderByPositionAsc`

---

### 5. 테스트 코드 보완

- 순서 변경 성공 케이스 보완 (`moveUp`, `moveDown` 모두 검증)
- position 충돌 예외 케이스 검증
- 불필요한 stubbing 제거
- JaCoCo 기준 분기 커버리지 보완

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> PlaylistTrack 순서 변경 및 삭제 로직 개선 동작을 검증합니다.

### 1. 순서 변경
- 특정 트랙을 다른 위치로 이동 시 정상적으로 위치가 재정렬되는지 확인
- 위/아래 이동 모두 검증

### 2. 부분 재정렬 검증
- 이동 대상이 아닌 트랙은 변경되지 않는지 확인

### 3. 삭제 후 재정렬
- 삭제된 위치 이후 트랙만 position이 감소하는지 확인

### 4. 예외 처리
- position 범위 벗어날 경우 예외 발생
- position 유니크 충돌 시 예외 변환 확인

## 스크린샷
- 테스트 커버리지 (JaCoCo 100%)
<img width="1766" height="355" alt="image" src="https://github.com/user-attachments/assets/c9083756-5499-4872-9f8d-a70f2ab0b88c" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 플레이리스트 트랙 순서 관리 로직을 최적화하여 부분 범위 업데이트 지원
  * 트랙 삭제 시 영향받는 항목만 효율적으로 처리하도록 개선

* **Tests**
  * 순서 변경 및 삭제 시나리오에 대한 테스트 커버리지 확대
  * 제약 조건 위반 시 예외 처리 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->