### PR TITLE
feat: redis 원자성 보장 및 검색 정렬 기준 추가

### DIFF
--- a/src/main/java/com/fivefy/domain/search/controller/SearchController.java
+++ b/src/main/java/com/fivefy/domain/search/controller/SearchController.java
@@ -25,7 +25,7 @@ public class SearchController {
     @GetMapping("/search")
     public ResponseEntity<BaseResponse<SearchResponse>> search(
             @RequestParam String keyword,
-            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @PageableDefault(size = 20, sort = "relevance", direction = Sort.Direction.DESC) Pageable pageable,
             @AuthenticationPrincipal Long userId) {
         SearchResponse response = searchService.search(keyword, pageable, userId);
 

--- a/src/main/java/com/fivefy/domain/search/repository/SearchQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/search/repository/SearchQueryRepositoryImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -27,15 +28,20 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
         if (keyword.length() < 2) {
             return em.createNativeQuery(
                             "SELECT * FROM artists WHERE name LIKE :keyword" +
-                                    " AND deleted_at IS NULL AND status = 'ACTIVE' LIMIT :limit",
+                                    " AND deleted_at IS NULL AND status = 'ACTIVE'" +
+                                    " ORDER BY " + artistSortSql(keyword) +
+                                    " LIMIT :limit",
                             Artist.class)
                     .setParameter("keyword", keyword + "%")
                     .setParameter("limit", limit)
                     .getResultList();
         }
         return em.createNativeQuery(
-                        "SELECT * FROM artists WHERE MATCH(name) AGAINST(:keyword IN BOOLEAN MODE)" +
-                                " AND deleted_at IS NULL AND status = 'ACTIVE' LIMIT :limit",
+                        "SELECT * FROM artists" +
+                                " WHERE MATCH(name) AGAINST(:keyword IN BOOLEAN MODE)" +
+                                " AND deleted_at IS NULL AND status = 'ACTIVE'" +
+                                " ORDER BY " + artistSortSql(keyword) +
+                                " LIMIT :limit",
                         Artist.class)
                 .setParameter("keyword", keyword)
                 .setParameter("limit", limit)
@@ -47,11 +53,15 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
     public Page<Track> searchTracks(String keyword, List<Long> artistIds, Pageable pageable) {
         List<Long> ids = artistIds.isEmpty() ? List.of(-1L) : artistIds;
         String joinedIds = ids.stream().map(String::valueOf).collect(Collectors.joining(","));
+        String orderClause = trackSortSql(keyword, pageable.getSort());
 
         if (keyword.length() < 2) {
             List<Track> results = em.createNativeQuery(
-                            "SELECT * FROM tracks WHERE (title LIKE :keyword OR artist_id IN (:ids))" +
-                                    " AND deleted_at IS NULL AND status = 'PUBLISHED' ORDER BY id DESC LIMIT :offset, :size",
+                            "SELECT * FROM tracks" +
+                                    " WHERE (title LIKE :keyword OR artist_id IN (:ids))" +
+                                    " AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                    " ORDER BY " + orderClause +
+                                    " LIMIT :offset, :size",
                             Track.class)
                     .setParameter("keyword", keyword + "%")
                     .setParameter("ids", ids)
@@ -62,16 +72,17 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
             Long total = jdbcTemplate.queryForObject(
                     "SELECT COUNT(*) FROM tracks WHERE (title LIKE ? OR artist_id IN (" + joinedIds + "))" +
                             " AND deleted_at IS NULL AND status = 'PUBLISHED'",
-                    Long.class,
-                    keyword + "%");
+                    Long.class, keyword + "%");
 
             return new PageImpl<>(results, pageable, total);
         }
 
         List<Track> results = em.createNativeQuery(
-                        "SELECT * FROM tracks WHERE (" +
-                                "MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) OR artist_id IN (:ids))" +
-                                " AND deleted_at IS NULL AND status = 'PUBLISHED' ORDER BY id DESC LIMIT :offset, :size",
+                        "SELECT * FROM tracks" +
+                                " WHERE (MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) OR artist_id IN (:ids))" +
+                                " AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                " ORDER BY " + orderClause +
+                                " LIMIT :offset, :size",
                         Track.class)
                 .setParameter("keyword", keyword)
                 .setParameter("ids", ids)
@@ -80,11 +91,9 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
                 .getResultList();
 
         Long total = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM tracks WHERE (" +
-                        "MATCH(title) AGAINST(? IN BOOLEAN MODE) OR artist_id IN (" + joinedIds + "))" +
+                "SELECT COUNT(*) FROM tracks WHERE (MATCH(title) AGAINST(? IN BOOLEAN MODE) OR artist_id IN (" + joinedIds + "))" +
                         " AND deleted_at IS NULL AND status = 'PUBLISHED'",
-                Long.class,
-                keyword);
+                Long.class, keyword);
 
         return new PageImpl<>(results, pageable, total);
     }
