### PR TITLE
refactor : 에러코드 작성 및 중복 로직 제거

### DIFF
--- a/src/main/java/com/fivefy/common/portone/client/PortoneClient.java
+++ b/src/main/java/com/fivefy/common/portone/client/PortoneClient.java
@@ -137,7 +137,7 @@ public class PortoneClient {
                         "currency": "KRW"
                     }
                     """
-                    .formatted(billingKey, description, amount, portoneProperties.storeId());
+                    .formatted(billingKey, description, amount);
 
             ResponseEntity<PortoneBillingPaymentResponse> response = restTemplate.exchange(
                     url, HttpMethod.POST, new HttpEntity<>(body, authHeaders()), PortoneBillingPaymentResponse.class

--- a/src/main/java/com/fivefy/common/portone/client/PortoneClient.java
+++ b/src/main/java/com/fivefy/common/portone/client/PortoneClient.java
@@ -1,10 +1,12 @@
 package com.fivefy.common.portone.client;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.portone.config.PortoneProperties;
 import com.fivefy.common.portone.dto.PortoneBillingKeyResponse;
 import com.fivefy.common.portone.dto.PortoneBillingPaymentResponse;
 import com.fivefy.common.portone.dto.PortoneCancelResponse;
 import com.fivefy.common.portone.dto.PortonePaymentResponse;
+import com.fivefy.common.portone.enums.PortoneErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -46,7 +48,7 @@ public class PortoneClient {
         );
 
         if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
-            throw new IllegalStateException("포트원 결제 조회 실패");
+            throw new BusinessException(PortoneErrorCode.ERR_PORTONE_PAYMENT_NOT_FOUND);
         }
 
         return response.getBody();
@@ -83,7 +85,7 @@ public class PortoneClient {
         );
 
         if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
-            throw new IllegalStateException("포트원 환불 실패");
+            throw new BusinessException(PortoneErrorCode.ERR_PORTONE_CANCEL_FAILED);
         }
 
         return response.getBody();
@@ -91,87 +93,85 @@ public class PortoneClient {
 
 
     /**
-         * 빌링키 단건 조회
-         * 프론트가 포트원 SDK로 카드 등록 완료 후 billingKeyId를 서버에 전달
-         * 서버는 이 메서드로 실제 빌링키 토큰 + 카드 정보를 확인
-         *
-         * @param billingKeyId 포트원이 발급한 빌링키 ID (프론트에서 전달)
-         */
-        public PortoneBillingKeyResponse getBillingKey(String billingKeyId) {
-            String url = BASE_URL + "/billing-keys/" + billingKeyId;
+     * 빌링키 단건 조회
+     * 프론트가 포트원 SDK로 카드 등록 완료 후 billingKeyId를 서버에 전달
+     * 서버는 이 메서드로 실제 빌링키 토큰 + 카드 정보를 확인
+     *
+     * @param billingKeyId 포트원이 발급한 빌링키 ID (프론트에서 전달)
+     */
+     public PortoneBillingKeyResponse getBillingKey(String billingKeyId) {
+         String url = BASE_URL + "/billing-keys/" + billingKeyId;
 
-            ResponseEntity<PortoneBillingKeyResponse> response = restTemplate.exchange(
-                    url, HttpMethod.GET, new HttpEntity<>(authHeaders()), PortoneBillingKeyResponse.class
-            );
+         ResponseEntity<PortoneBillingKeyResponse> response = restTemplate.exchange(
+                 url, HttpMethod.GET, new HttpEntity<>(authHeaders()), PortoneBillingKeyResponse.class
+         );
 
-            if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
-                throw new IllegalStateException("포트원 빌링키 조회 실패");
-            }
-            return response.getBody();
+         if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+             throw new BusinessException(PortoneErrorCode.ERR_PORTONE_BILLING_KEY_NOT_FOUND);
+         }
+         return response.getBody();
+     }
+
+    /**
+     * 빌링키로 카드 자동 청구
+     * 스케줄러에서 매월 호출 — 사용자 개입 없이 카드에서 돈을 빼감
+     *
+     * @param billingKey  DB에 저장된 빌링키 토큰
+     * @param orderNumber 이번 청구의 주문번호 (REC-xxxxxxxx)
+     * @param amount      청구 금액 (원)
+     * @param description 청구 설명 (카드 명세서에 표시)
+     */
+    public PortoneBillingPaymentResponse chargeWithBillingKey(
+            String billingKey,
+            String orderNumber,
+            Long amount,
+            String description
+    ) {
+        String url = BASE_URL + "/payments/" + orderNumber + "/billing-key";
+
+        String body = """
+                   {
+                       "billingKey": "%s",
+                       "orderName": "%s",
+                       "amount": {
+                           "total": %d
+                       },
+                       "currency": "KRW"
+                   }
+                   """
+                   .formatted(billingKey, description, amount);
+
+        ResponseEntity<PortoneBillingPaymentResponse> response = restTemplate.exchange(
+                url, HttpMethod.POST, new HttpEntity<>(body, authHeaders()), PortoneBillingPaymentResponse.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new BusinessException(PortoneErrorCode.ERR_PORTONE_BILLING_CHARGE_FAILED);
         }
+        return response.getBody();
+    }
 
-        /**
-         * 빌링키로 카드 자동 청구
-         * 스케줄러에서 매월 호출 — 사용자 개입 없이 카드에서 돈을 빼감
-         *
-         * @param billingKey  DB에 저장된 빌링키 토큰
-         * @param orderNumber 이번 청구의 주문번호 (REC-xxxxxxxx)
-         * @param amount      청구 금액 (원)
-         * @param description 청구 설명 (카드 명세서에 표시)
-         */
-        public PortoneBillingPaymentResponse chargeWithBillingKey(
-                String billingKey,
-                String orderNumber,
-                Long amount,
-                String description
-        ) {
-            String url = BASE_URL + "/payments/" + orderNumber + "/billing-key";
+    /**
+     * 포트원 빌링키 삭제 (카드 해지 시 포트원 측 데이터도 정리)
+     *
+     * @param billingKeyId 포트원이 발급한 빌링키 ID
+     */
+    public void deleteBillingKey(String billingKeyId) {
+        String url = BASE_URL + "/billing-keys/" + billingKeyId;
 
-            String body = """
-                    {
-                        "billingKey": "%s",
-                        "orderName": "%s",
-                        "amount": {
-                            "total": %d
-                        },
-                        "currency": "KRW"
-                    }
-                    """
-                    .formatted(billingKey, description, amount);
+        ResponseEntity<Void> response = restTemplate.exchange(
+                url, HttpMethod.DELETE, new HttpEntity<>(authHeaders()), Void.class
+        );
 
-            ResponseEntity<PortoneBillingPaymentResponse> response = restTemplate.exchange(
-                    url, HttpMethod.POST, new HttpEntity<>(body, authHeaders()), PortoneBillingPaymentResponse.class
-            );
-
-            if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
-                throw new IllegalStateException("빌링키 자동 청구 실패");
-            }
-            return response.getBody();
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new BusinessException(PortoneErrorCode.ERR_PORTONE_BILLING_KEY_DELETE_FAILED);
         }
+    }
 
-        /**
-         * 포트원 빌링키 삭제 (카드 해지 시 포트원 측 데이터도 정리)
-         *
-         * @param billingKeyId 포트원이 발급한 빌링키 ID
-         */
-        public void deleteBillingKey(String billingKeyId) {
-            String url = BASE_URL + "/billing-keys/" + billingKeyId;
-
-            ResponseEntity<Void> response = restTemplate.exchange(
-                    url, HttpMethod.DELETE, new HttpEntity<>(authHeaders()), Void.class
-            );
-
-            if (response.getStatusCode() != HttpStatus.OK) {
-                throw new IllegalStateException("포트원 빌링키 삭제 실패");
-            }
-        }
-
-        // ── 공통 ──────────────────────────────────────────────────────────────────
-
-        private HttpHeaders authHeaders() {
-            HttpHeaders headers = new HttpHeaders();
-            headers.set("Authorization", "PortOne " + portoneProperties.apiSecret());
-            headers.setContentType(MediaType.APPLICATION_JSON);
-            return headers;
-        }
+    private HttpHeaders authHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "PortOne " + portoneProperties.apiSecret());
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
 }

--- a/src/main/java/com/fivefy/common/portone/enums/PortoneErrorCode.java
+++ b/src/main/java/com/fivefy/common/portone/enums/PortoneErrorCode.java
@@ -1,0 +1,20 @@
+package com.fivefy.common.portone.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PortoneErrorCode implements ErrorCode {
+
+    ERR_PORTONE_PAYMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "포트원 결제 조회에 실패했습니다"),
+    ERR_PORTONE_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "포트원 환불에 실패했습니다"),
+    ERR_PORTONE_BILLING_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "포트원 빌링키 조회에 실패했습니다"),
+    ERR_PORTONE_BILLING_CHARGE_FAILED(HttpStatus.BAD_REQUEST, "빌링키 자동 청구에 실패했습니다"),
+    ERR_PORTONE_BILLING_KEY_DELETE_FAILED(HttpStatus.BAD_REQUEST, "포트원 빌링키 삭제에 실패했습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/billingkey/entity/BillingKey.java
+++ b/src/main/java/com/fivefy/domain/billingkey/entity/BillingKey.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.billingkey.entity;
 
 import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -75,7 +77,7 @@ public class BillingKey extends BaseEntity {
     /** 빌링키 해지 (카드 삭제) */
     public void deactivate() {
         if (!this.active) {
-            throw new IllegalStateException("이미 해지된 빌링키입니다.");
+            throw new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ALREADY_DEACTIVATED);
         }
 
         this.active = false;

--- a/src/main/java/com/fivefy/domain/billingkey/enums/BillingKeyErrorCode.java
+++ b/src/main/java/com/fivefy/domain/billingkey/enums/BillingKeyErrorCode.java
@@ -1,0 +1,19 @@
+package com.fivefy.domain.billingkey.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BillingKeyErrorCode implements ErrorCode {
+
+    ERR_BILLING_KEY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 카드입니다"),
+    ERR_BILLING_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "빌링키를 찾을 수 없습니다"),
+    ERR_BILLING_KEY_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 카드만 삭제할 수 있습니다"),
+    ERR_BILLING_KEY_ALREADY_DEACTIVATED(HttpStatus.BAD_REQUEST, "이미 해지된 빌링키입니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyService.java
+++ b/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyService.java
@@ -1,10 +1,12 @@
 package com.fivefy.domain.billingkey.service;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.portone.client.PortoneClient;
 import com.fivefy.common.portone.dto.PortoneBillingKeyResponse;
 import com.fivefy.domain.billingkey.dto.BillingKeyRegisterRequest;
 import com.fivefy.domain.billingkey.dto.BillingKeyResponse;
 import com.fivefy.domain.billingkey.entity.BillingKey;
+import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
 import com.fivefy.domain.billingkey.repository.BillingKeyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +42,7 @@ public class BillingKeyService {
 
         // 중복 등록 방지
         if (billingKeyRepository.existsByBillingKey(billingKeyToken)) {
-            throw new IllegalStateException("이미 등록된 카드입니다.");
+            throw new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ALREADY_EXISTS);
         }
 
         // 카드 정보 파싱 (끝 4자리)
@@ -88,10 +90,10 @@ public class BillingKeyService {
     public void deactivate(Long userId, Long billingKeyId) {
 
         BillingKey billingKey = billingKeyRepository.findById(billingKeyId)
-                .orElseThrow(() -> new IllegalArgumentException("빌링키를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_NOT_FOUND));
 
         if (!billingKey.getUserId().equals(userId)) {
-            throw new IllegalStateException("본인의 카드만 삭제할 수 있습니다.");
+            throw new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_FORBIDDEN);
         }
 
         // 포트원 측 빌링키 삭제

--- a/src/main/java/com/fivefy/domain/cashorder/entity/CashOrder.java
+++ b/src/main/java/com/fivefy/domain/cashorder/entity/CashOrder.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.cashorder.entity;
 
 import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.cashorder.enums.CashOrderErrorCode;
 import com.fivefy.domain.cashorder.enums.CashOrderStatus;
 import com.fivefy.domain.cashorder.enums.CashProductType;
 import jakarta.persistence.*;
@@ -72,7 +74,7 @@ public class CashOrder extends BaseEntity {
      */
     public void success(String webhookId) {
         if (this.status != CashOrderStatus.PENDING) {
-            throw new IllegalStateException("PENDING 상태에서만 성공 처리할 수 있습니다.");
+            throw new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_INVALID_STATUS_SUCCESS);
         }
         this.status = CashOrderStatus.SUCCESS;
         this.webhookId = webhookId;
@@ -84,7 +86,7 @@ public class CashOrder extends BaseEntity {
      */
     public void refund() {
         if (this.status != CashOrderStatus.SUCCESS) {
-            throw new IllegalStateException("SUCCESS 상태에서만 환불 처리할 수 있습니다.");
+            throw new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_INVALID_STATUS_REFUND);
         }
         this.status = CashOrderStatus.REFUNDED;
     }

--- a/src/main/java/com/fivefy/domain/cashorder/enums/CashOrderErrorCode.java
+++ b/src/main/java/com/fivefy/domain/cashorder/enums/CashOrderErrorCode.java
@@ -1,0 +1,22 @@
+package com.fivefy.domain.cashorder.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CashOrderErrorCode implements ErrorCode {
+
+    ERR_CASH_ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 주문입니다"),
+    ERR_CASH_ORDER_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 주문만 환불 가능합니다"),
+    ERR_CASH_ORDER_INVALID_STATUS_SUCCESS(HttpStatus.BAD_REQUEST, "PENDING 상태에서만 성공 처리할 수 있습니다"),
+    ERR_CASH_ORDER_INVALID_STATUS_REFUND(HttpStatus.BAD_REQUEST, "SUCCESS 상태에서만 환불 처리할 수 있습니다"),
+    ERR_CASH_ORDER_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 금액이 일치하지 않습니다"),
+    ERR_CASH_ORDER_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "포트원 결제 취소에 실패했습니다"),
+    ERR_CASH_ORDER_WEBHOOK_PARSE_FAILED(HttpStatus.BAD_REQUEST, "웹훅 body 파싱에 실패했습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.cashorder.service;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.lock.annotation.RedissonLock;
 import com.fivefy.common.portone.PortoneWebhookVerifier;
 import com.fivefy.common.portone.client.PortoneClient;
@@ -13,6 +14,7 @@ import com.fivefy.domain.cashorder.dto.CashOrderRefundRequest;
 import com.fivefy.domain.cashorder.dto.CashOrderResponse;
 import com.fivefy.domain.cashorder.dto.CashOrderVerifyRequest;
 import com.fivefy.domain.cashorder.entity.CashOrder;
+import com.fivefy.domain.cashorder.enums.CashOrderErrorCode;
 import com.fivefy.domain.cashorder.enums.CashOrderStatus;
 import com.fivefy.domain.cashorder.enums.CashProductType;
 import com.fivefy.domain.cashorder.repository.CashOrderRepository;
@@ -22,6 +24,7 @@ import com.fivefy.domain.wallet.entity.PointHistory;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.enums.PointHistoryType;
 import com.fivefy.domain.wallet.enums.PointType;
+import com.fivefy.domain.wallet.enums.WalletErrorCode;
 import com.fivefy.domain.wallet.repository.PointHistoryRepository;
 import com.fivefy.domain.wallet.repository.WalletRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -99,11 +102,11 @@ public class CashOrderService {
 
         // 주문 조회
         CashOrder cashOrder = cashOrderRepository.findByOrderNumber(request.orderNumber())
-                .orElseThrow(() -> new EntityNotFoundException("없는 주문"));
+                .orElseThrow(() -> new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_NOT_FOUND));
 
         // 본인 검증
         if (!cashOrder.getUserId().equals(userId))
-            throw new IllegalArgumentException("본인 주문만 환불 가능");
+            throw new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_FORBIDDEN);
 
         // Payment(CashOrder의 기록, pg트랜젝션과 멱등키가 있다.)에서 pgTransactionId 가져오기
         // Payment 상태 변경 (orderNumber로 조회 : 상태변경) : 포인트 구매 이력을 조회해서 orderNumber을 통해 환불(PaymentResponse)
@@ -119,7 +122,7 @@ public class CashOrderService {
 
         // 취소 응답 확인 : SUCCEEDED가 아니면 처리 중단
         if (!"SUCCEEDED".equals(cancelResponse.status())) {
-            throw new IllegalStateException("포트원 결제 취소 실패: " + cancelResponse.status());
+            throw new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_CANCEL_FAILED);
         }
 
         // 3. DB 상태 변경만 트랜잭션으로 처리
@@ -144,7 +147,7 @@ public class CashOrderService {
         // 포인트를 이미 사용한 경우 useBalance()에서 잔액 부족 예외 발생 가능
         //   → 스케줄러 도입 시 음수 잔액 허용 또는 별도 정책 필요
         Wallet wallet = walletRepository.findByUserId(cashOrder.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("지갑 없음"));
+                .orElseThrow(() -> new BusinessException(WalletErrorCode.ERR_WALLET_NOT_FOUND));
         wallet.refundBalance(cashOrder.getPointAmount());
 
         pointHistoryRepository.save(PointHistory.create(
@@ -193,7 +196,7 @@ public class CashOrderService {
         try {
             request = objectMapper.readValue(rawBody, PortoneWebhookRequest.class);
         } catch (Exception e) {
-            throw new IllegalArgumentException("웹훅 body 파싱 실패");
+            throw new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_WEBHOOK_PARSE_FAILED);
         }
 
         System.out.println("웹훅 타입: " + request.type());
@@ -219,7 +222,8 @@ public class CashOrderService {
 
         // CashOrder 조회 (orderNumber 기준)
         CashOrder cashOrder = cashOrderRepository.findByOrderNumber(pgPayment.orderNumber())
-                .orElseThrow(() -> new IllegalArgumentException("주문 없음"));
+                .orElseThrow(() -> new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_NOT_FOUND)
+                );
 
 
         // 상태(결제 대기) : PENDING이 아니면 이미 처리된 주문 → 무시
@@ -230,7 +234,7 @@ public class CashOrderService {
         // 금액 검증
         // PortonePaymentResponse에서 결제 대금을 totalAmount으로 두고, 포인트 구매에서 결제 대금을 CashAmount로 둔다.
         if (!pgPayment.totalAmount().equals(cashOrder.getCashAmount())) {
-            throw new IllegalStateException("결제 금액 불일치");
+            throw new BusinessException(CashOrderErrorCode.ERR_CASH_ORDER_AMOUNT_MISMATCH);
         }
 
         // CashOrder PENDING → SUCCESS, webhookId 저장
@@ -249,7 +253,7 @@ public class CashOrderService {
 
         // Wallet 충전
         Wallet wallet = walletRepository.findByUserId(cashOrder.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("지갑 없음"));
+                .orElseThrow(() -> new BusinessException(WalletErrorCode.ERR_WALLET_NOT_FOUND));
         wallet.chargeBalance(cashOrder.getPointAmount());   // 포인트 지급
         // 지갑 이력(PointHistory)
         pointHistoryRepository.save(PointHistory.create(

--- a/src/main/java/com/fivefy/domain/payment/enums/PaymentErrorCode.java
+++ b/src/main/java/com/fivefy/domain/payment/enums/PaymentErrorCode.java
@@ -1,0 +1,17 @@
+package com.fivefy.domain.payment.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+
+    ERR_PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 결제 내역입니다"),
+    ERR_PAYMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 결제만 조회 가능합니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/fivefy/domain/payment/service/PaymentService.java
@@ -1,7 +1,9 @@
 package com.fivefy.domain.payment.service;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.payment.dto.PaymentResponse;
 import com.fivefy.domain.payment.entity.Payment;
+import com.fivefy.domain.payment.enums.PaymentErrorCode;
 import com.fivefy.domain.payment.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,10 +38,10 @@ public class PaymentService {
      */
     public PaymentResponse getPayment(Long userId, Long paymentId) {
         Payment payment = paymentRepository.findById(paymentId)
-                .orElseThrow(() -> new IllegalArgumentException("결제 내역 없음"));
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.ERR_PAYMENT_NOT_FOUND));
 
         if (!payment.getUserId().equals(userId)) {
-            throw new IllegalStateException("본인 결제만 조회 가능");
+            throw new BusinessException(PaymentErrorCode.ERR_PAYMENT_FORBIDDEN);
         }
 
         return PaymentResponse.from(payment);

--- a/src/main/java/com/fivefy/domain/pointorder/entity/PointOrder.java
+++ b/src/main/java/com/fivefy/domain/pointorder/entity/PointOrder.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.pointorder.entity;
 
 import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.pointorder.enums.PointOrderErrorCode;
 import com.fivefy.domain.pointorder.enums.PointOrderStatus;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import jakarta.persistence.*;
@@ -75,7 +77,7 @@ public class PointOrder extends BaseEntity {
      */
     public void success() {
         if (this.status != PointOrderStatus.PENDING) {
-            throw new IllegalStateException("PENDING 상태에서만 성공 처리할 수 있습니다.");
+            throw new BusinessException(PointOrderErrorCode.ERR_POINT_ORDER_INVALID_STATUS_SUCCESS);
         }
         this.status = PointOrderStatus.SUCCESS;
     }
@@ -86,7 +88,7 @@ public class PointOrder extends BaseEntity {
      */
     public void refund() {
         if (this.status != PointOrderStatus.SUCCESS) {
-            throw new IllegalStateException("SUCCESS 상태에서만 환불 처리할 수 있습니다.");
+            throw new BusinessException(PointOrderErrorCode.ERR_POINT_ORDER_INVALID_STATUS_REFUND);
         }
         this.status = PointOrderStatus.REFUNDED;
     }

--- a/src/main/java/com/fivefy/domain/pointorder/enums/PointOrderErrorCode.java
+++ b/src/main/java/com/fivefy/domain/pointorder/enums/PointOrderErrorCode.java
@@ -1,0 +1,19 @@
+package com.fivefy.domain.pointorder.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PointOrderErrorCode implements ErrorCode {
+
+    ERR_FREE_PLAN_ALREADY_USED(HttpStatus.CONFLICT, "무료 체험은 1회만 가능합니다"),
+    ERR_SUBSCRIPTION_ALREADY_ACTIVE(HttpStatus.CONFLICT, "이미 구독 중입니다"),
+    ERR_POINT_ORDER_INVALID_STATUS_SUCCESS(HttpStatus.BAD_REQUEST, "PENDING 상태에서만 성공 처리할 수 있습니다"),
+    ERR_POINT_ORDER_INVALID_STATUS_REFUND(HttpStatus.BAD_REQUEST, "SUCCESS 상태에서만 환불 처리할 수 있습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/pointorder/service/PointOrderService.java
+++ b/src/main/java/com/fivefy/domain/pointorder/service/PointOrderService.java
@@ -1,8 +1,10 @@
 package com.fivefy.domain.pointorder.service;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.lock.annotation.RedissonLock;
 import com.fivefy.domain.pointorder.dto.PointOrderPurchaseRequest;
 import com.fivefy.domain.pointorder.entity.PointOrder;
+import com.fivefy.domain.pointorder.enums.PointOrderErrorCode;
 import com.fivefy.domain.pointorder.repository.PointOrderRepository;
 import com.fivefy.domain.subscription.dto.SubscriptionResponse;
 import com.fivefy.domain.subscription.entity.Subscription;
@@ -13,6 +15,7 @@ import com.fivefy.domain.wallet.entity.PointHistory;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.enums.PointHistoryType;
 import com.fivefy.domain.wallet.enums.PointType;
+import com.fivefy.domain.wallet.enums.WalletErrorCode;
 import com.fivefy.domain.wallet.repository.PointHistoryRepository;
 import com.fivefy.domain.wallet.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
@@ -60,7 +63,7 @@ public class PointOrderService {
             boolean alreadyUsedFree = userOrders.stream()
                     .anyMatch(o -> o.getPlanType() == SubscriptionPlanType.FREE);
             if (alreadyUsedFree) {
-                throw new IllegalStateException("무료 체험은 1회만 가능합니다.");
+                throw new BusinessException(PointOrderErrorCode.ERR_FREE_PLAN_ALREADY_USED);
             }
         }
 
@@ -71,7 +74,7 @@ public class PointOrderService {
                     .anyMatch(s -> s.getPlanType() == SubscriptionPlanType.RECURRING
                             && s.getStatus() == SubscriptionStatus.ACTIVE);
             if (alreadyActive) {
-                throw new IllegalStateException("이미 구독 중입니다.");
+                throw new BusinessException(PointOrderErrorCode.ERR_SUBSCRIPTION_ALREADY_ACTIVE);
             }
         }
 
@@ -84,7 +87,7 @@ public class PointOrderService {
         Long price = planType.getPrice();
         if (price > 0) {
             Wallet wallet = walletRepository.findByUserId(userId)
-                    .orElseThrow(() -> new IllegalArgumentException("지갑 없음"));
+                    .orElseThrow(() -> new BusinessException(WalletErrorCode.ERR_WALLET_NOT_FOUND));
             // (무료 포인트 먼저 소진 후 유료 차감)
             wallet.useBalanceWithPriority(price);
 

--- a/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.subscription.entity;
 
 import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.subscription.enums.SubscriptionErrorCode;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import jakarta.persistence.*;
@@ -93,10 +95,10 @@ public class Subscription extends BaseEntity {
      */
     public void cancel() {
         if (this.planType == SubscriptionPlanType.FREE) {
-            throw new IllegalStateException("무료 구독은 취소할 수 없습니다");
+            throw new BusinessException(SubscriptionErrorCode.ERR_FREE_SUBSCRIPTION_CANNOT_CANCEL);
         }
         if (this.status != SubscriptionStatus.ACTIVE && this.status != SubscriptionStatus.INACTIVE) {
-            throw new IllegalStateException("활성/비활성 상태에서만 취소할 수 있습니다 현재: " + this.status);
+            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL);
         }
 
         this.status = SubscriptionStatus.CANCELED;
@@ -118,10 +120,10 @@ public class Subscription extends BaseEntity {
      */
     public void renew() {
         if (this.planType != SubscriptionPlanType.RECURRING) {
-            throw new IllegalStateException("RECURRING 플랜만 갱신할 수 있습니다.");
+            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_RECURRING);
         }
         if (this.nextBillingDate == null) {
-            throw new IllegalStateException("취소된 구독은 갱신할 수 없습니다.");
+            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
         }
         this.nextBillingDate = this.nextBillingDate.plusMonths(1);
         this.expiryDate      = this.expiryDate.plusMonths(1);

--- a/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
+++ b/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
@@ -1,0 +1,20 @@
+package com.fivefy.domain.subscription.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubscriptionErrorCode implements ErrorCode {
+
+    ERR_SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 구독이 없습니다"),
+    ERR_FREE_SUBSCRIPTION_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "무료 구독은 취소할 수 없습니다"),
+    ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL(HttpStatus.BAD_REQUEST, "활성 또는 비활성 상태에서만 취소할 수 있습니다"),
+    ERR_SUBSCRIPTION_NOT_RECURRING(HttpStatus.BAD_REQUEST, "RECURRING 플랜만 갱신할 수 있습니다"),
+    ERR_SUBSCRIPTION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "취소된 구독은 갱신할 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
@@ -1,9 +1,11 @@
 package com.fivefy.domain.subscription.service;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.pointorder.entity.PointOrder;
 import com.fivefy.domain.pointorder.repository.PointOrderRepository;
 import com.fivefy.domain.subscription.dto.SubscriptionResponse;
 import com.fivefy.domain.subscription.entity.Subscription;
+import com.fivefy.domain.subscription.enums.SubscriptionErrorCode;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.repository.SubscriptionRepository;
@@ -48,7 +50,7 @@ public class SubscriptionService {
                         userId,
                         SubscriptionPlanType.RECURRING,
                         SubscriptionStatus.ACTIVE)
-                .orElseThrow(() -> new IllegalArgumentException("활성 구독 없음"));
+                .orElseThrow(() -> new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_FOUND));
 
         subscription.cancel();
     }

--- a/src/main/java/com/fivefy/domain/wallet/entity/Wallet.java
+++ b/src/main/java/com/fivefy/domain/wallet/entity/Wallet.java
@@ -1,10 +1,13 @@
 package com.fivefy.domain.wallet.entity;
 
 import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.wallet.enums.WalletErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -12,6 +15,7 @@ import java.time.LocalDateTime;
 
 import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
+@Slf4j
 @Entity
 @Getter
 @Table(name = "wallets")
@@ -90,7 +94,7 @@ public class Wallet extends BaseEntity {
      */
     public void useBalance(Long amount) {
         if (this.balance < amount) {
-            throw new IllegalArgumentException("유료 포인트 부족");
+            throw new BusinessException(WalletErrorCode.ERR_WALLET_PAID_BALANCE_INSUFFICIENT);
         }
         this.balance -= amount;
         this.totalBalance = this.balance + this.eventBalance;
@@ -103,7 +107,7 @@ public class Wallet extends BaseEntity {
      */
     public void useEventBalance(Long amount) {
         if (this.eventBalance < amount) {
-            throw new IllegalArgumentException("무료 포인트 부족");
+            throw new BusinessException(WalletErrorCode.ERR_WALLET_FREE_BALANCE_INSUFFICIENT);
         }
         this.eventBalance -= amount;
         this.totalBalance = this.balance + this.eventBalance;
@@ -116,9 +120,9 @@ public class Wallet extends BaseEntity {
      */
     public void useBalanceWithPriority(Long amount) {
         if (this.totalBalance < amount) {
-            throw new IllegalArgumentException(
-                "포인트 부족. 필요: " + amount + ", 보유: " + this.totalBalance
-            );
+            log.warn("포인트 부족 — 필요: {}P, 보유: {}P, 부족: {}P",
+                    amount, this.totalBalance, amount - this.totalBalance);
+            throw new BusinessException(WalletErrorCode.ERR_WALLET_TOTAL_BALANCE_INSUFFICIENT);
         }
         long fromFree = Math.min(this.eventBalance, amount);  // 무료에서 차감 가능한 양
         long fromPaid = amount - fromFree;                    // 나머지는 유료에서

--- a/src/main/java/com/fivefy/domain/wallet/enums/WalletErrorCode.java
+++ b/src/main/java/com/fivefy/domain/wallet/enums/WalletErrorCode.java
@@ -1,0 +1,19 @@
+package com.fivefy.domain.wallet.enums;
+
+import com.fivefy.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum WalletErrorCode implements ErrorCode {
+
+    ERR_WALLET_NOT_FOUND(HttpStatus.NOT_FOUND, "지갑을 찾을 수 없습니다"),
+    ERR_WALLET_PAID_BALANCE_INSUFFICIENT(HttpStatus.BAD_REQUEST, "유료 포인트가 부족합니다"),
+    ERR_WALLET_FREE_BALANCE_INSUFFICIENT(HttpStatus.BAD_REQUEST, "무료 포인트가 부족합니다"),
+    ERR_WALLET_TOTAL_BALANCE_INSUFFICIENT(HttpStatus.BAD_REQUEST, "포인트가 부족합니다");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/fivefy/domain/wallet/service/WalletService.java
+++ b/src/main/java/com/fivefy/domain/wallet/service/WalletService.java
@@ -1,8 +1,10 @@
 package com.fivefy.domain.wallet.service;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.wallet.dto.PointHistoryResponse;
 import com.fivefy.domain.wallet.dto.WalletResponse;
 import com.fivefy.domain.wallet.entity.Wallet;
+import com.fivefy.domain.wallet.enums.WalletErrorCode;
 import com.fivefy.domain.wallet.repository.PointHistoryRepository;
 import com.fivefy.domain.wallet.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,15 +24,13 @@ public class WalletService {
     // 지갑 조회
     @Transactional(readOnly = true)
     public WalletResponse getMyWallet(Long userId) {
-        Wallet wallet = walletRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("지갑을 찾을 수 없습니다."));
-        return WalletResponse.from(wallet);
+        return WalletResponse.from(getWallet(userId));  // getWallet() 재사용
     }
 
     // 지갑 여부 확인 시
     private Wallet getWallet(Long userId) {
         return walletRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("지갑 없음"));
+                .orElseThrow(() -> new BusinessException(WalletErrorCode.ERR_WALLET_NOT_FOUND));
     }
 
     // 지갑 내역 확인 시


### PR DESCRIPTION
## 개요

> 결제·구독·지갑 도메인에서 `IllegalStateException`, `IllegalArgumentException`으로 처리하던 예외를 팀 컨벤션에 맞게 `BusinessException` + 도메인별 `ErrorCode enum`으로 전환하였습니다.

## 변경 사항
- `BillingKeyErrorCode`, `CashOrderErrorCode`, `PointOrderErrorCode`, `SubscriptionErrorCode`, `WalletErrorCode`, `PaymentErrorCode`, `PortoneErrorCode` 에러코드 `enum` 신규 생성
- `BillingKey`, `CashOrder`, `PointOrder`, `Subscription`, `Wallet` 엔티티의 상태 검증 예외를 `BusinessException`으로 전환
- `BillingKeyService`, `CashOrderService`, `PointOrderService`, `SubscriptionService`, `WalletService`, `PaymentService`, `PortoneClient`의 예외를 `BusinessException`으로 전환
- `WalletService.getMyWallet()` 중복 로직 제거 — 내부 헬퍼 `getWallet()` 재사용

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> 별도 동작 변경 없음. 기존 테스트 통과 여부로 확인.

포인트 잔액 부족 시 400 BAD_REQUEST + 에러 메시지 응답 확인
존재하지 않는 결제 내역 조회 시 404 NOT_FOUND 응답 확인
본인 외 결제 조회 시 403 FORBIDDEN 응답 확인


## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트