### PR TITLE
refactor : 상태 전이 로직을 상태 객체와 enum으로 위임

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,8 @@ dependencies {
 
     // test
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 
     // querydsl
     implementation 'io.github.openfeign.querydsl:querydsl-core:7.1'
@@ -114,6 +116,11 @@ dependencies {
 tasks.named('test') {
     outputs.dir snippetsDir
     useJUnitPlatform()
+
+    testLogging {
+        events "passed", "failed", "skipped"
+        showStandardStreams = true
+    }
 }
 
 tasks.named('asciidoctor') {

--- a/src/main/java/com/fivefy/domain/cashorder/scheduler/CashOrderScheduler.java
+++ b/src/main/java/com/fivefy/domain/cashorder/scheduler/CashOrderScheduler.java
@@ -8,7 +8,6 @@ import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/fivefy/domain/payment/entity/Payment.java
+++ b/src/main/java/com/fivefy/domain/payment/entity/Payment.java
@@ -121,9 +121,9 @@ public class Payment extends BaseEntity {
      */
     public void refund(String reason) {
         validateNonNull(reason, "환불 사유");
-        this.refundReason = reason;
         this.status.transit(this, PaymentStatus.REFUNDED);
         this.refundedAt = LocalDateTime.now();
+        this.refundReason = reason;
     }
 
     // 실패

--- a/src/main/java/com/fivefy/domain/payment/entity/Payment.java
+++ b/src/main/java/com/fivefy/domain/payment/entity/Payment.java
@@ -1,6 +1,8 @@
     package com.fivefy.domain.payment.entity;
 
     import com.fivefy.common.entity.BaseEntity;
+    import com.fivefy.common.exception.BusinessException;
+    import com.fivefy.domain.payment.enums.PaymentErrorCode;
     import com.fivefy.domain.payment.enums.PaymentStatus;
     import jakarta.persistence.*;
     import lombok.AccessLevel;
@@ -86,10 +88,20 @@
          * 결제 완료 처리 (REQUESTED → COMPLETED)
          * create() 직후 processWebhook()에서 호출
          * 결제시각(paidAt) 기록
+         *
+         * 허용: REQUESTED → COMPLETED (일반 경로)
+         *      COMPLETED → COMPLETED (재호출 허용 — 멱등 처리)
+         * 차단: REFUNDED (환불 완료 후 재결제 불가)
          */
         public void complete() {
+            if (this.status == PaymentStatus.REFUNDED) {
+                throw new BusinessException(PaymentErrorCode.ERR_PAYMENT_INVALID_STATUS_COMPLETE);
+            }
+
             this.status = PaymentStatus.COMPLETED;
-            this.paidAt = LocalDateTime.now();
+            if (this.paidAt == null) {
+                this.paidAt = LocalDateTime.now();  // 최초 완료 시각만 기록
+            }
         }
 
         /**
@@ -102,9 +114,18 @@
         /**
          * 환불 처리 (COMPLETED → REFUNDED)
          * CashOrderService.refund()에서 포트원 취소 API 성공 확인 후 호출
+         *
+         * 허용: REQUESTED → REFUNDED (예외적 강제 환불)
+         *       COMPLETED → REFUNDED (일반 환불 경로)
+         * 차단: REFUNDED (이미 환불 완료)
+         *
          * 환불 이유, 환불 시각 기록
          */
         public void refund(String reason) {
+            if (this.status == PaymentStatus.REFUNDED) {
+                throw new BusinessException(PaymentErrorCode.ERR_PAYMENT_INVALID_STATUS_REFUND);
+            }
+
             validateNonNull(reason, "환불 사유");
             this.status = PaymentStatus.REFUNDED;
             this.refundReason = reason;

--- a/src/main/java/com/fivefy/domain/payment/entity/Payment.java
+++ b/src/main/java/com/fivefy/domain/payment/entity/Payment.java
@@ -1,134 +1,144 @@
-    package com.fivefy.domain.payment.entity;
+package com.fivefy.domain.payment.entity;
 
-    import com.fivefy.common.entity.BaseEntity;
-    import com.fivefy.common.exception.BusinessException;
-    import com.fivefy.domain.payment.enums.PaymentErrorCode;
-    import com.fivefy.domain.payment.enums.PaymentStatus;
-    import jakarta.persistence.*;
-    import lombok.AccessLevel;
-    import lombok.Getter;
-    import lombok.NoArgsConstructor;
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.domain.payment.enums.PaymentStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-    import java.time.LocalDateTime;
+import java.time.LocalDateTime;
 
-    import static com.fivefy.common.util.ValidationUtils.validateNonNull;
+import static com.fivefy.common.util.ValidationUtils.validateNonNull;
 
-    @Entity
-    @Getter
-    @Table(name = "payments")
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public class Payment extends BaseEntity {
+@Entity
+@Getter
+@Table(name = "payments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseEntity {
 
-        @Id
-        @GeneratedValue(strategy = GenerationType.IDENTITY)
-        private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-        @Column(nullable = false)
-        private Long userId;
+    @Column(nullable = false)
+    private Long userId;
 
-        // 음수값 처리는 나중에
-        @Column(nullable = false)
-        private Long amount;
+    // 음수값 처리는 나중에
+    @Column(nullable = false)
+    private Long amount;
 
-        @Enumerated(EnumType.STRING)
-        @Column(nullable = false)
-        private PaymentStatus status;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
 
-        @Column(length = 50, nullable = false)
-        private String orderNumber;     // CashOrder.orderNumber와 연결 (주문번호, 조회·환불 시 사용)
+    @Column(length = 50, nullable = false)
+    private String orderNumber;     // CashOrder.orderNumber와 연결 (주문번호, 조회·환불 시 사용)
 
-        @Column(length = 100, nullable = false, unique = true)
-        private String pgTransactionId; // 포트원 결제 고유 ID — 환불 시 cancelPayment()에 사용
+    @Column(length = 100, nullable = false, unique = true)
+    private String pgTransactionId; // 포트원 결제 고유 ID — 환불 시 cancelPayment()에 사용
 
-        @Column(length = 100, nullable = false, unique = true)
-        private String webhookId;       // 멱등키 — CashOrder.webhookId와 동일값, 중복 처리 방지
+    @Column(length = 100, nullable = false, unique = true)
+    private String webhookId;       // 멱등키 — CashOrder.webhookId와 동일값, 중복 처리 방지
 
-        @Column(length = 500)
-        private String refundReason;    // 환불 사유 (결제 시 null, 환불 시 기록)
+    @Column(length = 500)
+    private String refundReason;    // 환불 사유 (결제 시 null, 환불 시 기록)
 
-        private LocalDateTime paidAt;       // 결제 완료 시각 (환불이면 null)
-        private LocalDateTime refundedAt;   // 환불 완료 시각 (결제면 null)
+    private LocalDateTime paidAt;       // 결제 완료 시각 (환불이면 null)
+    private LocalDateTime refundedAt;   // 환불 완료 시각 (결제면 null)
 
-        /**
-         * 결제 기록
-         * processWebhook()에서 금액 검증 통과 후 호출
-         * @param userId            : 유저 ID
-         * @param amount            : 금액(원화 기준 : Long 통일)
-         *        status            : 상태(결제 요청(기본), 보류, 승인, 결제 완료, 실패, 취소, 환불)
-         *        refundReason      : 환불사유 (글자 500 제한), 결제면 null
-         * @param orderNumber       : 주문해서 구매한 포인트 패키지(실제돈->포인트) 주문 번호
-         * @param pgTransactionId   : 포트원의 결제 ID (단건 조회, 취소에 사용)
-         * @param webhookId         : 포트원 웹훅 고유 ID (멱등키, 중복 결제 방지)
-         *        paidAt            : 결제 시각 : 환불이면 null
-         *        refundedAt        : 환불 시각 : 결제면 null
-         * @return
-         */
-        public static Payment create(Long userId, Long amount, String orderNumber, String pgTransactionId, String webhookId) {
-            validateNonNull(userId, "orderId");
-            validateNonNull(amount, "amount");
-            validateNonNull(orderNumber, "orderNumber");
-            validateNonNull(pgTransactionId, "pgTransactionId");
-            validateNonNull(webhookId, "webhookId");
+    /**
+     * 결제 기록
+     * processWebhook()에서 금액 검증 통과 후 호출
+     * @param userId            : 유저 ID
+     * @param amount            : 금액(원화 기준 : Long 통일)
+     *        status            : 상태(결제 요청(기본), 보류, 승인, 결제 완료, 실패, 취소, 환불)
+     *        refundReason      : 환불사유 (글자 500 제한), 결제면 null
+     * @param orderNumber       : 주문해서 구매한 포인트 패키지(실제돈->포인트) 주문 번호
+     * @param pgTransactionId   : 포트원의 결제 ID (단건 조회, 취소에 사용)
+     * @param webhookId         : 포트원 웹훅 고유 ID (멱등키, 중복 결제 방지)
+     *        paidAt            : 결제 시각 : 환불이면 null
+     *        refundedAt        : 환불 시각 : 결제면 null
+     * @return
+     */
+    public static Payment create(Long userId, Long amount, String orderNumber, String pgTransactionId, String webhookId) {
+        validateNonNull(userId, "orderId");
+        validateNonNull(amount, "amount");
+        validateNonNull(orderNumber, "orderNumber");
+        validateNonNull(pgTransactionId, "pgTransactionId");
+        validateNonNull(webhookId, "webhookId");
 
-            Payment payment = new Payment();
-                payment.userId = userId;
-                payment.amount = amount;
-                payment.orderNumber = orderNumber;
-                payment.status = PaymentStatus.REQUESTED;
-                payment.refundReason = null;
-                payment.pgTransactionId = pgTransactionId;
-                payment.webhookId =  webhookId;   // 멱등키 idempotencyKey
-                payment.paidAt = null;            // complete() 호출 시 기록
-                payment.refundedAt = null;        // refund() 호출 시 기록
+        Payment payment = new Payment();
+            payment.userId = userId;
+            payment.amount = amount;
+            payment.orderNumber = orderNumber;
+            payment.status = PaymentStatus.REQUESTED;
+            payment.refundReason = null;
+            payment.pgTransactionId = pgTransactionId;
+            payment.webhookId = webhookId;   // 멱등키 idempotencyKey
+            payment.paidAt = null;            // complete() 호출 시 기록
+            payment.refundedAt = null;        // refund() 호출 시 기록
 
-            return payment;
-        }
+        return payment;
+    }
+    /**
+     * 결제 완료 처리 (REQUESTED → COMPLETED)
+     * create() 직후 processWebhook()에서 호출
+     * 결제시각(paidAt) 기록
+     *
+     * 허용: REQUESTED → COMPLETED (일반 경로)
+     *      COMPLETED → COMPLETED (재호출 허용 — 멱등 처리)
+     * 차단: REFUNDED (환불 완료 후 재결제 불가)
+     *
+     * 조건 검사는 PaymentStatus.canTransitTo()가 담당
+     */
+    public void complete() {
+        // 조건 검사
+        this.status.transit(this, PaymentStatus.COMPLETED);
 
-        /**
-         * 결제 완료 처리 (REQUESTED → COMPLETED)
-         * create() 직후 processWebhook()에서 호출
-         * 결제시각(paidAt) 기록
-         *
-         * 허용: REQUESTED → COMPLETED (일반 경로)
-         *      COMPLETED → COMPLETED (재호출 허용 — 멱등 처리)
-         * 차단: REFUNDED (환불 완료 후 재결제 불가)
-         */
-        public void complete() {
-            if (this.status == PaymentStatus.REFUNDED) {
-                throw new BusinessException(PaymentErrorCode.ERR_PAYMENT_INVALID_STATUS_COMPLETE);
-            }
-
-            this.status = PaymentStatus.COMPLETED;
-            if (this.paidAt == null) {
-                this.paidAt = LocalDateTime.now();  // 최초 완료 시각만 기록
-            }
-        }
-
-        /**
-         * 결제 실패 시(아마 안쓸 거 같음. 필요 없으면 지우자) : (미적용)(2026-04-17)
-         */
-        public void fail() {
-            this.status = PaymentStatus.FAILED;
-        }
-
-        /**
-         * 환불 처리 (COMPLETED → REFUNDED)
-         * CashOrderService.refund()에서 포트원 취소 API 성공 확인 후 호출
-         *
-         * 허용: REQUESTED → REFUNDED (예외적 강제 환불)
-         *       COMPLETED → REFUNDED (일반 환불 경로)
-         * 차단: REFUNDED (이미 환불 완료)
-         *
-         * 환불 이유, 환불 시각 기록
-         */
-        public void refund(String reason) {
-            if (this.status == PaymentStatus.REFUNDED) {
-                throw new BusinessException(PaymentErrorCode.ERR_PAYMENT_INVALID_STATUS_REFUND);
-            }
-
-            validateNonNull(reason, "환불 사유");
-            this.status = PaymentStatus.REFUNDED;
-            this.refundReason = reason;
-            this.refundedAt = LocalDateTime.now();
+        if (this.paidAt == null) {
+            this.paidAt = LocalDateTime.now();  // 최초 완료 시각만 기록
         }
     }
+
+    /**
+     * 결제 실패 시(아마 안쓸 거 같음. 필요 없으면 지우자) : (미적용)(2026-04-17)
+     */
+    public void fail() {
+        this.status.transit(this, PaymentStatus.FAILED);
+    }
+    /**
+     * 환불 처리 (COMPLETED → REFUNDED)
+     * CashOrderService.refund()에서 포트원 취소 API 성공 확인 후 호출
+     *
+     * 허용: REQUESTED → REFUNDED (예외적 강제 환불)
+     *       COMPLETED → REFUNDED (일반 환불 경로)
+     * 차단: REFUNDED (이미 환불 완료)
+     *
+     * 환불 이유, 환불 시각 기록
+     *
+     *  조건 검사는 PaymentStatus.canTransitTo()가 담당
+     */
+    public void refund(String reason) {
+        validateNonNull(reason, "환불 사유");
+        this.refundReason = reason;
+        this.status.transit(this, PaymentStatus.REFUNDED);
+        this.refundedAt = LocalDateTime.now();
+    }
+
+    // 실패
+    public void applyFail() {
+        this.status = PaymentStatus.FAILED;
+    }
+
+    // 환불
+    public void applyRefund() {
+        this.status = PaymentStatus.REFUNDED;
+        this.refundedAt = LocalDateTime.now();
+    }
+
+    // 성공
+    public void applyComplete() {
+        this.status = PaymentStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/fivefy/domain/payment/enums/PaymentErrorCode.java
+++ b/src/main/java/com/fivefy/domain/payment/enums/PaymentErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum PaymentErrorCode implements ErrorCode {
 
     ERR_PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 결제 내역입니다"),
-    ERR_PAYMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 결제만 조회 가능합니다");
+    ERR_PAYMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 결제만 조회 가능합니다"),
+    ERR_PAYMENT_INVALID_STATUS_COMPLETE(HttpStatus.BAD_REQUEST, "환불된 결제는 완료 처리할 수 없습니다"),
+    ERR_PAYMENT_INVALID_STATUS_REFUND(HttpStatus.BAD_REQUEST, "이미 환불된 결제입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/payment/enums/PaymentErrorCode.java
+++ b/src/main/java/com/fivefy/domain/payment/enums/PaymentErrorCode.java
@@ -12,7 +12,9 @@ public enum PaymentErrorCode implements ErrorCode {
     ERR_PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 결제 내역입니다"),
     ERR_PAYMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 결제만 조회 가능합니다"),
     ERR_PAYMENT_INVALID_STATUS_COMPLETE(HttpStatus.BAD_REQUEST, "환불된 결제는 완료 처리할 수 없습니다"),
-    ERR_PAYMENT_INVALID_STATUS_REFUND(HttpStatus.BAD_REQUEST, "이미 환불된 결제입니다");
+    ERR_PAYMENT_INVALID_STATUS_REFUND(HttpStatus.BAD_REQUEST, "이미 환불된 결제입니다"),
+    ERR_PAYMENT_INVALID_TRANSITION(HttpStatus.BAD_REQUEST, "허용되지 않는 결제 상태 전이입니다");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/fivefy/domain/payment/enums/PaymentStatus.java
@@ -10,11 +10,13 @@ public enum PaymentStatus {
     REQUESTED {
         @Override
         public boolean canTransitTo(PaymentStatus target) {
+
             return target == COMPLETED || target == FAILED;
         }
 
         @Override
         public void transit(Payment payment, PaymentStatus target) {
+
             validate(target);
             if (target == COMPLETED) {
                 payment.applyComplete();
@@ -31,11 +33,13 @@ public enum PaymentStatus {
     HOLD {
         @Override
         public boolean canTransitTo(PaymentStatus target) {
+
             return false;
         }
 
         @Override
         public void transit(Payment payment, PaymentStatus target) {
+
             validate(target);
         }
     },        // 보류
@@ -45,11 +49,13 @@ public enum PaymentStatus {
     APPROVED {
         @Override
         public boolean canTransitTo(PaymentStatus target) {
+
             return false;
         }
 
         @Override
         public void transit(Payment payment, PaymentStatus target) {
+
             validate(target);
         }
     },
@@ -59,13 +65,19 @@ public enum PaymentStatus {
     COMPLETED {
         @Override
         public boolean canTransitTo(PaymentStatus target) {
-            return target == REFUNDED;
+
+            // 포트원은 웹훅을 성공 응답을 받을 때까지 재전송
+            return target == REFUNDED || target == COMPLETED;   // 멱등 허용
         }
 
         @Override
         public void transit(Payment payment, PaymentStatus target) {
+
             validate(target);
-            payment.applyRefund();
+            // 환불 요청 시
+            if (target == REFUNDED) {
+                payment.applyRefund();
+            }
         }
     },
     /**
@@ -74,11 +86,13 @@ public enum PaymentStatus {
     FAILED {
         @Override
         public boolean canTransitTo(PaymentStatus target) {
+
             return false; // 실패 후 전이 없음
         }
 
         @Override
         public void transit(Payment payment, PaymentStatus target) {
+
             validate(target);
         }
     },     
@@ -89,11 +103,13 @@ public enum PaymentStatus {
     CANCELED {
         @Override
         public boolean canTransitTo(PaymentStatus target) {
+
             return false;
         }
 
         @Override
         public void transit(Payment payment, PaymentStatus target) {
+
             validate(target);
         }
     },    
@@ -104,20 +120,23 @@ public enum PaymentStatus {
     REFUNDED {
         @Override
         public boolean canTransitTo(PaymentStatus target) {
+
             return false; // 환불 후 전이 없음
         }
 
         @Override
         public void transit(Payment payment, PaymentStatus target) {
+
             validate(target);
         }
     };
 
 
-
+    // 조건 확인
     public abstract boolean canTransitTo(
             PaymentStatus target
     );
+    // 변경
     public abstract void transit(
             Payment payment, PaymentStatus target
     );

--- a/src/main/java/com/fivefy/domain/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/fivefy/domain/payment/enums/PaymentStatus.java
@@ -3,8 +3,8 @@ package com.fivefy.domain.payment.enums;
 public enum PaymentStatus {
     REQUESTED,   // 결제 요청
     HOLD,        // 보류
-    APPROVED,    // 승인
-    COMPLETED,   // 결제 완료
+    APPROVED,    // 승인      : PG사가 결제를 승인했지만 아직 최종 확정 전 단계(잘 안씀)
+    COMPLETED,   // 결제 완료  : 서버에서 금액 검증, 웹훅 처리까지 모두 마친 최종 완료 상태
     FAILED,      // 실패
     CANCELED,    // 취소
     REFUNDED     // 환불

--- a/src/main/java/com/fivefy/domain/payment/enums/PaymentStatus.java
+++ b/src/main/java/com/fivefy/domain/payment/enums/PaymentStatus.java
@@ -1,11 +1,131 @@
 package com.fivefy.domain.payment.enums;
 
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.payment.entity.Payment;
+
 public enum PaymentStatus {
-    REQUESTED,   // 결제 요청
-    HOLD,        // 보류
-    APPROVED,    // 승인      : PG사가 결제를 승인했지만 아직 최종 확정 전 단계(잘 안씀)
-    COMPLETED,   // 결제 완료  : 서버에서 금액 검증, 웹훅 처리까지 모두 마친 최종 완료 상태
-    FAILED,      // 실패
-    CANCELED,    // 취소
-    REFUNDED     // 환불
+    /**
+     * 결제 요청
+     */
+    REQUESTED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return target == COMPLETED || target == FAILED;
+        }
+
+        @Override
+        public void transit(Payment payment, PaymentStatus target) {
+            validate(target);
+            if (target == COMPLETED) {
+                payment.applyComplete();
+            } else {
+                payment.applyFail();
+            }
+        }
+    },   
+
+    /**
+     * 보류
+     * 현재 사용 위치는 0
+     */
+    HOLD {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return false;
+        }
+
+        @Override
+        public void transit(Payment payment, PaymentStatus target) {
+            validate(target);
+        }
+    },        // 보류
+    /**
+     * 승인 : PG사가 결제를 승인했지만 아직 최종 확정 전 단계(잘 안씀)
+     */
+    APPROVED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return false;
+        }
+
+        @Override
+        public void transit(Payment payment, PaymentStatus target) {
+            validate(target);
+        }
+    },
+    /**
+     * 결제 완료  : 서버에서 금액 검증, 웹훅 처리까지 모두 마친 최종 완료 상태
+     */
+    COMPLETED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return target == REFUNDED;
+        }
+
+        @Override
+        public void transit(Payment payment, PaymentStatus target) {
+            validate(target);
+            payment.applyRefund();
+        }
+    },
+    /**
+     * 실패
+     */
+    FAILED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return false; // 실패 후 전이 없음
+        }
+
+        @Override
+        public void transit(Payment payment, PaymentStatus target) {
+            validate(target);
+        }
+    },     
+
+    /**
+     * 취소
+     */
+    CANCELED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return false;
+        }
+
+        @Override
+        public void transit(Payment payment, PaymentStatus target) {
+            validate(target);
+        }
+    },    
+
+    /**
+     * 환불
+     */
+    REFUNDED {
+        @Override
+        public boolean canTransitTo(PaymentStatus target) {
+            return false; // 환불 후 전이 없음
+        }
+
+        @Override
+        public void transit(Payment payment, PaymentStatus target) {
+            validate(target);
+        }
+    };
+
+
+
+    public abstract boolean canTransitTo(
+            PaymentStatus target
+    );
+    public abstract void transit(
+            Payment payment, PaymentStatus target
+    );
+
+    // 전이 가능 여부 공통 검증 — 각 상태의 transit()에서 호출
+    protected void validate(PaymentStatus target) {
+        if (!canTransitTo(target)) {
+            throw new BusinessException(PaymentErrorCode.ERR_PAYMENT_INVALID_TRANSITION);
+        }
+    }
 }

--- a/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
@@ -5,6 +5,7 @@ import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.subscription.enums.SubscriptionErrorCode;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
+import com.fivefy.domain.subscription.state.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -36,7 +37,7 @@ public class Subscription extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private SubscriptionStatus status; // ACTIVE / INACTIVE / CANCELED / EXPIRE
+    private SubscriptionStatus status; // ACTIVE / INACTIVE / CANCELED / EXPIRE / CANCELED / REFUND
 
     @Column(nullable = false)
     private LocalDateTime startDate; // 구매 시점
@@ -89,6 +90,8 @@ public class Subscription extends BaseEntity {
         return subscription;
     }
 
+    // 2026-04-30 : 상태 패턴 적용. if문 → state() 교체
+
     /**
      * 구독 취소 - 다음 결제 중단, 만료일까지 이용 가능
      *
@@ -96,16 +99,19 @@ public class Subscription extends BaseEntity {
      * 차단: CANCELED (이미 취소), EXPIRE (이미 만료)
      * 제약: FREE(무료) 플랜 취소 불가, RECURRING(정기 구독) 플랜만 가능
      */
+//    public void cancel() {
+//        if (this.planType == SubscriptionPlanType.FREE) {
+//            throw new BusinessException(SubscriptionErrorCode.ERR_FREE_SUBSCRIPTION_CANNOT_CANCEL);
+//        }
+//        if (this.status != SubscriptionStatus.ACTIVE && this.status != SubscriptionStatus.INACTIVE) {
+//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL);
+//        }
+//
+//        this.status = SubscriptionStatus.CANCELED;
+//        this.nextBillingDate = null;
+//    }
     public void cancel() {
-        if (this.planType == SubscriptionPlanType.FREE) {
-            throw new BusinessException(SubscriptionErrorCode.ERR_FREE_SUBSCRIPTION_CANNOT_CANCEL);
-        }
-        if (this.status != SubscriptionStatus.ACTIVE && this.status != SubscriptionStatus.INACTIVE) {
-            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL);
-        }
-
-        this.status = SubscriptionStatus.CANCELED;
-        this.nextBillingDate = null;
+        state().cancel(this);
     }
 
     /**
@@ -116,13 +122,16 @@ public class Subscription extends BaseEntity {
      *
      * 만료 이후 재구독은 별개의 Subscription 객체를 생성한다.
      */
+//    public void expire() {
+//        if (this.status == SubscriptionStatus.EXPIRE) {
+//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_EXPIRED);
+//        }
+//
+//        this.status = SubscriptionStatus.EXPIRE;
+//        this.nextBillingDate = null;
+//    }
     public void expire() {
-        if (this.status == SubscriptionStatus.EXPIRE) {
-            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_EXPIRED);
-        }
-
-        this.status = SubscriptionStatus.EXPIRE;
-        this.nextBillingDate = null;
+        state().expire(this);
     }
 
     /**
@@ -133,16 +142,52 @@ public class Subscription extends BaseEntity {
      * 허용: ACTIVE + nextBillingDate 존재
      * 차단: FREE 플랜, 취소된 구독 (nextBillingDate = null)
      */
+//    public void renew() {
+//        if (this.planType != SubscriptionPlanType.RECURRING) {
+//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_RECURRING);
+//        }
+//
+//        if (this.nextBillingDate == null) {
+//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
+//        }
+//
+//        this.nextBillingDate = this.nextBillingDate.plusMonths(1);
+//        this.expiryDate      = this.expiryDate.plusMonths(1);
+//        this.status          = SubscriptionStatus.ACTIVE;
+//    }
+
     public void renew() {
-        if (this.planType != SubscriptionPlanType.RECURRING) {
-            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_RECURRING);
-        }
-        if (this.nextBillingDate == null) {
-            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
-        }
+        state().renew(this);
+    }
+    
+    /**
+     * 서비스에서 읽어옴
+     *      → subscriptionRepository.findByUserIdAndPlanTypeAndStatus(...)
+     *  DB에서 status를 가져와서 적용해봄
+     * @return
+     */
+    private SubscriptionState state() {
+        return switch (this.status) {
+            case ACTIVE -> ActiveState.INSTANCE;
+            case INACTIVE -> InactiveState.INSTANCE;
+            case CANCELED -> CanceledState.INSTANCE;
+            case EXPIRE -> ExpiredState.INSTANCE;
+            default -> throw new IllegalStateException("Unsupported status: " + this.status);
+        };
+    }
+
+
+    public void changeStatus(SubscriptionStatus status) {
+        this.status = status;
+    }
+
+    public void clearNextBillingDate() {
+        this.nextBillingDate = null;
+    }
+
+    public void extendOneMonth() {
+        this.expiryDate = this.expiryDate.plusMonths(1);
         this.nextBillingDate = this.nextBillingDate.plusMonths(1);
-        this.expiryDate      = this.expiryDate.plusMonths(1);
-        this.status          = SubscriptionStatus.ACTIVE;
     }
 
     /**

--- a/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
@@ -91,7 +91,10 @@ public class Subscription extends BaseEntity {
 
     /**
      * 구독 취소 - 다음 결제 중단, 만료일까지 이용 가능
-     * FREE 취소 불가, ACTIVE 상태에서만 가능
+     *
+     * 허용: ACTIVE, INACTIVE
+     * 차단: CANCELED (이미 취소), EXPIRE (이미 만료)
+     * 제약: FREE(무료) 플랜 취소 불가, RECURRING(정기 구독) 플랜만 가능
      */
     public void cancel() {
         if (this.planType == SubscriptionPlanType.FREE) {
@@ -107,8 +110,17 @@ public class Subscription extends BaseEntity {
 
     /**
      * 만료 처리 (스케줄러 또는 정기 결제 실패 시 호출)
+     *
+     * 허용: ACTIVE, CANCELED (취소 후 만료일 지나면 만료 처리)
+     * 차단: EXPIRE (이미 만료된 구독 재호출 차단)
+     *
+     * 만료 이후 재구독은 별개의 Subscription 객체를 생성한다.
      */
     public void expire() {
+        if (this.status == SubscriptionStatus.EXPIRE) {
+            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_EXPIRED);
+        }
+
         this.status = SubscriptionStatus.EXPIRE;
         this.nextBillingDate = null;
     }
@@ -117,6 +129,9 @@ public class Subscription extends BaseEntity {
      * 정기 구독 갱신 (RECURRING 전용)
      * expiryDate      += 1개월
      * nextBillingDate  = 새 expiryDate 당일 00:00
+     *
+     * 허용: ACTIVE + nextBillingDate 존재
+     * 차단: FREE 플랜, 취소된 구독 (nextBillingDate = null)
      */
     public void renew() {
         if (this.planType != SubscriptionPlanType.RECURRING) {

--- a/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
@@ -172,7 +172,8 @@ public class Subscription extends BaseEntity {
             case INACTIVE -> InactiveState.INSTANCE;
             case CANCELED -> CanceledState.INSTANCE;
             case EXPIRE -> ExpiredState.INSTANCE;
-            default -> throw new IllegalStateException("Unsupported status: " + this.status);
+            // FREE, REFUND 상태는 cancel/expire/renew 호출 자체가 잘못된 요청
+            default -> throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_UNSUPPORTED_STATUS);
         };
     }
 

--- a/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
+++ b/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
@@ -14,7 +14,8 @@ public enum SubscriptionErrorCode implements ErrorCode {
     ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL(HttpStatus.BAD_REQUEST, "활성 또는 비활성 상태에서만 취소할 수 있습니다"),
     ERR_SUBSCRIPTION_NOT_RECURRING(HttpStatus.BAD_REQUEST, "RECURRING 플랜만 갱신할 수 있습니다"),
     ERR_SUBSCRIPTION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "취소된 구독은 갱신할 수 없습니다"),
-    ERR_SUBSCRIPTION_ALREADY_EXPIRED(HttpStatus.BAD_REQUEST, "이미 만료된 구독입니다");
+    ERR_SUBSCRIPTION_ALREADY_EXPIRED(HttpStatus.BAD_REQUEST, "이미 만료된 구독입니다"),
+    ERR_SUBSCRIPTION_UNSUPPORTED_STATUS(HttpStatus.BAD_REQUEST, "해당 구독 상태에서는 지원하지 않는 작업입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
+++ b/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
@@ -13,7 +13,8 @@ public enum SubscriptionErrorCode implements ErrorCode {
     ERR_FREE_SUBSCRIPTION_CANNOT_CANCEL(HttpStatus.BAD_REQUEST, "무료 구독은 취소할 수 없습니다"),
     ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL(HttpStatus.BAD_REQUEST, "활성 또는 비활성 상태에서만 취소할 수 있습니다"),
     ERR_SUBSCRIPTION_NOT_RECURRING(HttpStatus.BAD_REQUEST, "RECURRING 플랜만 갱신할 수 있습니다"),
-    ERR_SUBSCRIPTION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "취소된 구독은 갱신할 수 없습니다");
+    ERR_SUBSCRIPTION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "취소된 구독은 갱신할 수 없습니다"),
+    ERR_SUBSCRIPTION_ALREADY_EXPIRED(HttpStatus.BAD_REQUEST, "이미 만료된 구독입니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionStatus.java
+++ b/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionStatus.java
@@ -1,7 +1,7 @@
 package com.fivefy.domain.subscription.enums;
 
 public enum SubscriptionStatus {
-    FREE,      // 체험 (구독 플랜 타입 : FREE)
+    FREE,       // 체험 (구독 플랜 타입 : FREE)
     ACTIVE,     // 활성
     INACTIVE,   // 비활성화 (결제 완료 했으나, 활성화 안 함)
     EXPIRE,     // 만료

--- a/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
@@ -29,7 +29,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
     // 구독 만료 스케줄러용 — 만료일이 지난 활성화 구독 조회
     // (dataTime -> now) ,활성화와 비활성화 둘 모두 체크했으나, 비활성화는 고려할 필요도 없다)
-    List<Subscription> findAllByStatusAndExpiryDateBefore(
+    List<Subscription> findAllByStatusInAndExpiryDateBefore(
             // SubscriptionStatus status,
             List<SubscriptionStatus> statuses,
             LocalDateTime now

--- a/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
@@ -30,7 +30,8 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
     // 구독 만료 스케줄러용 — 만료일이 지난 활성화 구독 조회
     // (dataTime -> now) ,활성화와 비활성화 둘 모두 체크했으나, 비활성화는 고려할 필요도 없다)
     List<Subscription> findAllByStatusAndExpiryDateBefore(
-            SubscriptionStatus status,
+            // SubscriptionStatus status,
+            List<SubscriptionStatus> statuses,
             LocalDateTime now
     );
 

--- a/src/main/java/com/fivefy/domain/subscription/scheduler/SubscriptionScheduler.java
+++ b/src/main/java/com/fivefy/domain/subscription/scheduler/SubscriptionScheduler.java
@@ -7,11 +7,13 @@ import com.fivefy.domain.subscription.entity.Subscription;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.repository.SubscriptionRepository;
+import com.fivefy.domain.subscription.service.SubscriptionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,12 +26,14 @@ public class SubscriptionScheduler {
     private final SubscriptionRepository subscriptionRepository;
     private final PointOrderService pointOrderService;
     private final ApplicationEventPublisher eventPublisher;
+    private final SubscriptionService subscriptionService;
 
     /**
      * 정기 구독 결제
      * 매월 1일 09:00
      * 대상: RECURRING + ACTIVE + nextBillingDate 지난 구독
      */
+    @Transactional
     @Scheduled(cron = "${scheduler.subscription-cron}")
     public void processRecurringPayments() {
         LocalDateTime now = LocalDateTime.now();
@@ -65,15 +69,25 @@ public class SubscriptionScheduler {
      * 구독 만료 처리
      * 매일 00:00
      * 대상: expiryDate 지난 ACTIVE 구독
+     *
+     * 트랜젝션은 건별로 붙임(subscriptionService.expireOne())
      */
     @Scheduled(cron = "0 0 0 * * *")
     public void expireSubscriptions() {
         LocalDateTime now = LocalDateTime.now();
         log.info("[만료 스케줄러] 실행 시작 — {}", now);
 
+        // 기존 활성화 조회 → 활성화, 취소 조회
+        /**
+         * (기존) 활성화 조회
+         * (수정) 활성화, 취소 조회
+         * 이유 : 활성화 시 취소하는 경우 ACTIVE → 취소 → CANCELED → 만료일 경과 → EXPIRE
+         * 이때, CANCELED를 조회하지 않으면 상태값이 만료되지 않고 CANCELED에 남기에 수정함
+         */
         List<Subscription> expiredTargets = subscriptionRepository
                 .findAllByStatusAndExpiryDateBefore(
-                        SubscriptionStatus.ACTIVE,
+                        // SubscriptionStatus.ACTIVE,
+                        List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED),
                         now
                 );
 
@@ -81,8 +95,8 @@ public class SubscriptionScheduler {
 
         for (Subscription subscription : expiredTargets) {
             try {
-                subscription.expire();
-                subscriptionRepository.save(subscription);
+                subscriptionService.expireOne(subscription.getId()); // 건별 트랜잭션
+                // subscriptionRepository.save(subscription);
 
                 eventPublisher.publishEvent(NotificationEvent.of(
                         subscription.getUserId(),

--- a/src/main/java/com/fivefy/domain/subscription/scheduler/SubscriptionScheduler.java
+++ b/src/main/java/com/fivefy/domain/subscription/scheduler/SubscriptionScheduler.java
@@ -85,7 +85,7 @@ public class SubscriptionScheduler {
          * 이때, CANCELED를 조회하지 않으면 상태값이 만료되지 않고 CANCELED에 남기에 수정함
          */
         List<Subscription> expiredTargets = subscriptionRepository
-                .findAllByStatusAndExpiryDateBefore(
+                .findAllByStatusInAndExpiryDateBefore(
                         // SubscriptionStatus.ACTIVE,
                         List.of(SubscriptionStatus.ACTIVE, SubscriptionStatus.CANCELED),
                         now

--- a/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
@@ -44,6 +44,7 @@ public class SubscriptionService {
      * 포인트 반환 없음
      * nextBillingDate → null, status → CANCELED
      * 만료일(expiryDate)까지는 이용 가능
+     * 구독 취소 : 활성화 -> 취소 : 정기 구독 취소 상태. 만료일이 되면 만료 상태로 변경
      * @param userId
      */
     @Transactional
@@ -62,5 +63,14 @@ public class SubscriptionService {
                 NotificationType.SUBSCRIPTION_CANCEL,
                 "구독 취소 성공"
         ));
+    }
+
+    // 건별 만료 처리 — 스케줄러에서 호출
+    // 기존의 엔티티 안의 매서드 expire() 기능을 트랜젝션 안에 넣어서 실행
+    @Transactional
+    public void expireOne(Long subscriptionId) {
+        Subscription subscription = subscriptionRepository.findById(subscriptionId)
+                .orElseThrow(() -> new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_FOUND));
+        subscription.expire();
     }
 }

--- a/src/main/java/com/fivefy/domain/subscription/state/ActiveState.java
+++ b/src/main/java/com/fivefy/domain/subscription/state/ActiveState.java
@@ -1,0 +1,61 @@
+package com.fivefy.domain.subscription.state;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.subscription.entity.Subscription;
+import com.fivefy.domain.subscription.enums.*;
+
+/**
+ *
+ */
+public class ActiveState implements SubscriptionState {
+
+    // 싱글턴 방식 : 생성자가 여러 차례 호출되더라도 실제로 생성되는 객체는 하나
+        // 최초 생성 이후에 호출된 생성자는 최초의 생성자가 생성한 객체를 리턴
+    // 클래스 로드 시 객체 생성 : static 영역에 객체를 딱 1개만 생성
+    public static final ActiveState INSTANCE = new ActiveState();
+    // 외부에서 new로 객체 생성 못하게 막음
+    private ActiveState() {}
+
+    /**
+     * ACTIVE → CANCELED
+     * - FREE 플랜은 취소 불가
+     * - 정상적인 취소 흐름
+     */
+    @Override
+    public void cancel(Subscription subscription) {
+        if (subscription.getPlanType() == SubscriptionPlanType.FREE) {
+            throw new BusinessException(SubscriptionErrorCode.ERR_FREE_SUBSCRIPTION_CANNOT_CANCEL);
+        }
+
+        subscription.changeStatus(SubscriptionStatus.CANCELED);
+        subscription.clearNextBillingDate(); // 자동 결제 중단
+    }
+
+    /**
+     * ACTIVE → EXPIRE
+     * - 만료 시 자동 결제 중단
+     */
+    @Override
+    public void expire(Subscription subscription) {
+        subscription.changeStatus(SubscriptionStatus.EXPIRE);
+        subscription.clearNextBillingDate();
+    }
+
+    /**
+     * ACTIVE 유지 + 기간 연장
+     * - RECURRING 플랜만 가능
+     * - nextBillingDate 없으면 이미 취소된 상태
+     */
+    @Override
+    public void renew(Subscription subscription) {
+        if (subscription.getPlanType() != SubscriptionPlanType.RECURRING) {
+            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_RECURRING);
+        }
+
+        if (subscription.getNextBillingDate() == null) {
+            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
+        }
+
+        subscription.extendOneMonth();
+    }
+}

--- a/src/main/java/com/fivefy/domain/subscription/state/CanceledState.java
+++ b/src/main/java/com/fivefy/domain/subscription/state/CanceledState.java
@@ -1,0 +1,40 @@
+package com.fivefy.domain.subscription.state;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.subscription.entity.Subscription;
+import com.fivefy.domain.subscription.enums.*;
+
+public class CanceledState implements SubscriptionState {
+
+    // 클래스 로드 시 객체 생성
+    public static final CanceledState INSTANCE = new CanceledState();
+
+    // 외부에서 new 못하게 막음
+    private CanceledState() {}
+
+    /**
+     * 이미 취소된 상태 → 재취소 불가
+     */
+    @Override
+    public void cancel(Subscription subscription) {
+        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL);
+    }
+
+    /**
+     * 취소 → 만료
+     * - 취소 후 기간 종료 시 만료 처리
+     * - 취소 = 정기 구독 취소(다음 갱신일 null)
+     */
+    @Override
+    public void expire(Subscription subscription) {
+        subscription.changeStatus(SubscriptionStatus.EXPIRE);
+    }
+
+    /**
+     * 취소된 구독은 갱신 불가
+     */
+    @Override
+    public void renew(Subscription subscription) {
+        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
+    }
+}

--- a/src/main/java/com/fivefy/domain/subscription/state/ExpiredState.java
+++ b/src/main/java/com/fivefy/domain/subscription/state/ExpiredState.java
@@ -1,0 +1,32 @@
+package com.fivefy.domain.subscription.state;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.subscription.entity.Subscription;
+import com.fivefy.domain.subscription.enums.*;
+
+public class ExpiredState implements SubscriptionState {
+
+    // 클래스 로드 시 객체 생성
+    public static final ExpiredState INSTANCE = new ExpiredState();
+
+    // 외부에서 new 못하게 막음
+    private ExpiredState() {}
+
+    /**
+     * 만료 상태에서는 어떤 행동도 불가
+     */
+    @Override
+    public void cancel(Subscription subscription) {
+        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL);
+    }
+
+    @Override
+    public void expire(Subscription subscription) {
+        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_EXPIRED);
+    }
+
+    @Override
+    public void renew(Subscription subscription) {
+        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
+    }
+}

--- a/src/main/java/com/fivefy/domain/subscription/state/ExpiredState.java
+++ b/src/main/java/com/fivefy/domain/subscription/state/ExpiredState.java
@@ -13,20 +13,30 @@ public class ExpiredState implements SubscriptionState {
     private ExpiredState() {}
 
     /**
+     * 만료 상태에서 취소
      * 만료 상태에서는 어떤 행동도 불가
+     * @param subscription
      */
     @Override
     public void cancel(Subscription subscription) {
         throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL);
     }
 
+    /**
+     * 만료 상태에서 만료
+     * @param subscription
+     */
     @Override
     public void expire(Subscription subscription) {
         throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_EXPIRED);
     }
 
+    /**
+     * 만료 상태에서 재갱신
+     * @param subscription
+     */
     @Override
     public void renew(Subscription subscription) {
-        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
+        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_EXPIRED);
     }
 }

--- a/src/main/java/com/fivefy/domain/subscription/state/InactiveState.java
+++ b/src/main/java/com/fivefy/domain/subscription/state/InactiveState.java
@@ -1,0 +1,40 @@
+package com.fivefy.domain.subscription.state;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.subscription.entity.Subscription;
+import com.fivefy.domain.subscription.enums.*;
+
+public class InactiveState implements SubscriptionState {
+
+    // 클래스 로드 시 객체 생성
+    public static final InactiveState INSTANCE = new InactiveState();
+
+    // 외부에서 new 못하게 막음
+    private InactiveState() {}
+
+    /**
+     * 비활성화 → 취소
+     * - 아직 활성화 안된 구독 취소 가능
+     */
+    @Override
+    public void cancel(Subscription subscription) {
+        subscription.changeStatus(SubscriptionStatus.CANCELED);
+        subscription.clearNextBillingDate();
+    }
+
+    /**
+     * 비활성화 → 만료
+     */
+    @Override
+    public void expire(Subscription subscription) {
+        subscription.changeStatus(SubscriptionStatus.EXPIRE);
+    }
+
+    /**
+     * 비활성화 상태에서는 갱신 불가
+     */
+    @Override
+    public void renew(Subscription subscription) {
+        throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
+    }
+}

--- a/src/main/java/com/fivefy/domain/subscription/state/SubscriptionState.java
+++ b/src/main/java/com/fivefy/domain/subscription/state/SubscriptionState.java
@@ -1,0 +1,29 @@
+package com.fivefy.domain.subscription.state;
+
+import com.fivefy.domain.subscription.entity.Subscription;
+
+/**
+ * 구독 상태별 행동 정의 인터페이스
+ *
+ * 핵심 역할:
+ * - 상태마다 "가능한 행동"을 분리 : 취소, 만료, 갱신
+ * - if문 제거
+ * - 상태가 직접 자신의 행동을 책임지도록 설계
+ */
+public interface SubscriptionState {
+
+    /**
+     * 구독 취소
+     */
+    void cancel(Subscription subscription);
+
+    /**
+     * 구독 만료 처리
+     */
+    void expire(Subscription subscription);
+
+    /**
+     * 정기 구독 갱신
+     */
+    void renew(Subscription subscription);
+}

--- a/src/test/java/com/fivefy/domain/cashorder/service/CashOrderServiceTest.java
+++ b/src/test/java/com/fivefy/domain/cashorder/service/CashOrderServiceTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;

--- a/src/test/java/com/fivefy/domain/payment/entity/PaymentTest.java
+++ b/src/test/java/com/fivefy/domain/payment/entity/PaymentTest.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.payment.entity;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.payment.enums.PaymentStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,8 @@ class PaymentTest {
     }
 
     // ─────────────────────────────────────────
-    // complete() — REQUESTED → COMPLETED
+    // complete() — 결제 완료(REQUESTED)    → COMPLETED
+    //              승인(COMPLETED)        → COMPLETED    : 재호출
     // ─────────────────────────────────────────
 
     @Test
@@ -39,7 +41,8 @@ class PaymentTest {
     }
 
     // ─────────────────────────────────────────
-    // refund() — COMPLETED → REFUNDED
+    // refund() — 결제 완료(REQUESTED)  → 환불(REFUNDED)
+    //            승인(COMPLETED)      → 환불(REFUNDED)
     // ─────────────────────────────────────────
 
     @Test
@@ -53,6 +56,17 @@ class PaymentTest {
         assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
         assertThat(payment.getRefundedAt()).isNotNull();
         assertThat(payment.getRefundReason()).isEqualTo("단순 변심");
+    }
+
+    @Test
+    @DisplayName("REFUNDED 상태에서 refund() 재호출 시 예외가 발생한다")
+    void refund_REFUNDED에서_재호출_예외() {
+        Payment payment = Payment.create(1L, 1000L, "ORD-12345678", "pg-tx-001", "webhook-001");
+        payment.complete();
+        payment.refund("첫 번째 환불");
+
+        assertThatThrownBy(() -> payment.refund("두 번째 환불"))
+                .isInstanceOf(BusinessException.class);
     }
 
     @Test

--- a/src/test/java/com/fivefy/domain/payment/entity/PaymentTest.java
+++ b/src/test/java/com/fivefy/domain/payment/entity/PaymentTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
 class PaymentTest {
 
@@ -77,5 +78,17 @@ class PaymentTest {
 
         assertThatThrownBy(() -> payment.refund(null))
                 .isInstanceOf(Exception.class);
+    }
+
+    @Test
+    @DisplayName("COMPLETED 상태에서 complete() 재호출 시 예외 없이 멱등 처리된다")
+    void complete_COMPLETED에서_재호출_멱등() {
+        Payment payment = Payment.create(1L, 1000L, "ORD-12345678", "pg-tx-001", "webhook-001");
+        payment.complete();
+
+        // assertThatCode는 예외가 없어야 통과하는 케이스
+        assertThatCode(() -> payment.complete())
+                .doesNotThrowAnyException();
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
     }
 }

--- a/src/test/java/com/fivefy/domain/subscription/entity/SubscriptionTest.java
+++ b/src/test/java/com/fivefy/domain/subscription/entity/SubscriptionTest.java
@@ -89,7 +89,8 @@ class SubscriptionTest {
     }
 
     // ─────────────────────────────────────────
-    // expire() — → EXPIRE
+    //  expire() —  활성화(ACTIVE)    → 만료(EXPIRE)
+    //              취소(CANCLE)      → 만료(EXPIRE)
     // ─────────────────────────────────────────
 
     @Test
@@ -101,6 +102,27 @@ class SubscriptionTest {
 
         assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.EXPIRE);
         assertThat(subscription.getNextBillingDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("CANCELED 상태에서 expire() 호출 시 EXPIRE로 전이된다 — 취소 후 만료일 지나면 만료 처리")
+    void expire_CANCELED에서_EXPIRE로() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        subscription.cancel();
+
+        subscription.expire();
+
+        assertThat(subscription.getStatus()).isEqualTo(SubscriptionStatus.EXPIRE);
+    }
+
+    @Test
+    @DisplayName("EXPIRE 상태에서 expire() 재호출 시 예외가 발생한다 — 만료 재호출 차단")
+    void expire_EXPIRE에서_재호출_예외() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        subscription.expire();
+
+        assertThatThrownBy(() -> subscription.expire())
+                .isInstanceOf(BusinessException.class);
     }
 
     // ─────────────────────────────────────────


### PR DESCRIPTION
## 개요

구독(Subscription)과 결제(Payment) 도메인의 상태 전이 로직을 리팩토링했습니다.

- `Subscription`: 별도 State 클래스로 분리하는 **상태 패턴(State Pattern)** 적용
- `Payment`: enum 상수에 전이 규칙을 위임하는 **Enum State Machine** 적용

기존에는 `cancel()`, `expire()`, `renew()`, `complete()`, `refund()` 등의 메서드 내부에
if문으로 상태 검사 로직이 분산되어 있었습니다.
리팩토링 후 조건은 state/enum이 직접 책임지고, 엔티티와 서비스는 실행만 담당합니다.

그 외의 엔티티에 대한 상태값은 if문으로도 충분하다고 판단하여 이 이상 진행하진 않았습니다.

## 변경 사항
## 변경 사항
- `Subscription` 엔티티에 상태 패턴 적용
  - `ActiveState`, `InactiveState`, `CanceledState`, `ExpiredState` 클래스 추가
  - `cancel()`, `expire()`, `renew()`의 if문 → `state().메서드(this)` 위임으로 교체
  - `SubscriptionErrorCode`에 `ERR_SUBSCRIPTION_ALREADY_EXPIRED`, `ERR_SUBSCRIPTION_UNSUPPORTED_STATUS` 추가
- `Payment` 엔티티에 Enum State Machine 적용
  - `PaymentStatus` enum에 `canTransitTo()`, `transit()` 추상 메서드 추가
  - 상태별 허용 전이 규칙을 각 enum 상수가 직접 정의
  - `complete()`, `fail()`, `refund()`는 `status.transit()` 호출만 담당
  - `PaymentErrorCode`에 `ERR_PAYMENT_INVALID_TRANSITION`, `ERR_PAYMENT_INVALID_STATUS_COMPLETE`, `ERR_PAYMENT_INVALID_STATUS_REFUND` 추가
- `SubscriptionRepository` 만료 조회 메서드 수정
  - `findAllByStatusAndExpiryDateBefore` → `findAllByStatusInAndExpiryDateBefore`
  - 만료 대상: `ACTIVE` 단독 → `ACTIVE`, `CANCELED` 포함으로 변경
- `SubscriptionScheduler` 만료 처리 수정
  - `subscription.expire()` 직접 호출 → `subscriptionService.expireOne()` 위임 (건별 트랜잭션)


## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

**Subscription 상태 전이**
> 정기 구독 구매 → POST /api/me/point-orders/purchases
구독 취소 → DELETE /api/me/subscriptions
만료된 구독에서 cancel() 재호출 시 400 응답 확인
FREE 구독에서 cancel() 호출 시 400 응답 확인


**Payment 상태 전이**
>포인트 충전 → POST /api/v1/cash-orders/purchase
환불 → POST /api/v1/cash-orders/refund
이미 환불된 결제에 refund() 재호출 시 400 응답 확인


**단위 테스트 실행**
> ./gradlew test --tests ".SubscriptionTest"
./gradlew test --tests ".PaymentTest"

**테스트 실행 방법에 대한 추가 내용**
> 인텔리제이 버전과 SpringBoot4.0의 버전이 호환되지 않는 경우 테스트 실행에 문제가 있다고 한다.
버전을 한 단계 낮추면(3.x) 해결된다 하지만, 프로젝트 시작 전 정한 규칙에 의거하여 터미널로 각각 테스트하는 방법 외에는 인텔리제이 자체를 업데이트 하는 방법 밖에 없는 것 같습니다.
통합 테스트와 단위 테스트는 개인 테스트의 선호 차이 같으나, 동시성 테스트를 단위 테스트의 @Mock로는 할 수 없다고 판단하여 유지하였습니다.

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  - 결제 상태 전이 검증 강화로 무효한 상태 변경 방지
  - 구독 상태 관리 개선으로 중복 작업 방지
  - 환불된 결제에 대한 중복 처리 차단

* **테스트**
  - 결제 및 구독 상태 처리 테스트 커버리지 확대

* **기타**
  - 빌드 및 테스트 로깅 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->