### PR TITLE
test : 상태전이 경로 테스트

### DIFF
--- a/src/test/java/com/fivefy/domain/cashorder/entity/CashOrderTest.java
+++ b/src/test/java/com/fivefy/domain/cashorder/entity/CashOrderTest.java
@@ -1,0 +1,85 @@
+package com.fivefy.domain.cashorder.entity;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.cashorder.enums.CashOrderStatus;
+import com.fivefy.domain.cashorder.enums.CashProductType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CashOrderTest {
+
+    // ─────────────────────────────────────────
+    // create() — 초기 상태 검증
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("CashOrder 생성 시 초기 상태는 PENDING이다")
+    void create_초기상태_PENDING() {
+        CashOrder cashOrder = CashOrder.create(1L, CashProductType.PRODUCT_1, "ORD-12345678");
+
+        assertThat(cashOrder.getStatus()).isEqualTo(CashOrderStatus.PENDING);
+    }
+
+    // ─────────────────────────────────────────
+    // success() — PENDING → SUCCESS
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("PENDING 상태에서 success() 호출 시 SUCCESS로 전이된다")
+    void success_PENDING에서_SUCCESS로() {
+        CashOrder cashOrder = CashOrder.create(1L, CashProductType.PRODUCT_1, "ORD-12345678");
+
+        cashOrder.success("webhook-id-001");
+
+        assertThat(cashOrder.getStatus()).isEqualTo(CashOrderStatus.SUCCESS);
+        assertThat(cashOrder.getWebhookId()).isEqualTo("webhook-id-001");
+    }
+
+    @Test
+    @DisplayName("SUCCESS 상태에서 success() 재호출 시 예외가 발생한다")
+    void success_SUCCESS에서_재호출_예외() {
+        CashOrder cashOrder = CashOrder.create(1L, CashProductType.PRODUCT_1, "ORD-12345678");
+        cashOrder.success("webhook-id-001");
+
+        assertThatThrownBy(() -> cashOrder.success("webhook-id-002"))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("REFUNDED 상태에서 success() 호출 시 예외가 발생한다")
+    void success_REFUNDED에서_호출_예외() {
+        CashOrder cashOrder = CashOrder.create(1L, CashProductType.PRODUCT_1, "ORD-12345678");
+        cashOrder.success("webhook-id-001");
+        cashOrder.refund();
+
+        assertThatThrownBy(() -> cashOrder.success("webhook-id-002"))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    // ─────────────────────────────────────────
+    // refund() — SUCCESS → REFUNDED
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("SUCCESS 상태에서 refund() 호출 시 REFUNDED로 전이된다")
+    void refund_SUCCESS에서_REFUNDED로() {
+        CashOrder cashOrder = CashOrder.create(1L, CashProductType.PRODUCT_1, "ORD-12345678");
+        cashOrder.success("webhook-id-001");
+
+        cashOrder.refund();
+
+        assertThat(cashOrder.getStatus()).isEqualTo(CashOrderStatus.REFUNDED);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태에서 refund() 호출 시 예외가 발생한다")
+    void refund_PENDING에서_호출_예외() {
+        CashOrder cashOrder = CashOrder.create(1L, CashProductType.PRODUCT_1, "ORD-12345678");
+
+        assertThatThrownBy(() -> cashOrder.refund())
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/fivefy/domain/payment/entity/PaymentTest.java
+++ b/src/test/java/com/fivefy/domain/payment/entity/PaymentTest.java
@@ -1,0 +1,67 @@
+package com.fivefy.domain.payment.entity;
+
+import com.fivefy.domain.payment.enums.PaymentStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PaymentTest {
+
+    // ─────────────────────────────────────────
+    // create() — 초기 상태 검증
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("Payment 생성 시 초기 상태는 REQUESTED이다")
+    void create_초기상태_REQUESTED() {
+        Payment payment = Payment.create(1L, 1000L, "ORD-12345678", "pg-tx-001", "webhook-001");
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REQUESTED);
+        assertThat(payment.getPaidAt()).isNull();
+        assertThat(payment.getRefundedAt()).isNull();
+    }
+
+    // ─────────────────────────────────────────
+    // complete() — REQUESTED → COMPLETED
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("complete() 호출 시 COMPLETED로 전이되고 paidAt이 기록된다")
+    void complete_REQUESTED에서_COMPLETED로() {
+        Payment payment = Payment.create(1L, 1000L, "ORD-12345678", "pg-tx-001", "webhook-001");
+
+        payment.complete();
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+        assertThat(payment.getPaidAt()).isNotNull();
+    }
+
+    // ─────────────────────────────────────────
+    // refund() — COMPLETED → REFUNDED
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("COMPLETED 상태에서 refund() 호출 시 REFUNDED로 전이되고 refundedAt이 기록된다")
+    void refund_COMPLETED에서_REFUNDED로() {
+        Payment payment = Payment.create(1L, 1000L, "ORD-12345678", "pg-tx-001", "webhook-001");
+        payment.complete();
+
+        payment.refund("단순 변심");
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        assertThat(payment.getRefundedAt()).isNotNull();
+        assertThat(payment.getRefundReason()).isEqualTo("단순 변심");
+    }
+
+    @Test
+    @DisplayName("refund() 호출 시 reason이 null이면 예외가 발생한다")
+    void refund_reason이_null이면_예외() {
+        Payment payment = Payment.create(1L, 1000L, "ORD-12345678", "pg-tx-001", "webhook-001");
+        payment.complete();
+
+        assertThatThrownBy(() -> payment.refund(null))
+                .isInstanceOf(Exception.class);
+    }
+}

--- a/src/test/java/com/fivefy/domain/pointorder/entity/PointOrderTest.java
+++ b/src/test/java/com/fivefy/domain/pointorder/entity/PointOrderTest.java
@@ -1,0 +1,73 @@
+package com.fivefy.domain.pointorder.entity;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.pointorder.enums.PointOrderStatus;
+import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PointOrderTest {
+
+    // ─────────────────────────────────────────
+    // create() — 초기 상태 검증
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("PointOrder 생성 시 초기 상태는 PENDING이다")
+    void create_초기상태_PENDING() {
+        PointOrder pointOrder = PointOrder.create(1L, SubscriptionPlanType.RECURRING, "SUB-12345678");
+
+        assertThat(pointOrder.getStatus()).isEqualTo(PointOrderStatus.PENDING);
+    }
+
+    // ─────────────────────────────────────────
+    // success() — PENDING → SUCCESS
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("PENDING 상태에서 success() 호출 시 SUCCESS로 전이된다")
+    void success_PENDING에서_SUCCESS로() {
+        PointOrder pointOrder = PointOrder.create(1L, SubscriptionPlanType.RECURRING, "SUB-12345678");
+
+        pointOrder.success();
+
+        assertThat(pointOrder.getStatus()).isEqualTo(PointOrderStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("SUCCESS 상태에서 success() 재호출 시 예외가 발생한다")
+    void success_SUCCESS에서_재호출_예외() {
+        PointOrder pointOrder = PointOrder.create(1L, SubscriptionPlanType.RECURRING, "SUB-12345678");
+        pointOrder.success();
+
+        assertThatThrownBy(() -> pointOrder.success())
+                .isInstanceOf(BusinessException.class);
+    }
+
+    // ─────────────────────────────────────────
+    // refund() — SUCCESS → REFUNDED
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("SUCCESS 상태에서 refund() 호출 시 REFUNDED로 전이된다")
+    void refund_SUCCESS에서_REFUNDED로() {
+        PointOrder pointOrder = PointOrder.create(1L, SubscriptionPlanType.RECURRING, "SUB-12345678");
+        pointOrder.success();
+
+        pointOrder.refund();
+
+        assertThat(pointOrder.getStatus()).isEqualTo(PointOrderStatus.REFUNDED);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태에서 refund() 호출 시 예외가 발생한다")
+    void refund_PENDING에서_호출_예외() {
+        PointOrder pointOrder = PointOrder.create(1L, SubscriptionPlanType.RECURRING, "SUB-12345678");
+
+        assertThatThrownBy(() -> pointOrder.refund())
+                .isInstanceOf(BusinessException.class);
+    }
+}

--- a/src/test/java/com/fivefy/domain/subscription/entity/SubscriptionTest.java
+++ b/src/test/java/com/fivefy/domain/subscription/entity/SubscriptionTest.java
@@ -1,0 +1,163 @@
+package com.fivefy.domain.subscription.entity;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
+import com.fivefy.domain.subscription.enums.SubscriptionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SubscriptionTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.now();
+
+    // ─────────────────────────────────────────
+    // create() — 초기 상태 검증
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("구독 생성 시 초기 상태는 ACTIVE이다")
+    void create_초기상태_ACTIVE() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("RECURRING 구독 생성 시 nextBillingDate가 1개월 후로 설정된다")
+    void create_RECURRING_nextBillingDate_1개월후() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+
+        assertThat(subscription.getNextBillingDate()).isNotNull();
+        assertThat(subscription.getNextBillingDate()).isAfter(NOW);
+    }
+
+    @Test
+    @DisplayName("FREE 구독 생성 시 nextBillingDate는 null이다")
+    void create_FREE_nextBillingDate_null() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.FREE, NOW);
+
+        assertThat(subscription.getNextBillingDate()).isNull();
+    }
+
+    // ─────────────────────────────────────────
+    // cancel() — ACTIVE → CANCELED
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("ACTIVE 상태에서 cancel() 호출 시 CANCELED로 전이되고 nextBillingDate가 null이 된다")
+    void cancel_ACTIVE에서_CANCELED로() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+
+        subscription.cancel();
+
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.CANCELED);
+        assertThat(subscription.getNextBillingDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("FREE 구독은 cancel() 호출 시 예외가 발생한다")
+    void cancel_FREE_예외() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.FREE, NOW);
+
+        assertThatThrownBy(() -> subscription.cancel())
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("CANCELED 상태에서 cancel() 재호출 시 예외가 발생한다")
+    void cancel_CANCELED에서_재호출_예외() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        subscription.cancel();
+
+        assertThatThrownBy(() -> subscription.cancel())
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("EXPIRE 상태에서 cancel() 호출 시 예외가 발생한다")
+    void cancel_EXPIRE에서_호출_예외() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        subscription.expire();
+
+        assertThatThrownBy(() -> subscription.cancel())
+                .isInstanceOf(BusinessException.class);
+    }
+
+    // ─────────────────────────────────────────
+    // expire() — → EXPIRE
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("expire() 호출 시 EXPIRE로 전이되고 nextBillingDate가 null이 된다")
+    void expire_EXPIRE로_전이() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+
+        subscription.expire();
+
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.EXPIRE);
+        assertThat(subscription.getNextBillingDate()).isNull();
+    }
+
+    // ─────────────────────────────────────────
+    // renew() — ACTIVE 유지, 날짜 갱신
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("RECURRING 구독에서 renew() 호출 시 expiryDate와 nextBillingDate가 1개월 연장된다")
+    void renew_날짜_1개월_연장() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        LocalDateTime beforeExpiry = subscription.getExpiryDate();
+        LocalDateTime beforeBilling = subscription.getNextBillingDate();
+
+        subscription.renew();
+
+        assertThat(subscription.getExpiryDate()).isEqualTo(beforeExpiry.plusMonths(1));
+        assertThat(subscription.getNextBillingDate()).isEqualTo(beforeBilling.plusMonths(1));
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("FREE 구독에서 renew() 호출 시 예외가 발생한다")
+    void renew_FREE_예외() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.FREE, NOW);
+
+        assertThatThrownBy(() -> subscription.renew())
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("취소된 구독(nextBillingDate=null)에서 renew() 호출 시 예외가 발생한다")
+    void renew_취소된구독_예외() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        subscription.cancel();
+
+        assertThatThrownBy(() -> subscription.renew())
+                .isInstanceOf(BusinessException.class);
+    }
+
+    // ─────────────────────────────────────────
+    // isActive() — 활성 여부 확인
+    // ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("ACTIVE 상태이고 만료일이 지나지 않았으면 isActive()는 true다")
+    void isActive_true() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+
+        assertThat(subscription.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("CANCELED 상태이면 isActive()는 false다")
+    void isActive_CANCELED_false() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        subscription.cancel();
+
+        assertThat(subscription.isActive()).isFalse();
+    }
+}


