### PR TITLE
feat: 공개 트랙 조회 Slice 기반으로 전환 및 성능 최적화 (count 제거 + 인덱스 추가)

### DIFF
--- a/src/main/java/com/fivefy/common/dto/response/SliceResponse.java
+++ b/src/main/java/com/fivefy/common/dto/response/SliceResponse.java
@@ -1,0 +1,21 @@
+package com.fivefy.common.dto.response;
+
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record SliceResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        boolean hasNext
+) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(
+                slice.getContent(),
+                slice.getNumber(),
+                slice.getSize(),
+                slice.hasNext()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/track/controller/TrackController.java
+++ b/src/main/java/com/fivefy/domain/track/controller/TrackController.java
@@ -2,6 +2,7 @@ package com.fivefy.domain.track.controller;
 
 import com.fivefy.common.dto.response.BaseResponse;
 import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.dto.response.SliceResponse;
 import com.fivefy.domain.track.dto.response.ArtistFreeCreationTrackResponse;
 import com.fivefy.domain.track.dto.response.PublicTrackListResponse;
 import com.fivefy.domain.track.dto.response.TrackDetailResponse;
@@ -44,7 +45,7 @@ public class TrackController {
      * 공개 트랙 목록 조회 API
      */
     @GetMapping("/tracks")
-    public ResponseEntity<BaseResponse<PageResponse<PublicTrackListResponse>>> getPublicTracks(
+    public ResponseEntity<BaseResponse<SliceResponse<PublicTrackListResponse>>> getPublicTracks(
             @PageableDefault(
                     size = 20,
                     sort = "publishedAt",
@@ -53,7 +54,7 @@ public class TrackController {
     ) {
 
         // 공개 트랙 목록 조회
-        PageResponse<PublicTrackListResponse> response =
+        SliceResponse<PublicTrackListResponse> response =
                 trackService.getPublicTracks(pageable);
 
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/fivefy/domain/track/entity/Track.java
+++ b/src/main/java/com/fivefy/domain/track/entity/Track.java
@@ -26,7 +26,8 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
                 @Index(name = "idx_track_owner_user_id", columnList = "owner_user_id"),
                 @Index(name = "idx_track_artist_id", columnList = "artist_id"),
                 @Index(name = "idx_track_album_id", columnList = "album_id"),
-                @Index(name = "idx_track_status", columnList = "status")
+                @Index(name = "idx_track_status", columnList = "status"),
+                @Index(name = "idx_track_status_deleted_published", columnList = "status, deleted_at, published_at")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
+++ b/src/main/java/com/fivefy/domain/track/entity/TrackComment.java
@@ -19,7 +19,8 @@ import static com.fivefy.common.util.ValidationUtils.validateNonNull;
         name = "track_comments",
         indexes = {
                 @Index(name = "idx_track_comment_track_id", columnList = "track_id"),
-                @Index(name = "idx_track_comment_user_id", columnList = "user_id")
+                @Index(name = "idx_track_comment_user_id", columnList = "user_id"),
+                @Index(name = "idx_track_comment_track_deleted_created", columnList = "track_id, deleted_at, created_at")
         }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepository.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.track.repository;
 import com.fivefy.domain.track.entity.Track;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
@@ -19,7 +20,7 @@ public interface TrackQueryRepository {
     /**
      * 공개 트랙 목록 조회
      */
-    Page<PublicTrackListProjection> searchPublicTracks(Pageable pageable);
+    Slice<PublicTrackListProjection> searchPublicTracks(Pageable pageable);
 
     /**
      * 아티스트별 자유 창작 트랙 목록 조회

--- a/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackQueryRepositoryImpl.java
@@ -6,9 +6,7 @@ import com.fivefy.domain.track.enums.TrackType;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -49,7 +47,9 @@ public class TrackQueryRepositoryImpl implements TrackQueryRepository {
      * 공개 트랙 목록 조회
      */
     @Override
-    public Page<PublicTrackListProjection> searchPublicTracks(Pageable pageable) {
+    public Slice<PublicTrackListProjection> searchPublicTracks(Pageable pageable) {
+
+        int pageSize = pageable.getPageSize();
 
         // 공개된 트랙만 조회 (삭제되지 않았고 PUBLISHED 상태)
         List<PublicTrackListProjection> content = queryFactory
@@ -83,31 +83,18 @@ public class TrackQueryRepositoryImpl implements TrackQueryRepository {
                 )
                 // 최신 공개순 정렬 (명세 기준)
                 .orderBy(track.publishedAt.desc())
-                // 페이지네이션 적용
+                // Slice 응답을 위해 다음 페이지 존재 여부 확인용으로 1건 더 조회
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .limit(pageSize + 1)
                 .fetch();
 
-        // 전체 개수 조회 (PageResponse 생성용)
-        Long total = queryFactory
-                .select(track.count())
-                .from(track)
-                .leftJoin(artist).on(track.artistId.eq(artist.id))
-                .leftJoin(album).on(track.albumId.eq(album.id))
-                .where(
-                        track.deletedAt.isNull(),
-                        track.status.eq(TrackStatus.PUBLISHED),
-                        track.trackType.eq(TrackType.FREE_CREATION)
-                                .or(
-                                        track.trackType.eq(TrackType.OFFICIAL_RELEASE)
-                                                .and(album.deletedAt.isNull())
-                                                .and(album.status.eq(com.fivefy.domain.album.enums.AlbumStatus.PUBLISHED))
-                                                .and(artist.deletedAt.isNull())
-                                )
-                )
-                .fetchOne();
+        boolean hasNext = content.size() > pageSize;
 
-        return new PageImpl<>(content, pageable, total == null ? 0 : total);
+        if (hasNext) {
+            content = content.subList(0, pageSize);
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     /**

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.track.service;
 
 import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.dto.response.SliceResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
@@ -30,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -270,15 +272,15 @@ public class TrackService {
      * 공개 트랙 목록 조회
      */
     @Transactional(readOnly = true)
-    public PageResponse<PublicTrackListResponse> getPublicTracks(Pageable pageable) {
+    public SliceResponse<PublicTrackListResponse> getPublicTracks(Pageable pageable) {
 
         // 공개 트랙 목록 조회 (Querydsl)
-        Page<PublicTrackListProjection> page =
+        Slice<PublicTrackListProjection> slice =
                 trackRepository.searchPublicTracks(pageable);
 
         // Projection → 응답 DTO 변환
-        return PageResponse.from(
-                page.map(projection -> PublicTrackListResponse.of(
+        return SliceResponse.from(
+                slice.map(projection -> PublicTrackListResponse.of(
                         projection.trackId(),
                         projection.trackType(),
                         projection.title(),

--- a/src/main/resources/db/migration/V3__add_performance_indexes.sql
+++ b/src/main/resources/db/migration/V3__add_performance_indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX idx_track_status_deleted_published
+    ON tracks (status, deleted_at, published_at DESC);
+
+CREATE INDEX idx_track_comment_track_deleted_created
+    ON track_comments (track_id, deleted_at, created_at DESC);

--- a/src/main/resources/db/migration/V3__add_performance_indexes.sql
+++ b/src/main/resources/db/migration/V3__add_performance_indexes.sql
@@ -1,5 +1,9 @@
-CREATE INDEX idx_track_status_deleted_published
-    ON tracks (status, deleted_at, published_at DESC);
+ALTER TABLE tracks
+    ADD INDEX idx_track_status_deleted_published (status, deleted_at, published_at DESC),
+    ALGORITHM=INPLACE,
+    LOCK=NONE;
 
-CREATE INDEX idx_track_comment_track_deleted_created
-    ON track_comments (track_id, deleted_at, created_at DESC);
+ALTER TABLE track_comments
+    ADD INDEX idx_track_comment_track_deleted_created (track_id, deleted_at, created_at DESC),
+    ALGORITHM=INPLACE,
+    LOCK=NONE;

--- a/src/test/java/com/fivefy/domain/track/controller/TrackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/track/controller/TrackControllerTest.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.track.controller;
 import com.fivefy.common.config.security.JwtUtil;
 import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.dto.response.SliceResponse;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.filter.LastActiveAtFilter;
 import com.fivefy.domain.artist.enums.ArtistErrorCode;
@@ -20,6 +21,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -186,8 +188,8 @@ class TrackControllerTest extends RestDocsSupport {
                     LocalDateTime.of(2026, 5, 1, 18, 0, 0)
             );
 
-            PageResponse<PublicTrackListResponse> response = PageResponse.from(
-                    new PageImpl<>(List.of(content), PageRequest.of(0, 20), 1)
+            SliceResponse<PublicTrackListResponse> response = SliceResponse.from(
+                    new SliceImpl<>(List.of(content), PageRequest.of(0, 20), true)
             );
 
             given(trackService.getPublicTracks(any(Pageable.class))).willReturn(response);
@@ -202,8 +204,7 @@ class TrackControllerTest extends RestDocsSupport {
                     .andExpect(jsonPath("$.data.content[0].trackId").value(1L))
                     .andExpect(jsonPath("$.data.page").value(0))
                     .andExpect(jsonPath("$.data.size").value(20))
-                    .andExpect(jsonPath("$.data.totalElements").value(1))
-                    .andExpect(jsonPath("$.data.totalPages").value(1))
+                    .andExpect(jsonPath("$.data.hasNext").value(true))
                     .andDo(document("tracks-get-list",
                             queryParameters(
                                     parameterWithName("page").optional().description("페이지 번호"),
@@ -215,7 +216,7 @@ class TrackControllerTest extends RestDocsSupport {
                             ).and(
                                     publicTrackListResponseFields()
                             ).and(
-                                    pageResponseFields()
+                                    sliceResponseFields()
                             )
                     ));
         }
@@ -346,6 +347,14 @@ class TrackControllerTest extends RestDocsSupport {
                 fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
                 fieldWithPath("data.totalElements").type(NUMBER).description("전체 데이터 수"),
                 fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수")
+        };
+    }
+
+    private FieldDescriptor[] sliceResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.page").type(NUMBER).description("현재 페이지"),
+                fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
+                fieldWithPath("data.hasNext").type(BOOLEAN).description("다음 페이지 존재 여부")
         };
     }
 

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -34,10 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -1990,7 +1987,7 @@ class TrackServiceTest {
             );
 
             when(trackRepository.searchPublicTracks(pageable))
-                    .thenReturn(new PageImpl<>(List.of(projection1, projection2), pageable, 2));
+                    .thenReturn(new SliceImpl<>(List.of(projection1, projection2), pageable, true));
 
             SliceResponse<PublicTrackListResponse> response =
                     trackService.getPublicTracks(pageable);
@@ -2011,6 +2008,7 @@ class TrackServiceTest {
 
             assertThat(response.page()).isEqualTo(0);
             assertThat(response.size()).isEqualTo(20);
+            assertThat(response.hasNext()).isTrue();
         }
 
         @Test
@@ -2032,7 +2030,7 @@ class TrackServiceTest {
             );
 
             when(trackRepository.searchPublicTracks(pageable))
-                    .thenReturn(new PageImpl<>(List.of(projection), pageable, 1));
+                    .thenReturn(new SliceImpl<>(List.of(projection), pageable, false));
 
             SliceResponse<PublicTrackListResponse> response =
                     trackService.getPublicTracks(pageable);
@@ -2049,6 +2047,7 @@ class TrackServiceTest {
             assertThat(response.content().get(0).playCount()).isEqualTo(300L);
             assertThat(response.content().get(0).publishedAt())
                     .isEqualTo(LocalDateTime.of(2026, 5, 2, 12, 0, 0));
+            assertThat(response.hasNext()).isFalse();
         }
 
         @Test
@@ -2057,7 +2056,7 @@ class TrackServiceTest {
             Pageable pageable = PageRequest.of(0, 20);
 
             when(trackRepository.searchPublicTracks(pageable))
-                    .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+                    .thenReturn(new SliceImpl<>(List.of(), pageable, false));
 
             SliceResponse<PublicTrackListResponse> response =
                     trackService.getPublicTracks(pageable);
@@ -2065,6 +2064,7 @@ class TrackServiceTest {
             assertThat(response.content()).isEmpty();
             assertThat(response.page()).isEqualTo(0);
             assertThat(response.size()).isEqualTo(20);
+            assertThat(response.hasNext()).isFalse();
         }
     }
 

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.track.service;
 
 import com.fivefy.common.dto.response.PageResponse;
+import com.fivefy.common.dto.response.SliceResponse;
 import com.fivefy.common.enums.ApplicationStatus;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.album.entity.Album;
@@ -60,6 +61,8 @@ import static org.mockito.Mockito.when;
  * 트랙 등록 신청 승인 기능 검증
  * 트랙 등록 신청 거절 기능 검증
  * 트랙 상세 조회 기능 검증
+ * 공개 트랙 목록 조회 기능 검증
+ * 아티스트별 자유 창작 트랙 목록 조회 기능 검증
  */
 @ExtendWith(MockitoExtension.class)
 class TrackServiceTest {
@@ -1989,7 +1992,7 @@ class TrackServiceTest {
             when(trackRepository.searchPublicTracks(pageable))
                     .thenReturn(new PageImpl<>(List.of(projection1, projection2), pageable, 2));
 
-            PageResponse<PublicTrackListResponse> response =
+            SliceResponse<PublicTrackListResponse> response =
                     trackService.getPublicTracks(pageable);
 
             assertThat(response.content()).hasSize(2);
@@ -2008,8 +2011,6 @@ class TrackServiceTest {
 
             assertThat(response.page()).isEqualTo(0);
             assertThat(response.size()).isEqualTo(20);
-            assertThat(response.totalElements()).isEqualTo(2);
-            assertThat(response.totalPages()).isEqualTo(1);
         }
 
         @Test
@@ -2033,7 +2034,7 @@ class TrackServiceTest {
             when(trackRepository.searchPublicTracks(pageable))
                     .thenReturn(new PageImpl<>(List.of(projection), pageable, 1));
 
-            PageResponse<PublicTrackListResponse> response =
+            SliceResponse<PublicTrackListResponse> response =
                     trackService.getPublicTracks(pageable);
 
             assertThat(response.content()).hasSize(1);
@@ -2048,9 +2049,6 @@ class TrackServiceTest {
             assertThat(response.content().get(0).playCount()).isEqualTo(300L);
             assertThat(response.content().get(0).publishedAt())
                     .isEqualTo(LocalDateTime.of(2026, 5, 2, 12, 0, 0));
-
-            assertThat(response.totalElements()).isEqualTo(1);
-            assertThat(response.totalPages()).isEqualTo(1);
         }
 
         @Test
@@ -2061,14 +2059,12 @@ class TrackServiceTest {
             when(trackRepository.searchPublicTracks(pageable))
                     .thenReturn(new PageImpl<>(List.of(), pageable, 0));
 
-            PageResponse<PublicTrackListResponse> response =
+            SliceResponse<PublicTrackListResponse> response =
                     trackService.getPublicTracks(pageable);
 
             assertThat(response.content()).isEmpty();
             assertThat(response.page()).isEqualTo(0);
             assertThat(response.size()).isEqualTo(20);
-            assertThat(response.totalElements()).isZero();
-            assertThat(response.totalPages()).isZero();
         }
     }
 


### PR DESCRIPTION
## 개요
- 공개 트랙 목록 조회의 `PageResponse` 기반 count 쿼리 병목 제거
- 사용자 탐색형 조회 응답을 `SliceResponse`로 전환하여 `hasNext` 기반 페이징 제공
- 성능 측정 결과 채택된 공개 트랙 목록 / 트랙 댓글 목록 복합 인덱스 반영
- 실험 결과 응답속도가 악화된 관리자 트랙 신청 목록 인덱스는 제외

## 변경 사항

### 공개 트랙 목록 조회 응답 구조 변경
- `GET /api/tracks` 응답을 `PageResponse<PublicTrackListResponse>`에서 `SliceResponse<PublicTrackListResponse>`로 변경
- `totalElements`, `totalPages` 제거
- `hasNext` 추가
- 공통 응답 DTO `SliceResponse<T>` 추가
- 공개 트랙 목록 조회 Service 반환 타입을 `SliceResponse<PublicTrackListResponse>`로 변경

### 조회 계층 구성
- `TrackQueryRepository#searchPublicTracks` 반환 타입을 `Page<PublicTrackListProjection>`에서 `Slice<PublicTrackListProjection>`로 변경
- Querydsl 공개 트랙 목록 조회에서 count 쿼리 제거
- `pageSize + 1` 조회 후 `hasNext` 계산
- 다음 페이지 존재 시 응답 content는 `pageSize`만 유지
- 공개 트랙 조회 조건과 최신 공개순 정렬 유지
  - 삭제되지 않은 트랙
  - `PUBLISHED` 상태
  - `FREE_CREATION` 또는 공개 가능한 `OFFICIAL_RELEASE`
  - `publishedAt DESC`

### 성능 개선 인덱스 반영
- `tracks` 복합 인덱스 추가
  - `idx_track_status_deleted_published`
  - `(status, deleted_at, published_at DESC)`
- `track_comments` 복합 인덱스 추가
  - `idx_track_comment_track_deleted_created`
  - `(track_id, deleted_at, created_at DESC)`
- Entity `@Index`와 Flyway migration에 채택 인덱스 반영
- `V3__add_performance_indexes.sql` 추가
- 실험 결과 악화된 `track_applications(status, created_at DESC)` 인덱스는 제외
- 인덱스 생성 시 운영 환경 영향 최소화를 위해
  `ALTER TABLE ... ADD INDEX ... ALGORITHM=INPLACE, LOCK=NONE` 방식 적용
- 롤백 시 아래 SQL로 인덱스 제거 가능
  ```sql
  DROP INDEX idx_track_status_deleted_published ON tracks;
  DROP INDEX idx_track_comment_track_deleted_created ON track_comments;

### 테스트 및 문서화
- 공개 트랙 목록 ControllerTest를 `SliceResponse` 기준으로 수정
- REST Docs 응답 필드를 `totalElements`, `totalPages`에서 `hasNext` 기준으로 변경
- 공개 트랙 목록 ServiceTest를 `SliceImpl` 기반 mock으로 수정
- `PageResponse` 검증 제거 및 `hasNext` 검증 추가

## 변경 유형
- [x] 성능 개선
- [x] 테스트 코드 수정
- [x] 문서 수정

## 테스트 방법
```bash
./gradlew test --tests "com.fivefy.domain.track.service.TrackServiceTest"
./gradlew test --tests "com.fivefy.domain.track.controller.TrackControllerTest"
./gradlew test
```

주요 확인 시나리오
- `GET /api/tracks` 공개 트랙 목록 조회 성공
- 공개 트랙 목록 응답에서 `hasNext` 반환 확인
- 공개 트랙 목록 응답에서 `totalElements`, `totalPages` 제거 확인
- 공개 트랙 목록 ServiceTest가 `SliceImpl` 기반으로 동작하는지 확인
- REST Docs 응답 필드가 Slice 응답 구조와 일치하는지 확인
- Flyway `V3__add_performance_indexes.sql` 적용 가능 여부 확인

## 체크리스트
- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 공개 트랙 목록 조회 API의 페이지네이션 응답이 업데이트되었습니다. 전체 페이지 수 정보 대신 다음 페이지 존재 여부가 표시됩니다.

* **리팩토링**
  * 트랙 및 댓글 조회 성능을 최적화하기 위한 데이터베이스 인덱스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->