### PR TITLE
fix: LastActiveAtFilter를 Security 필터 체인에 추가 및 테스트 설정 수정

### DIFF
--- a/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(lastActiveAtFilter, JwtFilter.class)
                 .build();
     }
 

--- a/src/test/java/com/fivefy/domain/album/controller/AlbumSecurityTest.java
+++ b/src/test/java/com/fivefy/domain/album/controller/AlbumSecurityTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -26,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AlbumController.class)
 @AutoConfigureMockMvc
-@Import({SecurityConfig.class, JwtFilter.class, JwtAuthenticationEntryPoint.class, JwtAccessDeniedHandler.class})
+@Import({SecurityConfig.class, JwtFilter.class, JwtAuthenticationEntryPoint.class, JwtAccessDeniedHandler.class, LastActiveAtFilter.class})
 class AlbumSecurityTest {
 
     @Autowired
@@ -39,7 +40,7 @@ class AlbumSecurityTest {
     private JwtUtil jwtUtil;
 
     @MockitoBean
-    private LastActiveAtFilter lastActiveAtFilter;
+    private StringRedisTemplate redisTemplate;
 
     @Nested
     @DisplayName("공개 API 접근")


### PR DESCRIPTION
## 개요

> LastActiveAtFilter를 비활성화한 것을 발견 후 수정

## 변경 사항

- SecurityConfig에 lastActiveAtFilter를 JwtFilter 이후 실행되도록 추가
- AlbumSecurityTest에서 LastActiveAtFilter를 Import하고 StringRedisTemplate 모킹으로 변경
- 필터 체인: JwtFilter (인증) → LastActiveAtFilter (활동 추적) 순서로 동작

## 변경 유형

- [ ] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 보안 필터 체인의 처리 순서를 개선하여 사용자 활동 추적 로직이 인증 처리 이후에 실행되도록 변경했습니다.
  * 테스트 구성을 업데이트하여 보안 계층의 변경 사항을 정확하게 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->