@@ -94,11 +103,15 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
     public Page<Album> searchAlbums(String keyword, List<Long> artistIds, Pageable pageable) {
         List<Long> ids = artistIds.isEmpty() ? List.of(-1L) : artistIds;
         String joinedIds = ids.stream().map(String::valueOf).collect(Collectors.joining(","));
+        String orderClause = albumSortSql(keyword, pageable.getSort());
 
         if (keyword.length() < 2) {
             List<Album> results = em.createNativeQuery(
-                            "SELECT * FROM albums WHERE (title LIKE :keyword OR artist_id IN (:ids))" +
-                                    " AND deleted_at IS NULL AND status = 'PUBLISHED' ORDER BY id DESC LIMIT :offset, :size",
+                            "SELECT * FROM albums" +
+                                    " WHERE (title LIKE :keyword OR artist_id IN (:ids))" +
+                                    " AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                    " ORDER BY " + orderClause +
+                                    " LIMIT :offset, :size",
                             Album.class)
                     .setParameter("keyword", keyword + "%")
                     .setParameter("ids", ids)
@@ -109,16 +122,17 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
             Long total = jdbcTemplate.queryForObject(
                     "SELECT COUNT(*) FROM albums WHERE (title LIKE ? OR artist_id IN (" + joinedIds + "))" +
                             " AND deleted_at IS NULL AND status = 'PUBLISHED'",
-                    Long.class,
-                    keyword + "%");
+                    Long.class, keyword + "%");
 
             return new PageImpl<>(results, pageable, total);
         }
 
         List<Album> results = em.createNativeQuery(
-                        "SELECT * FROM albums WHERE (" +
-                                "MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) OR artist_id IN (:ids))" +
-                                " AND deleted_at IS NULL AND status = 'PUBLISHED' ORDER BY id DESC LIMIT :offset, :size",
+                        "SELECT * FROM albums" +
+                                " WHERE (MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) OR artist_id IN (:ids))" +
+                                " AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                " ORDER BY " + orderClause +
+                                " LIMIT :offset, :size",
                         Album.class)
                 .setParameter("keyword", keyword)
                 .setParameter("ids", ids)
@@ -127,12 +141,60 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
                 .getResultList();
 
         Long total = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM albums WHERE (" +
-                        "MATCH(title) AGAINST(? IN BOOLEAN MODE) OR artist_id IN (" + joinedIds + "))" +
+                "SELECT COUNT(*) FROM albums WHERE (MATCH(title) AGAINST(? IN BOOLEAN MODE) OR artist_id IN (" + joinedIds + "))" +
                         " AND deleted_at IS NULL AND status = 'PUBLISHED'",
-                Long.class,
-                keyword);
+                Long.class, keyword);
 
         return new PageImpl<>(results, pageable, total);
