### PR TITLE
feat: 구독 알림발송 기능 및 sse안정성 개선

### DIFF
--- a/src/main/java/com/fivefy/common/config/async/AsyncConfig.java
+++ b/src/main/java/com/fivefy/common/config/async/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.fivefy.common.config.Async;
+package com.fivefy.common.config.async;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/fivefy/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/fivefy/domain/notification/controller/NotificationController.java
@@ -24,8 +24,10 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @GetMapping(value = "/notifications/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(@AuthenticationPrincipal Long userId) {
-        return notificationService.subscribe(userId);
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal Long userId,
+            @RequestHeader(value = "last-event-id", required = false) Long lastEventId) {
+        return notificationService.subscribe(userId, lastEventId);
     }
 
     @GetMapping("/notifications")

--- a/src/main/java/com/fivefy/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/fivefy/domain/notification/enums/NotificationType.java
@@ -5,5 +5,7 @@ public enum NotificationType {
     PUBLISH_TRACK,
     TRACK_LIKED,
     ALBUM_LIKED,
-    SUBSCRIBE
+    SUBSCRIBE,
+    SUBSCRIPTION_CANCEL,
+    SUBSCRIPTION_EXPIRE
 }

--- a/src/main/java/com/fivefy/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/fivefy/domain/notification/repository/NotificationRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     Page<Notification> findAllByUserId(Long userId, Pageable pageable);
@@ -19,4 +21,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Integer markAllAsRead(@Param("userId") Long userId);
 
     void deleteAllByUserId(Long userId);
+
+    @Query("SELECT n FROM Notification n WHERE n.userId = :userId AND n.id > :lastEventId ORDER BY n.id ASC")
+    List<Notification> findMissedNotifications(
+            @Param("userId") Long userId,
+            @Param("lastEventId") Long lastEventId
+    );
 }

--- a/src/main/java/com/fivefy/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/fivefy/domain/notification/repository/NotificationRepository.java
@@ -25,6 +25,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("SELECT n FROM Notification n WHERE n.userId = :userId AND n.id > :lastEventId ORDER BY n.id ASC")
     List<Notification> findMissedNotifications(
             @Param("userId") Long userId,
-            @Param("lastEventId") Long lastEventId
+            @Param("lastEventId") Long lastEventId,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
@@ -35,6 +35,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -189,6 +190,31 @@ public class NotificationService {
             log.error("알림 발송 실패: userId={}, type={}", userId, type);
             saved.markAsFailed();
             notificationRepository.save(saved);
+
+            // redis 실패 보완 현재 연결된 emitter 직접 전송
+            fallbackSseDirectPush(saved);
+        }
+    }
+
+    private void fallbackSseDirectPush(Notification notification) {
+        List<SseEmitter> emitters = sseEmitterRepository.findAllByUserId(notification.getUserId());
+        if (emitters.isEmpty()) {
+            log.warn("SSE 직접 전송 불가 (연결된 emitter 없음): userId{}", notification.getUserId());
+            return;
+        }
+
+        for (SseEmitter emitter : emitters) {
+            try{
+                emitter.send(SseEmitter.event()
+                        .id(String.valueOf(notification.getId()))
+                        .name(SSE_EVENT_NOTIFICATION)
+                        .data(NotificationGetResponse.from(notification)));
+                log.info("SSE 직접 전송 성공: userId={}, notificationId={}",
+                        notification.getUserId(), notification.getId());
+            } catch (IOException e) {
+                log.warn("SSE 직접 전송 실패: userID={}", notification.getUserId());
+                sseEmitterRepository.delete(notification.getUserId(), emitter);
+            }
         }
     }
 