### PR DESCRIPTION
## 개요

`CashOrder`, `Payment`, `PointOrder`, `Subscription` 4개 도메인 엔티티의 상태 전이 경로가 올바르게 동작하는지 검증하는 단위 테스트를 작성했습니다.
`@SpringBootTest` 없이 순수 Java 단위 테스트로 작성하여 DB 연결 없이 빠르게 실행할 수 있습니다.


## 변경 사항
- `CashOrderTest` — `PENDING → SUCCESS → REFUNDED` 상태 전이 및 잘못된 상태에서 예외 발생 검증
- `PaymentTest` — `REQUESTED → COMPLETED → REFUNDED` 상태 전이, `paidAt`/`refundedAt` 기록 검증
- `PointOrderTest` — `PENDING → SUCCESS → REFUNDED` 상태 전이 및 예외 검증
- `SubscriptionTest` — `ACTIVE → CANCELED / EXPIRE`, `renew()` 날짜 연장, `isActive()` 검증
   - ( 필요 : `fivefy_test` DB 생성 (기존 서비스 테스트 `application-test.yml` 연동))

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

IntelliJ에서 직접 실행하는 경우 문제 발생
각각 실행하면 문제가 없으나, 인텔리제이에서 시작을 누르면 전체적으로 확인하는 과정에서 어딘지 모를 테스트가 JVM을 종료시켜 실패합니다. 
**(JVM 버전 문제라 하는데, test 자료가 너무 많아 찾질 못했습니다.)**
터미널에서 아래 명령어로 실행해주세요.

```bash
./gradlew test --tests "com.fivefy.domain.cashorder.entity.*" \
               --tests "com.fivefy.domain.payment.entity.*" \
               --tests "com.fivefy.domain.pointorder.entity.*" \
               --tests "com.fivefy.domain.subscription.entity.*"
```

`BUILD SUCCESSFUL` 확인 후 `build/reports/tests/test/index.html`을
브라우저로 열어 전체 통과 여부를 확인할 수 있습니다.

## 스크린샷 (선택)
<img width="1633" height="916" alt="image" src="https://github.com/user-attachments/assets/9f51461d-61ba-46f3-b4e2-4154b0da5c98" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 캐시 주문, 결제, 포인트 주문, 구독 도메인 엔티티의 상태 전이 및 비즈니스 규칙 검증을 위한 테스트 스위트 추가
  * 각 도메인 엔티티의 정상 동작 및 예외 처리에 대한 포괄적인 테스트 커버리지 확보

<!-- end of auto-generated comment: release notes by coderabbit.ai -->