+    }
+
+    private String trackSortSql(String keyword, Sort sort) {
+        if (sort.isSorted()) {
+            for (Sort.Order order : sort) {
+                return switch (order.getProperty()) {
+                    case "popular" -> "play_count DESC";
+                    case "latest"  -> "published_at DESC";
+                    default        -> relevanceSortSql(keyword, "title");
+                };
+            }
+        }
+        return relevanceSortSql(keyword, "title");
+    }
+
+    private String albumSortSql(String keyword, Sort sort) {
+        if (sort.isSorted()) {
+            for (Sort.Order order : sort) {
+                return switch (order.getProperty()) {
+                    case "latest" -> "published_at DESC";
+                    default       -> relevanceSortSql(keyword, "title");
+                };
+            }
+        }
+        return relevanceSortSql(keyword, "title");
+    }
+
+    private String artistSortSql(String keyword) {
+        return relevanceSortSql(keyword, "name");
+    }
+
+    private String relevanceSortSql(String keyword, String column) {
+        String safeColumn  = column.matches("^[a-z_]+$") ? column : "title";
+        String sanitized   = sanitizeKeyword(keyword);
+
+        return String.format("""
+                CASE
+                    WHEN %s = '%s'      THEN 2
+                    WHEN %s LIKE '%s%%' THEN 1
+                    ELSE 0
+                END DESC,
+                MATCH(%s) AGAINST('%s' IN BOOLEAN MODE) DESC,
+                id DESC
+                """, safeColumn, sanitized, safeColumn, sanitized, safeColumn, sanitized);
+    }
+
+    private String sanitizeKeyword(String keyword) {
+        return keyword
+                .replace("\\", "\\\\")
+                .replace("'", "''");
     }
 }

--- a/src/main/java/com/fivefy/domain/search/repository/SearchQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/search/repository/SearchQueryRepositoryImpl.java
@@ -195,6 +195,8 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
     private String sanitizeKeyword(String keyword) {
         return keyword
                 .replace("\\", "\\\\")
-                .replace("'", "''");
+                .replace("'", "''")
+                .replace("%", "\\%")   // LIKE 와일드카드 이스케이프
+                .replace("_", "\\_");  // LIKE 단일문자 와일드카드 이스케이프
     }
 }

--- a/src/main/java/com/fivefy/domain/search/service/SearchHistoryService.java
+++ b/src/main/java/com/fivefy/domain/search/service/SearchHistoryService.java
@@ -4,10 +4,12 @@ import com.fivefy.domain.search.entity.SearchHistory;
 import com.fivefy.domain.search.repository.SearchHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
 
 @Service