--- a/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
@@ -92,7 +92,8 @@ public class NotificationService {
 
     // 재연결 시 lastEventId 이후 알림 전송
     private void replayMissedNotifications(Long userId, Long lastEventId, SseEmitter emitter) {
-        List<Notification> missed = notificationRepository.findMissedNotifications(userId, lastEventId);
+        List<Notification> missed = notificationRepository.findMissedNotifications(
+                userId, lastEventId, PageRequest.of(0, 100));
 
         if (missed.isEmpty()) {
             return;

--- a/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
@@ -46,6 +46,7 @@ public class NotificationService {
     private static final long SSE_TIMEOUT = 60 * 60 * 1000L;
     private static final String SSE_EVENT_CONNECT = "connect";
     private static final String REDIS_NOTIFICATION_CHANNEL = "notification:";
+    private static final String SSE_EVENT_NOTIFICATION = "notification";
     private static final int CHUNK_SIZE = 1000;
 
     private final NotificationRepository notificationRepository;
@@ -57,7 +58,7 @@ public class NotificationService {
     private final FollowRepository  followRepository;
 
     // 알림 구독
-    public SseEmitter subscribe(Long userId) {
+    public SseEmitter subscribe(Long userId, Long lastEventId) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT);
 
         sseEmitterRepository.save(userId, emitter);
@@ -68,7 +69,6 @@ public class NotificationService {
             emitter.complete();
         });
         emitter.onError(e -> sseEmitterRepository.delete(userId, emitter));
-
 
         // 연결 직후 초기 이벤트 전송
         try {
@@ -81,7 +81,36 @@ public class NotificationService {
             sseEmitterRepository.delete(userId, emitter);
         }
 
+        // last-event-id 기반 미수신 알림 재전송
+        if (lastEventId != null) {
+            replayMissedNotifications(userId, lastEventId, emitter);
+        }
+
         return emitter;
+    }
+
+    // 재연결 시 lastEventId 이후 알림 전송
+    private void replayMissedNotifications(Long userId, Long lastEventId, SseEmitter emitter) {
+        List<Notification> missed = notificationRepository.findMissedNotifications(userId, lastEventId);
+
+        if (missed.isEmpty()) {
+            return;
+        }
+
+        log.info("미수신 알림 재전송: userId={}, lastEventId={}, 건수={}", userId, lastEventId, missed.size());
+
+        for (Notification notification : missed) {
+            try {
+                emitter.send(SseEmitter.event()
+                        .id(String.valueOf(notification.getId()))
+                        .name(SSE_EVENT_NOTIFICATION)
+                        .data(NotificationGetResponse.from(notification)));
+            } catch (IOException e) {
+                log.warn("미수신 알림 재전송 실패: userId={}, lastEventId={}", userId, lastEventId);
+                sseEmitterRepository.delete(userId, emitter);
+                break;
+            }
+        }
     }
 
     // 알림 발송 (수신 -> 저장 -> sse push)

--- a/src/main/java/com/fivefy/domain/pointorder/service/PointOrderService.java
+++ b/src/main/java/com/fivefy/domain/pointorder/service/PointOrderService.java
@@ -2,6 +2,8 @@ package com.fivefy.domain.pointorder.service;
 
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.lock.annotation.RedissonLock;
+import com.fivefy.domain.notification.enums.NotificationType;
+import com.fivefy.domain.notification.event.NotificationEvent;
 import com.fivefy.domain.pointorder.dto.PointOrderPurchaseRequest;
 import com.fivefy.domain.pointorder.entity.PointOrder;
 import com.fivefy.domain.pointorder.enums.PointOrderErrorCode;
@@ -20,10 +22,12 @@ import com.fivefy.domain.wallet.repository.PointHistoryRepository;
 import com.fivefy.domain.wallet.repository.WalletRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 
@@ -36,6 +40,9 @@ public class PointOrderService {
     private final PointOrderRepository pointOrderRepository;
     private final WalletRepository walletRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
 
     /**
      * 구독 구매 (포인트 → 구독)
@@ -112,6 +119,9 @@ public class PointOrderService {
         log.info("구독 구매 완료 — userId={}, planType={}, price={}P, expiryDate={}",
                 userId, planType, price, subscription.getExpiryDate());
 
+        String content = buildSubscribeContent(planType, subscription.getExpiryDate());
+        eventPublisher.publishEvent(NotificationEvent.of(userId, NotificationType.SUBSCRIBE, content));
+
         return SubscriptionResponse.from(subscription);
     }
 
@@ -135,6 +145,13 @@ public class PointOrderService {
                     userId, price, wallet.getTotalBalance());
             subscription.expire();
             subscriptionRepository.save(subscription);
+
+            eventPublisher.publishEvent(NotificationEvent.of(
+                    userId,
+                    NotificationType.SUBSCRIPTION_EXPIRE,
+                    "포인트 잔액이 부족하여 구독이 만료되었습니다."
+            ));
+
             return;
         }
 
@@ -163,5 +180,18 @@ public class PointOrderService {
 
         log.info("[정기구독] 결제 완료 — userId={}, orderNumber={}, price={}P",
                 userId, orderNumber, price);
+
+        eventPublisher.publishEvent(NotificationEvent.of(
+                userId,
+                NotificationType.SUBSCRIBE,
+                "정기 구독이 갱신되었습니다. 다음 만료일: " + subscription.getExpiryDate().format(DATE_FORMATTER)
+        ));
+    }
+
+    private String buildSubscribeContent(SubscriptionPlanType planType, LocalDateTime expiryDate) {
+        return switch (planType) {
+            case FREE -> "무료 체험 구독이 시작되었습니다. 만료일: " + expiryDate.format(DATE_FORMATTER);
+            case RECURRING -> "정기 구독이 시작되었습니다. 다음 갱신일: " + expiryDate.format(DATE_FORMATTER);
+        };
     }
 }

--- a/src/main/java/com/fivefy/domain/subscription/scheduler/SubscriptionScheduler.java
+++ b/src/main/java/com/fivefy/domain/subscription/scheduler/SubscriptionScheduler.java
@@ -1,5 +1,7 @@
 package com.fivefy.domain.subscription.scheduler;
 
+import com.fivefy.domain.notification.enums.NotificationType;
+import com.fivefy.domain.notification.event.NotificationEvent;
 import com.fivefy.domain.pointorder.service.PointOrderService;
 import com.fivefy.domain.subscription.entity.Subscription;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
@@ -7,6 +9,7 @@ import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +23,7 @@ public class SubscriptionScheduler {
 
     private final SubscriptionRepository subscriptionRepository;
     private final PointOrderService pointOrderService;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 정기 구독 결제
@@ -79,6 +83,13 @@ public class SubscriptionScheduler {
             try {
                 subscription.expire();
                 subscriptionRepository.save(subscription);
+
+                eventPublisher.publishEvent(NotificationEvent.of(
+                        subscription.getUserId(),
+                        NotificationType.SUBSCRIPTION_EXPIRE,
+                        "구독이 만료되었습니다."
+                ));
+
                 log.info("[만료 스케줄러] 만료 처리 — subscriptionId={}, userId={}",
                         subscription.getId(), subscription.getUserId());
             } catch (Exception e) {

--- a/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
@@ -1,7 +1,8 @@
 package com.fivefy.domain.subscription.service;
 
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.pointorder.entity.PointOrder;
+import com.fivefy.domain.notification.enums.NotificationType;
+import com.fivefy.domain.notification.event.NotificationEvent;
 import com.fivefy.domain.pointorder.repository.PointOrderRepository;
 import com.fivefy.domain.subscription.dto.SubscriptionResponse;
 import com.fivefy.domain.subscription.entity.Subscription;
@@ -10,6 +11,7 @@ import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +23,7 @@ public class SubscriptionService {
 
     private final SubscriptionRepository subscriptionRepository;
     private final PointOrderRepository pointOrderRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 내 구독 조회
@@ -53,5 +56,11 @@ public class SubscriptionService {
                 .orElseThrow(() -> new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_FOUND));
 
         subscription.cancel();
+
+        eventPublisher.publishEvent(NotificationEvent.of(
+                subscription.getUserId(),
+                NotificationType.SUBSCRIPTION_CANCEL,
+                "구독 취소 성공"
+        ));
     }
 }

--- a/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
@@ -73,13 +73,24 @@ class NotificationControllerTest {
         @DisplayName("구독 요청 시 200과 text/event-stream을 반환한다")
         void subscribe_returns200() throws Exception {
             // given
-            given(notificationService.subscribe(any())).willReturn(new SseEmitter());
+            given(notificationService.subscribe(any(), any())).willReturn(new SseEmitter());
 
             // when & then
             mockMvc.perform(get("/api/notifications/subscribe")
                             .accept(MediaType.TEXT_EVENT_STREAM))
                             .andExpect(status().isOk())
                             .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM));
+        }
+
+        @Test
+        @DisplayName("Last-Event-ID 헤더와 함께 재연결 시 200을 반환한다")
+        void subscribe_withLastEventId_returns200() throws Exception {
+            given(notificationService.subscribe(any(), eq(5L))).willReturn(new SseEmitter());
+
+            mockMvc.perform(get("/api/notifications/subscribe")
+                            .header("Last-Event-ID", "5")
+                            .accept(MediaType.TEXT_EVENT_STREAM))
+                            .andExpect(status().isOk());
         }
     }
 

--- a/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -42,30 +43,21 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
 
-    @Mock
-    private NotificationRepository notificationRepository;
-
-    @Mock
-    private UserRepository userRepository;
-
-    @Mock
-    private SseEmitterRepository sseEmitterRepository;
-
-    @Mock
-    private FollowRepository followRepository;
-
-    @Mock
-    private StringRedisTemplate stringRedisTemplate;
-
-    @Mock
-    private ObjectMapper objectMapper;
+    @Mock private NotificationRepository notificationRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private SseEmitterRepository sseEmitterRepository;
+    @Mock private FollowRepository followRepository;
+    @Mock private StringRedisTemplate stringRedisTemplate;
+    @Mock private ObjectMapper objectMapper;
+    @Mock private RabbitTemplate rabbitTemplate;
 
     @InjectMocks
     private NotificationService notificationService;
 
-    private static final Long USER_ID = 1L;
-    private static final Long OTHER_USER_ID = 2L;
-    private static final Long NOTIFICATION_ID = 10L;
+    private static final Long USER_ID          = 1L;
+    private static final Long OTHER_USER_ID    = 2L;
+    private static final Long NOTIFICATION_ID  = 10L;
+    private static final Long LAST_EVENT_ID    = 5L;
 
     private Notification makeNotification(Long userId) {
         return Notification.create(userId, "테스트 알림", NotificationType.NEW_FOLLOWER, NotificationChannel.IN_APP);
@@ -76,18 +68,65 @@ class NotificationServiceTest {
     class Subscribe {
 
         @Test
-        @DisplayName("구독 시 SseEmitter를 저장하고 초기 이벤트를 전송한다")
-        void subscribe_savesEmitterAndSendsConnectEvent() throws Exception {
+        @DisplayName("최초 구독 시 SseEmitter를 저장하고 초기 이벤트를 전송한다")
+        void subscribe_savesEmitterAndSendsConnectEvent() {
             // given
             given(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).willReturn(3L);
 
             // when
-            SseEmitter emitter = notificationService.subscribe(USER_ID);
+            SseEmitter emitter = notificationService.subscribe(USER_ID, null);
 
             // then
             assertThat(emitter).isNotNull();
             verify(sseEmitterRepository).save(eq(USER_ID), any(SseEmitter.class));
             verify(notificationRepository).countByUserIdAndReadAtIsNull(USER_ID);
+        }
+
+        @Test
+        @DisplayName("최초 구독 시 lastEventId가 null이면 미수신 알림 조회를 하지 않는다")
+        void subscribe_nullLastEventId_skipsReplay() {
+            // given
+            given(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).willReturn(0L);
+
+            // when
+            notificationService.subscribe(USER_ID, null);
+
+            // then
+            verify(notificationRepository, never()).findMissedNotifications(any(), any());
+        }
+
+        @Test
+        @DisplayName("재연결 시 lastEventId 이후의 미수신 알림을 SSE로 재전송한다")
+        void subscribe_withLastEventId_replaysMissedNotifications() {
+            // given
+            Notification missed1 = makeNotification(USER_ID);
+            Notification missed2 = makeNotification(USER_ID);
+
+            given(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).willReturn(2L);
+            given(notificationRepository.findMissedNotifications(USER_ID, LAST_EVENT_ID))
+                    .willReturn(List.of(missed1, missed2));
+
+            // when
+            SseEmitter emitter = notificationService.subscribe(USER_ID, LAST_EVENT_ID);
+
+            // then
+            assertThat(emitter).isNotNull();
+            verify(notificationRepository).findMissedNotifications(USER_ID, LAST_EVENT_ID);
+        }
+
+        @Test
+        @DisplayName("재연결 시 미수신 알림이 없으면 재전송하지 않는다")
+        void subscribe_withLastEventId_noMissed_noReplay() {
+            // given
+            given(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).willReturn(0L);
+            given(notificationRepository.findMissedNotifications(USER_ID, LAST_EVENT_ID))
+                    .willReturn(List.of());
+
+            // when
+            notificationService.subscribe(USER_ID, LAST_EVENT_ID);
+
+            // then — findMissedNotifications는 호출되지만 emitter.send()는 0번
+            verify(notificationRepository).findMissedNotifications(USER_ID, LAST_EVENT_ID);
         }
     }
 
@@ -97,7 +136,7 @@ class NotificationServiceTest {
 
         @Test
         @DisplayName("Redis publish 성공 시 SENT 상태로 저장된다")
-        void send_withConnection_marksAsSent() throws Exception {
+        void send_redisSuccess_marksAsSent() throws Exception {
             // given
             Notification notification = makeNotification(USER_ID);
             given(notificationRepository.save(any())).willReturn(notification);
@@ -113,12 +152,28 @@ class NotificationServiceTest {
         }
 
         @Test
+        @DisplayName("Redis publish 성공 시 fallbackSseDirectPush를 호출하지 않는다")
+        void send_redisSuccess_doesNotCallFallback() throws Exception {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            given(notificationRepository.save(any())).willReturn(notification);
+            given(objectMapper.writeValueAsString(any())).willReturn("{}");
+
+            // when
+            notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
+
+            // then
+            verify(sseEmitterRepository, never()).findAllByUserId(any());
+        }
+
+        @Test
         @DisplayName("Redis publish 실패 시 FAILED 상태로 저장된다")
-        void send_redisPublishFails_marksAsFailed() throws Exception {
+        void send_redisFails_marksAsFailed() throws Exception {
             // given
             Notification notification = makeNotification(USER_ID);
             given(notificationRepository.save(any())).willReturn(notification);
             given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("직렬화 실패"));
+            given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of());
 
             // when
             notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
@@ -126,6 +181,60 @@ class NotificationServiceTest {
             // then
             assertThat(notification.getStatus()).isEqualTo(NotificationStatus.FAILED);
             verify(notificationRepository, times(2)).save(any());
+        }
+
+        @Test
+        @DisplayName("Redis publish 실패 시 연결된 SSE emitter에 직접 전송한다")
+        void send_redisFails_fallbackSseDirectPush() throws Exception {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            SseEmitter emitter = mock(SseEmitter.class);
+
+            given(notificationRepository.save(any())).willReturn(notification);
+            given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("Redis 장애"));
+            given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of(emitter));
+
+            // when
+            notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
+
+            // then
+            verify(sseEmitterRepository).findAllByUserId(USER_ID);
+            verify(emitter).send(any(SseEmitter.SseEventBuilder.class));
+        }
+
+        @Test
+        @DisplayName("Redis publish 실패 시 연결된 emitter가 없으면 SSE 전송을 시도하지 않는다")
+        void send_redisFails_noEmitter_skipsDirectPush() throws Exception {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            given(notificationRepository.save(any())).willReturn(notification);
+            given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("Redis 장애"));
+            given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of());
+
+            // when
+            notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
+
+            // then — emitter.send() 호출 없음
+            verify(sseEmitterRepository).findAllByUserId(USER_ID);
+        }
+
+        @Test
+        @DisplayName("SSE 직접 전송 중 IOException 발생 시 해당 emitter를 삭제한다")
+        void send_fallbackSseDirectPush_ioException_removesEmitter() throws Exception {
+            // given
+            Notification notification = makeNotification(USER_ID);
+            SseEmitter brokenEmitter = mock(SseEmitter.class);
+
+            given(notificationRepository.save(any())).willReturn(notification);
+            given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("Redis 장애"));
+            given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of(brokenEmitter));
+            doThrow(new IOException("연결 끊김")).when(brokenEmitter).send(any(SseEmitter.SseEventBuilder.class));
+
+            // when
+            notificationService.send(USER_ID, NotificationType.NEW_FOLLOWER, "테스트 알림");
+
+            // then
+            verify(sseEmitterRepository).delete(eq(USER_ID), eq(brokenEmitter));
         }
 
         @Test

--- a/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
@@ -92,7 +92,7 @@ class NotificationServiceTest {
             notificationService.subscribe(USER_ID, null);
 
             // then
-            verify(notificationRepository, never()).findMissedNotifications(any(), any());
+            verify(notificationRepository, never()).findMissedNotifications(any(), any(), any(Pageable.class));
         }
 
         @Test
@@ -103,7 +103,7 @@ class NotificationServiceTest {
             Notification missed2 = makeNotification(USER_ID);
 
             given(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).willReturn(2L);
-            given(notificationRepository.findMissedNotifications(USER_ID, LAST_EVENT_ID))
+            given(notificationRepository.findMissedNotifications(eq(USER_ID), eq(LAST_EVENT_ID), any(Pageable.class)))
                     .willReturn(List.of(missed1, missed2));
 
             // when
@@ -111,7 +111,7 @@ class NotificationServiceTest {
 
             // then
             assertThat(emitter).isNotNull();
-            verify(notificationRepository).findMissedNotifications(USER_ID, LAST_EVENT_ID);
+            verify(notificationRepository).findMissedNotifications(eq(USER_ID), eq(LAST_EVENT_ID), any(Pageable.class));
         }
 
         @Test
@@ -119,14 +119,14 @@ class NotificationServiceTest {
         void subscribe_withLastEventId_noMissed_noReplay() {
             // given
             given(notificationRepository.countByUserIdAndReadAtIsNull(USER_ID)).willReturn(0L);
-            given(notificationRepository.findMissedNotifications(USER_ID, LAST_EVENT_ID))
+            given(notificationRepository.findMissedNotifications(eq(USER_ID), eq(LAST_EVENT_ID), any(Pageable.class)))
                     .willReturn(List.of());
 
             // when
             notificationService.subscribe(USER_ID, LAST_EVENT_ID);
 
             // then — findMissedNotifications는 호출되지만 emitter.send()는 0번
-            verify(notificationRepository).findMissedNotifications(USER_ID, LAST_EVENT_ID);
+            verify(notificationRepository).findMissedNotifications(eq(USER_ID), eq(LAST_EVENT_ID), any(Pageable.class));
         }
     }
 
@@ -172,7 +172,9 @@ class NotificationServiceTest {
             // given
             Notification notification = makeNotification(USER_ID);
             given(notificationRepository.save(any())).willReturn(notification);
-            given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("직렬화 실패"));
+            given(objectMapper.writeValueAsString(any())).willReturn("{}");
+            given(stringRedisTemplate.convertAndSend(any(), any(String.class)))
+                    .willThrow(new RuntimeException("Redis 장애"));
             given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of());
 
             // when

--- a/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/fivefy/domain/notification/service/NotificationServiceTest.java
@@ -191,7 +191,9 @@ class NotificationServiceTest {
             SseEmitter emitter = mock(SseEmitter.class);
 
             given(notificationRepository.save(any())).willReturn(notification);
-            given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("Redis 장애"));
+            given(objectMapper.writeValueAsString(any())).willReturn("{}");
+            given(stringRedisTemplate.convertAndSend(any(), any(String.class)))
+                    .willThrow(new RuntimeException("Redis 장애"));
             given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of(emitter));
 
             // when
@@ -208,7 +210,9 @@ class NotificationServiceTest {
             // given
             Notification notification = makeNotification(USER_ID);
             given(notificationRepository.save(any())).willReturn(notification);
-            given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("Redis 장애"));
+            given(objectMapper.writeValueAsString(any())).willReturn("{}");
+            given(stringRedisTemplate.convertAndSend(any(), any(String.class)))
+                    .willThrow(new RuntimeException("Redis 장애"));
             given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of());
 
             // when
@@ -226,7 +230,9 @@ class NotificationServiceTest {
             SseEmitter brokenEmitter = mock(SseEmitter.class);
 
             given(notificationRepository.save(any())).willReturn(notification);
-            given(objectMapper.writeValueAsString(any())).willThrow(new RuntimeException("Redis 장애"));
+            given(objectMapper.writeValueAsString(any())).willReturn("{}");
+            given(stringRedisTemplate.convertAndSend(any(), any(String.class)))
+                    .willThrow(new RuntimeException("Redis 장애"));
             given(sseEmitterRepository.findAllByUserId(USER_ID)).willReturn(List.of(brokenEmitter));
             doThrow(new IOException("연결 끊김")).when(brokenEmitter).send(any(SseEmitter.SseEventBuilder.class));
 


### PR DESCRIPTION
## 개요
SSE 재연결 시 미수신 알림을 복구하는 Last-Event-ID 기반 보완과 Redis 장애 시 SSE 직접 전송 폴백을 추가
구독 시작/취소/갱신/만료 시점 알림 발송

## 변경 사항
- NotificationType에 SUBSCRIPTION_CANCEL, SUBSCRIPTION_EXPIRE 타입 추가
- PointOrderService: 구독 시작, 정기 갱신 성공, 잔액 부족 만료 시 알림 발송
- SubscriptionService: 구독 취소 시 만료일 포함 알림 발송
- SubscriptionScheduler: 스케줄러 만료 처리 시 알림 발송
- NotificationController: subscribe()에 Last-Event-ID 헤더 파라미터 추가
- NotificationService: replayMissedNotifications()로 재연결 시 미수신 알림 재전송
- NotificationService: Redis publish 실패 시 fallbackSseDirectPush()로 SSE 직접 전송
- NotificationRepository: findMissedNotifications() 쿼리 추가
- NotificationServiceTest: 기능 테스트 코드 추가

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 알림 스트림 재연결 시 놓친 알림 자동 복구 기능 추가
  * 구독 취소, 만료, 갱신 등 구독 수명 주기별 알림 추가
  * 알림 전달 실패 시 백업 전송 메커니즘 강화

* **버그 수정**
  * Redis 기반 알림 발행 실패 시 직접 전달로 안정성 개선

* **테스트**
  * SSE 재연결 및 알림 복구 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->