@@ -16,9 +18,25 @@ public class SearchHistoryService {
 
     private static final String RECENT_SEARCH_KEY = "search:recent:";
     private static final int MAX_RECENT_SEARCH = 10;
+    private static final Duration RECENT_SEARCH_TTL = Duration.ofDays(30);
 
     private final SearchHistoryRepository searchHistoryRepository;
     private final RedisTemplate<String, String> redisTemplate;
+
+    private static final DefaultRedisScript<Long> PUSH_RECENT_SEARCH_SCRIPT =
+            new DefaultRedisScript<>("""
+                    local key     = KEYS[1]
+                    local keyword = ARGV[1]
+                    local max     = tonumber(ARGV[2])
+                    local ttlSec  = tonumber(ARGV[3])
+ 
+                    redis.call('LREM',   key, 0, keyword)
+                    redis.call('LPUSH',  key, keyword)
+                    redis.call('LTRIM',  key, 0, max - 1)
+                    redis.call('EXPIRE', key, ttlSec)
+ 
+                    return 1
+                    """, Long.class);
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveSearchHistory(Long userId, String keyword, Integer resultCount) {
@@ -28,9 +46,13 @@ public class SearchHistoryService {
         // Redis에 최근 기록 저장
         if (userId != null) {
             String key = RECENT_SEARCH_KEY + userId;
-            redisTemplate.opsForList().remove(key, 0, keyword); // 중복 제거
-            redisTemplate.opsForList().leftPush(key, keyword);  // 맨 앞에 추가
-            redisTemplate.opsForList().trim(key, 0, MAX_RECENT_SEARCH - 1); // 10개 유지
+            redisTemplate.execute(
+                    PUSH_RECENT_SEARCH_SCRIPT,
+                    List.of(key),
+                    keyword,
+                    String.valueOf(MAX_RECENT_SEARCH),
+                    String.valueOf(RECENT_SEARCH_TTL.toSeconds())
+            );
         }
     }
 

--- a/src/main/java/com/fivefy/domain/search/service/SearchHistoryService.java
+++ b/src/main/java/com/fivefy/domain/search/service/SearchHistoryService.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.search.service;
 import com.fivefy.domain.search.entity.SearchHistory;
 import com.fivefy.domain.search.repository.SearchHistoryRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.Duration;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SearchHistoryService {
@@ -46,13 +48,17 @@ public class SearchHistoryService {
         // Redis에 최근 기록 저장
         if (userId != null) {
             String key = RECENT_SEARCH_KEY + userId;
-            redisTemplate.execute(
-                    PUSH_RECENT_SEARCH_SCRIPT,
-                    List.of(key),
-                    keyword,
-                    String.valueOf(MAX_RECENT_SEARCH),
-                    String.valueOf(RECENT_SEARCH_TTL.toSeconds())
-            );
+            try {
+                redisTemplate.execute(
+                        PUSH_RECENT_SEARCH_SCRIPT,
+                        List.of(key),
+                        keyword,
+                        String.valueOf(MAX_RECENT_SEARCH),
+                        String.valueOf(RECENT_SEARCH_TTL.toSeconds())
+                );
+            } catch (Exception e) {
+                log.warn("Redis 최근 검색어 저장 실패: userId={}, keyword={}", userId, keyword);
+            }
         }
     }
 

--- a/src/main/java/com/fivefy/domain/search/service/SearchService.java
+++ b/src/main/java/com/fivefy/domain/search/service/SearchService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -25,6 +26,7 @@ public class SearchService {
     private final SearchQueryRepository searchQueryRepository;
     private final SearchHistoryService searchHistoryService;
 
+    @Transactional(readOnly = true)
     public SearchResponse search(String keyword, Pageable pageable, Long userId) {
         String trimmedKeyword = keyword.trim();
 

--- a/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
+++ b/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 
 import java.util.List;
 
@@ -44,9 +45,6 @@ class SearchHistoryServiceTest {
         @Test
         @DisplayName("검색 기록 저장 시 DB에 INSERT 된다")
         void saveSearchHistory_savesToDB() {
-            // given
-            given(redisTemplate.opsForList()).willReturn(listOperations);
-
             // when
             searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
 
@@ -55,43 +53,27 @@ class SearchHistoryServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기록 저장 시 Redis에 leftPush 된다")
-        void saveSearchHistory_leftPushToRedis() {
-            // given
-            given(redisTemplate.opsForList()).willReturn(listOperations);
-
+        @DisplayName("검색 기록 저장 시 개별 Redis 명령(leftPush, trim, remove)을 직접 호출하지 않는다")
+        void saveSearchHistory_doesNotCallIndividualRedisOps() {
             // when
             searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
 
-            // then
-            verify(listOperations, times(1)).leftPush(REDIS_KEY, KEYWORD);
+            // then — Lua Script로 원자화되었으므로 개별 호출 없음
+            verify(redisTemplate, never()).opsForList();
         }
 
         @Test
-        @DisplayName("Redis 최근 기록 10개 초과 시 trim 된다")
-        void saveSearchHistory_trimAfterPush() {
-            // given
-            given(redisTemplate.opsForList()).willReturn(listOperations);
-
+        @DisplayName("TTL이 Lua Script 내부에서 설정된다")
+        void saveSearchHistory_setsTTLviaLuaScript() {
             // when
             searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
 
-            // then
-            verify(listOperations, times(1)).trim(REDIS_KEY, 0, 9);
-        }
-
-        @Test
-        @DisplayName("중복 키워드 저장 시 remove 후 leftPush 된다")
-        void saveSearchHistory_removeThenLeftPushForDuplicate() {
-            // given
-            given(redisTemplate.opsForList()).willReturn(listOperations);
-
-            // when
-            searchHistoryService.saveSearchHistory(USER_ID, KEYWORD, 10);
-
-            // then
-            verify(listOperations, times(1)).remove(REDIS_KEY, 0, KEYWORD);
-            verify(listOperations, times(1)).leftPush(REDIS_KEY, KEYWORD);
+            // then — EXPIRE 명령도 Lua Script 내부에서 처리, execute 1번 호출로 검증
+            verify(redisTemplate, times(1)).execute(
+                    any(RedisScript.class),
+                    anyList(),
+                    any(), any(), any()
+            );
         }
 
         @Test
@@ -101,7 +83,7 @@ class SearchHistoryServiceTest {
             searchHistoryService.saveSearchHistory(null, KEYWORD, 10);
 
             // then
-            verify(redisTemplate, never()).opsForList();
+            verify(redisTemplate, never()).execute(any(RedisScript.class), anyList(), any());
             verify(searchHistoryRepository, times(1)).save(any()); // DB는 저장
         }
     }
@@ -124,6 +106,20 @@ class SearchHistoryServiceTest {
             // then
             assertThat(result).hasSize(3);
             assertThat(result).containsExactly("아이유", "루나", "뉴진스");
+        }
+
+        @Test
+        @DisplayName("Redis에서 null 반환 시 빈 리스트를 반환한다")
+        void getRecentSearchHistories_redisReturnsNull_returnsEmptyList() {
+            // given
+            given(redisTemplate.opsForList()).willReturn(listOperations);
+            given(listOperations.range(REDIS_KEY, 0, -1)).willReturn(null);
+
+            // when
+            List<String> result = searchHistoryService.getRecentSearchHistories(USER_ID);
+
+            // then
+            assertThat(result).isEmpty();
         }
 
         @Test

--- a/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
+++ b/src/test/java/com/fivefy/domain/search/service/SearchHistoryServiceTest.java
@@ -83,7 +83,7 @@ class SearchHistoryServiceTest {
             searchHistoryService.saveSearchHistory(null, KEYWORD, 10);
 
             // then
-            verify(redisTemplate, never()).execute(any(RedisScript.class), anyList(), any());
+            verifyNoInteractions(redisTemplate);
             verify(searchHistoryRepository, times(1)).save(any()); // DB는 저장
         }
     }


### PR DESCRIPTION
## 개요
최근 검색어 Redis 조작의 원자성 보장과 검색 결과 정렬 기준 추가 작업입니다.
기존 remove → leftPush → trim 3개의 개별 Redis 명령이 명령 사이에 다른 요청이 끼어들 수 있는 경쟁 조건 문제가 있었고, 검색 결과가 id DESC 고정으로 정렬 기준 선택이 불가했습니다. Lua Script로 원자화하고 TTL을 추가했으며, 정렬 기준을 파라미터로 선택할 수 있도록 개선했습니다.

## 변경 사항
SearchHistoryService: remove → leftPush → trim → expire 4개 명령을 Lua Script 1개로 원자화
SearchHistoryService: 최근 검색어 TTL 30일 추가
SearchQueryRepositoryImpl: trackSortSql(), albumSortSql(), artistSortSql() 정렬 헬퍼 추가
SearchQueryRepositoryImpl: relevanceSortSql() 추가 — exact match → prefix match → Full-Text score 순 정렬
SearchQueryRepositoryImpl: sanitizeKeyword() 추가 — ORDER BY 직접 삽입 시 SQL injection 방지
SearchController: @PageableDefault 기본 정렬값 id → relevance 변경
SearchHistoryServiceTest: Lua Script 원자화에 따른 테스트 수정

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법
1. 최근 검색어 원자화 확인
   GET /api/search?keyword=루나 (동시 다수 요청)
   → Redis에서 search:recent:{userId} 리스트 확인
   → 중복 없이 최대 10개 유지

2. 정렬 기준 확인
   GET /api/search?keyword=루나&sort=popular,desc → 재생수 내림차순
   GET /api/search?keyword=루나&sort=latest,desc  → 발매일 내림차순
   GET /api/search?keyword=루나 → relevance 기본 정렬

3. SQL injection 방지 확인
   GET /api/search?keyword='; DROP TABLE tracks;--
   → 정상 응답 확인 (500 에러 없음) 200 OK

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 결과의 기본 정렬 기준이 관련성을 우선으로 하는 방식으로 개선되었습니다.
  * 아티스트, 곡, 앨범 등 콘텐츠 유형에 따라 최적화된 검색 결과 정렬을 지원합니다.
  * 사용자의 검색 이력이 더욱 안정적으로 저장되고 관리됩니다.
  * 검색 기능의 성능과 신뢰성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->