### PR TITLE
refactor : 포인트주문 + 빌링키 외부 API 트랜잭션 분리 최종본

### DIFF
--- a/src/main/java/com/fivefy/domain/billingkey/entity/BillingKey.java
+++ b/src/main/java/com/fivefy/domain/billingkey/entity/BillingKey.java
@@ -54,8 +54,16 @@ public class BillingKey extends BaseEntity {
     @Column(nullable = false)
     private boolean active = true;
 
-    // ── 생성 ──────────────────────────────────────────────────────────────────
-
+    /**
+     * 빌링키 생성
+     *
+     * @param userId
+     * @param billingKey
+     * @param cardLast4
+     * @param payMethod
+     * @param cardName
+     * @return
+     */
     public static BillingKey create(Long userId, String billingKey,
                                     String cardLast4, String payMethod, String cardName) {
         validateNonNull(userId, "userId");
@@ -72,9 +80,9 @@ public class BillingKey extends BaseEntity {
         return billingkey;
     }
 
-    // ── 상태 변경 ─────────────────────────────────────────────────────────────
-
-    /** 빌링키 해지 (카드 삭제) */
+    /**
+     * 빌링키 해지(카드 삭제)
+     */
     public void deactivate() {
         if (!this.active) {
             throw new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ALREADY_DEACTIVATED);

--- a/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyPersistenceService.java
@@ -1,0 +1,51 @@
+package com.fivefy.domain.billingkey.service;
+
+import com.fivefy.domain.billingkey.entity.BillingKey;
+import com.fivefy.domain.billingkey.repository.BillingKeyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * BillingKey 관련 DB 작업 전담 서비스
+ *
+ * BillingKeyService에서 외부 API 호출(트랜잭션 밖),
+ * 이 클래스에서 DB 저장만(@Transactional) 담당하도록 분리.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BillingKeyPersistenceService {
+
+    private final BillingKeyRepository billingKeyRepository;
+
+    /**
+     * 빌링키 등록은 DB 저장만 담당
+     * BillingKeyService.register()에서 portoneClient.getBillingKey() 성공 확인 후 호출
+     */
+    @Transactional
+    public BillingKey saveBillingKey(
+            Long userId,
+            String billingKeyToken,
+            String cardLast4,
+            String payMethod,
+            String cardName
+    ) {
+        BillingKey billingKey = BillingKey.create(userId, billingKeyToken, cardLast4, payMethod, cardName);
+        billingKeyRepository.save(billingKey);
+
+        log.info("[BillingKey] DB 저장 완료 userId={}, cardName={}, cardLast4={}", userId, cardName, cardLast4);
+        return billingKey;
+    }
+
+    /**
+     * 빌링키 해지는 DB 비활성화만 담당
+     * BillingKeyService.deactivate()에서 portoneClient.deleteBillingKey() 성공 확인 후 호출
+     */
+    @Transactional
+    public void deactivateBillingKey(BillingKey billingKey) {
+        billingKey.deactivate();
+        log.info("[BillingKey] DB 비활성화 완료 userId={}", billingKey.getUserId());
+    }
+}

--- a/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyPersistenceService.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.billingkey.service;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.billingkey.entity.BillingKey;
+import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
 import com.fivefy.domain.billingkey.repository.BillingKeyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,8 +46,10 @@ public class BillingKeyPersistenceService {
      * BillingKeyService.deactivate()에서 portoneClient.deleteBillingKey() 성공 확인 후 호출
      */
     @Transactional
-    public void deactivateBillingKey(BillingKey billingKey) {
-        billingKey.deactivate();
+    public void deactivateBillingKey(Long billingKeyId) {  // BillingKey → Long으로 변경
+        BillingKey billingKey = billingKeyRepository.findById(billingKeyId)
+                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_NOT_FOUND));
+        billingKey.deactivate();  // 트랜잭션 안에서 조회했으므로 dirty checking 정상 작동
         log.info("[BillingKey] DB 비활성화 완료 userId={}", billingKey.getUserId());
     }
 }

--- a/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyService.java
+++ b/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyService.java
@@ -20,29 +20,33 @@ public class BillingKeyService {
 
     private final BillingKeyRepository billingKeyRepository;
     private final PortoneClient portoneClient;
+    private final BillingKeyPersistenceService persistenceService;  // DB 저장 분리
 
     /**
      * 빌링키 등록 방법
      *
      * 1. 프론트가 포트원 SDK로 카드 등록 → 포트원이 billingKeyId 발급 → 프론트가 서버에 전달
-     *      - 이걸 어떻게 하냐고...
      * 2. 서버가 포트원에 billingKeyId로 단건 조회 → 빌링키 토큰 + 카드 정보 확인
      * 3. DB에 BillingKey 저장
+     *
+     * DB 저장 실패 시 롤백이 되어도 포트원 조회는 이미 완료된 상태.
+     * 조회라서 큰 문제는 없지만 DB 커넥션을 외부 API 응답 대기 시간만큼 점유하는 문제가 있음.
+     * → 외부 API를 트랜잭션 밖에서 먼저 실행하고,
+     *   DB 저장만 persistenceService에 위임(별도 @Transactional)
      *
      * @param userId
      * @param request billingKeyId (포트원이 발급한 ID, 프론트에서 전달)
      */
-    @Transactional
     public BillingKeyResponse register(Long userId, BillingKeyRegisterRequest request) {
 
         log.info("[BillingKey] 등록 요청 userId={}, billingKeyId={}", userId, request.billingKeyId());
 
-        // 1. 포트원에서 빌링키 정보 조회
+        //  포트원에서 빌링키 정보 조회(외부 API)
         PortoneBillingKeyResponse portoneResponse = portoneClient.getBillingKey(request.billingKeyId());
 
         String billingKeyToken = portoneResponse.billingKey();
 
-        // 중복 등록 방지
+        // 중복 등록 방지 — 외부 API 응답 받은 후 token 기준으로 확인
         if (billingKeyRepository.existsByBillingKey(billingKeyToken)) {
             throw new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ALREADY_EXISTS);
         }
@@ -69,9 +73,8 @@ public class BillingKeyService {
             payMethod = "KAKAOPAY"; // 기본값 : 카카오페이
         }
 
-        // 2. DB 저장
-        BillingKey billingKey = BillingKey.create(userId, billingKeyToken, cardLast4, payMethod, cardName);
-        billingKeyRepository.save(billingKey);
+        // DB 저장
+        BillingKey billingKey = persistenceService.saveBillingKey(userId, billingKeyToken, cardLast4, payMethod, cardName);
 
         log.info("빌링키 등록 완료 — userId={}, cardName={}, cardLast4={}", userId, cardName, cardLast4);
 
@@ -81,15 +84,19 @@ public class BillingKeyService {
     /**
      * 빌링키 해지 (카드 삭제)
      *
-     * 흐름:
      * 1. DB에서 빌링키 조회 + 본인 검증
      * 2. 포트원에 빌링키 삭제 요청
      * 3. DB에서 비활성화 (active = false)
      *
+     * portoneClient.deleteBillingKey()가 트랜잭션 안에 있으면
+     * 포트원 삭제 성공 후 DB 비활성화 실패 시 롤백이 되어도
+     * 포트원에서는 이미 삭제된 상태라 불일치가 생김.
+     * → 외부 API를 트랜잭션 밖에서 먼저 실행하고,
+     *   DB 비활성화만 persistenceService에 위임(별도 @Transactional)
+     *
      * @param userId
      * @param billingKeyId DB PK
      */
-    @Transactional
     public void deactivate(Long userId, Long billingKeyId) {
 
         log.info("[BillingKey] 해지 요청 userId={}, billingKeyId={}", userId, billingKeyId);
@@ -101,11 +108,11 @@ public class BillingKeyService {
             throw new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_FORBIDDEN);
         }
 
-        // 포트원 측 빌링키 삭제
+        // 포트원 측 빌링키 삭제(외부 API)
         portoneClient.deleteBillingKey(billingKey.getBillingKey());
 
         // DB 비활성화
-        billingKey.deactivate();
+        persistenceService.deactivateBillingKey(billingKey);
 
         log.info("빌링키 해지 완료 — userId={}, billingKeyId={}", userId, billingKeyId);
     }

--- a/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyService.java
+++ b/src/main/java/com/fivefy/domain/billingkey/service/BillingKeyService.java
@@ -112,7 +112,7 @@ public class BillingKeyService {
         portoneClient.deleteBillingKey(billingKey.getBillingKey());
 
         // DB 비활성화
-        persistenceService.deactivateBillingKey(billingKey);
+        persistenceService.deactivateBillingKey(billingKeyId);
 
         log.info("빌링키 해지 완료 — userId={}, billingKeyId={}", userId, billingKeyId);
     }

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
@@ -1,0 +1,139 @@
+package com.fivefy.domain.cashorder.service;
+
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.cashorder.dto.CashOrderResponse;
+import com.fivefy.domain.cashorder.entity.CashOrder;
+import com.fivefy.domain.cashorder.enums.CashProductType;
+import com.fivefy.domain.cashorder.repository.CashOrderRepository;
+import com.fivefy.domain.billingkey.entity.BillingKey;
+import com.fivefy.domain.payment.entity.Payment;
+import com.fivefy.domain.payment.repository.PaymentRepository;
+import com.fivefy.domain.wallet.entity.PointHistory;
+import com.fivefy.domain.wallet.entity.Wallet;
+import com.fivefy.domain.wallet.enums.PointHistoryType;
+import com.fivefy.domain.wallet.enums.PointType;
+import com.fivefy.domain.wallet.enums.WalletErrorCode;
+import com.fivefy.domain.wallet.repository.PointHistoryRepository;
+import com.fivefy.domain.wallet.repository.WalletRepository;
+import com.fivefy.common.portone.dto.PortoneBillingPaymentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * CashOrder 관련 DB 작업 전담 서비스
+ *
+ * CashOrderService에서 외부 API 호출(트랜잭션 밖),
+ *       이 클래스에서 DB 저장만(@Transactional) 담당하도록 분리.
+ *       + CashOrderService에서만 작성하면 너무 길어져서 무게감 감소
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CashOrderPersistenceService {
+
+    private final CashOrderRepository cashOrderRepository;
+    private final PaymentRepository paymentRepository;
+    private final WalletRepository walletRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
+    /**
+     * [refund] DB 상태 변경만 담당
+     *
+     * CashOrderService.refund()에서 portoneClient.cancelPayment() 성공 확인 후 호출
+     * 포트원 취소가 확정된 상태에서만 진입하므로 DB 작업만 트랜잭션으로 처리
+     */
+    @Transactional
+    public CashOrderResponse saveRefundResult(CashOrder cashOrder, Payment payment, String reason) {
+
+        // CashOrder 상태 변경  : SUCCESS → REFUNDED
+        cashOrder.refund();
+        // Payment 상태 변경    : COMPLETED → REFUNDED, 환불 사유/시간 기록
+        payment.refund(reason);
+
+
+        // 지갑 포인트 차감
+        // 포인트를 이미 소진한 경우 잔액 부족 예외 발생 가능
+        // → 스케줄러 도입 시 음수 잔액 허용 또는 별도 정책 필요
+        Wallet wallet = walletRepository.findByUserId(cashOrder.getUserId())
+                .orElseThrow(() -> new BusinessException(WalletErrorCode.ERR_WALLET_NOT_FOUND));
+        wallet.refundBalance(cashOrder.getPointAmount());
+
+        // 포인트 이력 기록
+        pointHistoryRepository.save(PointHistory.create(
+                wallet.getId(),
+                PointType.PAID,
+                PointHistoryType.REFUND,
+                cashOrder.getPointAmount(),
+                wallet.getBalance(),
+                "포인트 환불 (" + reason + ")",
+                cashOrder.getId(),
+                null
+        ));
+
+        log.info("[CashOrder] 환불 DB 저장 완료 orderNumber={}", cashOrder.getOrderNumber());
+        return CashOrderResponse.from(cashOrder);
+    }
+
+    /**
+     * 정기충전 DB 저장
+     * CashOrderService.processRecurringCharge()에서 portoneClient.chargeWithBillingKey() 성공 확인 후 호출
+     * 포트원 청구가 확정된 상태에서만 진입하므로 DB 작업만 트랜잭션으로 처리
+     */
+    @Transactional
+    public void saveRecurringChargeResult(
+            BillingKey billingKey,    // Long userId → BillingKey billingKey 로 변경
+            String orderNumber,
+            CashProductType productType,
+            PortoneBillingPaymentResponse pgResponse
+    ) {
+        Long userId = billingKey.getUserId();  // 내부에서 꺼내서 사용
+
+        // CashOrder 생성 (SUCCESS) — 빌링키 청구는 webhookId 대신 orderNumber를 멱등키로 대체
+        CashOrder cashOrder = CashOrder.create(userId, productType, orderNumber);
+        cashOrder.success(orderNumber);
+        cashOrderRepository.save(cashOrder);
+
+        // Payment 기록 : 2026-04-22 : 실제 PG 거래 ID pgIxId 수정
+        Payment payment = Payment.create(
+                userId,
+                productType.getCashAmount(),
+                orderNumber,
+                pgResponse.payment().pgTxId(),      // 포트원 결제 ID paymentId() -> 실제 PG 거래 ID는 pgTxId. PortoneBillingPaymentResponse 참고하기
+                orderNumber                         // 멱등키 (orderNumber 재사용)
+        );
+        payment.complete();
+        paymentRepository.save(payment);
+
+        // 지갑 포인트 충전
+        Wallet wallet = walletRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(WalletErrorCode.ERR_WALLET_NOT_FOUND));
+        wallet.chargeBalance(productType.getPointAmount());
+
+        // 포인트 이력 기록
+        pointHistoryRepository.save(PointHistory.create(
+                wallet.getId(),
+                PointType.PAID,
+                PointHistoryType.CHARGE,
+                productType.getPointAmount(),
+                wallet.getBalance(),
+                "정기 포인트 자동 충전",
+                cashOrder.getId(),
+                null
+        ));
+
+        log.info("[정기충전] DB 저장 완료 userId={}, orderNumber={}", userId, orderNumber);
+    }
+
+    /**
+     * 빌링키 비활성화 DB 저장
+     * portoneClient.chargeWithBillingKey() 실패/거절 시 호출
+     * 카드 만료, 한도 초과 등의 사유로 더 이상 청구 불가한 빌링키를 비활성화
+     */
+    @Transactional
+    public void deactivateBillingKey(BillingKey billingKey) {
+        billingKey.deactivate();
+        log.info("[BillingKey] DB 비활성화 완료 userId={}", billingKey.getUserId());
+    }
+}

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
@@ -42,7 +42,7 @@ public class CashOrderPersistenceService {
     private final BillingKeyRepository billingKeyRepository;
 
     /**
-     * [refund] DB 상태 변경만 담당
+     * 환불은 DB 상태 변경만 담당
      *
      * CashOrderService.refund()에서 portoneClient.cancelPayment() 성공 확인 후 호출
      * 포트원 취소가 확정된 상태에서만 진입하므로 DB 작업만 트랜잭션으로 처리

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
@@ -1,6 +1,8 @@
 package com.fivefy.domain.cashorder.service;
 
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
+import com.fivefy.domain.billingkey.repository.BillingKeyRepository;
 import com.fivefy.domain.cashorder.dto.CashOrderResponse;
 import com.fivefy.domain.cashorder.entity.CashOrder;
 import com.fivefy.domain.cashorder.enums.CashProductType;
@@ -37,6 +39,7 @@ public class CashOrderPersistenceService {
     private final PaymentRepository paymentRepository;
     private final WalletRepository walletRepository;
     private final PointHistoryRepository pointHistoryRepository;
+    private final BillingKeyRepository billingKeyRepository;
 
     /**
      * [refund] DB 상태 변경만 담당
@@ -51,6 +54,11 @@ public class CashOrderPersistenceService {
         cashOrder.refund();
         // Payment 상태 변경    : COMPLETED → REFUNDED, 환불 사유/시간 기록
         payment.refund(reason);
+
+        // 토끼 : cashOrder와 payment는 트랜잭션 밖에서 로드된 detached 엔티티라 CashOrder.refund() 호출 시 dirty checking이 작동하지 않아 DB에 반영이 안 될 수 있다.
+        // 토끼 해결 : 명시적 save() 추가 — detached 엔티티여도 merge되어 DB 반영 보장
+        cashOrderRepository.save(cashOrder);
+        paymentRepository.save(payment);
 
 
         // 지갑 포인트 차감
@@ -124,16 +132,5 @@ public class CashOrderPersistenceService {
         ));
 
         log.info("[정기충전] DB 저장 완료 userId={}, orderNumber={}", userId, orderNumber);
-    }
-
-    /**
-     * 빌링키 비활성화 DB 저장
-     * portoneClient.chargeWithBillingKey() 실패/거절 시 호출
-     * 카드 만료, 한도 초과 등의 사유로 더 이상 청구 불가한 빌링키를 비활성화
-     */
-    @Transactional
-    public void deactivateBillingKey(BillingKey billingKey) {
-        billingKey.deactivate();
-        log.info("[BillingKey] DB 비활성화 완료 userId={}", billingKey.getUserId());
     }
 }

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
@@ -47,8 +47,8 @@ public class CashOrderService {
     private final PointHistoryRepository pointHistoryRepository;
     private final PortoneClient portoneClient;
     private final PortoneWebhookVerifier portoneWebhookVerifier;
-    private final ObjectMapper objectMapper;    // Spring Boot가 기본으로 Bean 등록
-
+    private final ObjectMapper objectMapper;
+    private final CashOrderPersistenceService persistenceService;   // DB 저장 분리
 
     /**
      * 포인트 충전 주문
@@ -95,13 +95,17 @@ public class CashOrderService {
      * 포트원 취소 API 호출 → SUCCEEDED 확인
      * CashOrder.refund() + Payment.refund() 상태 변경
      * wallet.useBalance() → 포인트 차감 + PointHistory(REFUND) 기록
+     *
+     * 수정 : 외부 API 호출은 트랜잭션 밖, DB 저장은 persistenceService.saveRefundResult()로 위임
+     * → 조회는 트랜잭션 없이 단순 읽기로 충분
+     * → portoneClient.cancelPayment() 성공 확인 후 DB 진입
+     *
      * @param userId
      * @param request
      * @return
      */
     // CashOrder와 PointOrder 모두 wallet와  같은 Wallet ID 수정
     @RedissonLock(key = "'wallet:' + #userId")
-    @Transactional
     public CashOrderResponse refund(Long userId, CashOrderRefundRequest request) {
 
         log.info("[CashOrder] 환불 요청 userId={}, orderNumber={}", userId, request.orderNumber());
@@ -119,6 +123,7 @@ public class CashOrderService {
              .orElseThrow(() -> new BusinessException(PaymentErrorCode.ERR_PAYMENT_NOT_FOUND));
 
         // 포트원에 취소 요청(외부 API 호출) (참고 코드의 cancelPaymentByImpUid에 해당)
+        // 트랜잭션 미적용(밖에서 실행)
         PortoneCancelResponse cancelResponse = portoneClient.cancelPayment(
             payment.getPgTransactionId(),
             cashOrder.getCashAmount(),
@@ -133,48 +138,13 @@ public class CashOrderService {
 
         log.info("[CashOrder] 환불 완료 userId={}, orderNumber={}", userId, request.orderNumber());
 
-        // 3. DB 상태 변경만 트랜잭션으로 처리
-        return saveRefundResult(cashOrder, payment, request.reason());
-    }
-
-    /**
-     * 토끼 : 외부 취소 호출과 DB 상태 변경 구간은 분리하는 편이 안전
-     * DB 작업만 별도 메서드로 분리 — AopForTransaction이 이 메서드에 트랜잭션 적용
-     * @param cashOrder
-     * @param payment
-     * @param reason
-     * @return
-     */
-    @Transactional
-    public CashOrderResponse saveRefundResult(CashOrder cashOrder, Payment payment, String reason) {
-        // DB 상태 변경
-        cashOrder.refund();         // CashOrder.status: SUCCESS → REFUNDED
-        payment.refund(reason);     // Payment.status: COMPLETED → REFUNDED, 환불이유/환불시간(refundReason/refundedAt) 기록
-
-        // 지갑의 포인트 차감
-        // 포인트를 이미 사용한 경우 useBalance()에서 잔액 부족 예외 발생 가능
-        //   → 스케줄러 도입 시 음수 잔액 허용 또는 별도 정책 필요
-        Wallet wallet = walletRepository.findByUserId(cashOrder.getUserId())
-                .orElseThrow(() -> new BusinessException(WalletErrorCode.ERR_WALLET_NOT_FOUND));
-        wallet.refundBalance(cashOrder.getPointAmount());
-
-        pointHistoryRepository.save(PointHistory.create(
-                wallet.getId(),
-                PointType.PAID,
-                PointHistoryType.REFUND,
-                cashOrder.getPointAmount(),
-                wallet.getBalance(),
-                "포인트 환불 (" + reason + ")",
-                cashOrder.getId(),  
-                null                // pointOrderId
-        ));
-
-        return CashOrderResponse.from(cashOrder);
+        // 3. DB 상태 변경만 트랜잭션으로 처리(기존에 같은 파일에서 실행하던 걸 persistenceService으로 옮김)
+        return persistenceService.saveRefundResult(cashOrder, payment, request.reason());
     }
 
     /**
      * 포트원 웹훅 처리 (결제 완료 시 포트원 서버가 호출)
-     * -PortoneWebhookController에서 헤더 검증 후 이 메서드로 위임
+     * PortoneWebhookController에서 헤더 검증 후 이 메서드로 위임
      *
      * rawBody 파싱 → 웹훅 타입 확인 (Transaction.Paid만 처리)
      * 시그니처 + 타임스탬프 검증 (위변조 / 리플레이 방지)
@@ -198,7 +168,6 @@ public class CashOrderService {
         // 웹훅 수신 즉시 로그(디버깅용)
         log.debug("[Webhook] 수신 webhookId={}", webhookId);
         log.debug("[Webhook] rawBody={}", rawBody);
-
 
         // 웹훅 body 파싱 : rawBody → PortoneWebhookRequest
         PortoneWebhookRequest request;
@@ -230,7 +199,7 @@ public class CashOrderService {
         String pgPaymentId = request.data().paymentId();  // ORD-xxxxxx : 포트원이 부여한 결제 ID (= orderNumber)
         log.info("[Webhook] 결제 검증 시작합니다 webhookId={}, pgPaymentId={}", webhookId, pgPaymentId);    // 웹훅 ID와 결제 ID
 
-        //                                  실제 결제 데이터 확인
+        // 읽기 전용 조회                    실제 결제 데이터 확인
         PortonePaymentResponse pgPayment = portoneClient.getPayment(pgPaymentId);
 
         // CashOrder 조회 (orderNumber 기준)
@@ -308,7 +277,7 @@ public class CashOrderService {
 
         log.info("[정기충전] 시작 userId={}, orderNumber={}", userId, orderNumber);
 
-        // 1. 포트원 빌링키 청구
+        // 1. 포트원 빌링키 청구(외부 API 호출)
         PortoneBillingPaymentResponse pgResponse;
         try {
             pgResponse = portoneClient.chargeWithBillingKey(
@@ -318,8 +287,10 @@ public class CashOrderService {
                     productType.getDescription()
             );
         } catch (Exception e) {
+            // 청구 자체가 실패 (네트워크 오류, 카드 만료 등)
+            // → 빌링키 비활성화도 DB 작업이므로 persistenceService 위임(billingKey.deactivate();)
             log.error("[정기충전] 포트원 청구 실패 — userId={}, 사유={}", userId, e.getMessage());
-            billingKey.deactivate();    // 카드 만료/한도 초과 등 → 비활성화
+            persistenceService.deactivateBillingKey(billingKey);        // 카드 만료/한도 초과 등 → 비활성화
             return;
         }
 
@@ -332,37 +303,8 @@ public class CashOrderService {
             return;
         }
 
-        // 2. CashOrder 생성 (SUCCESS)
-        CashOrder cashOrder = CashOrder.create(userId, productType, orderNumber);
-        cashOrder.success(orderNumber); // 빌링키 청구는 webhookId 대신 orderNumber로 멱등키 대체
-        cashOrderRepository.save(cashOrder);
-
-        // 3. Payment 기록 : 2026-04-22 : 실제 PG 거래 ID pgIxId 수정
-        Payment payment = Payment.create(
-                userId,
-                productType.getCashAmount(),
-                orderNumber,
-                pgResponse.payment().pgTxId(),  // 포트원 결제 ID paymentId() -> 실제 PG 거래 ID는 pgTxId. PortoneBillingPaymentResponse 참고하기
-                orderNumber              // 멱등키 (orderNumber 재사용)
-        );
-        payment.complete();
-        paymentRepository.save(payment);
-
-        // 4. 지갑 포인트 충전
-        Wallet wallet = walletRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("지갑 없음"));
-        wallet.chargeBalance(productType.getPointAmount());
-
-        pointHistoryRepository.save(PointHistory.create(
-                wallet.getId(),
-                PointType.PAID,
-                PointHistoryType.CHARGE,
-                productType.getPointAmount(),
-                wallet.getBalance(),
-                "정기 포인트 자동 충전",
-                cashOrder.getId(),
-                null            // pointOrderId
-        ));
+        // 포트원 청구 성공 확정 후 DB 작업만 별도 트랜잭션으로
+        persistenceService.saveRecurringChargeResult(billingKey, orderNumber, productType, pgResponse);
 
         log.info("[정기충전] 완료 — userId={}, orderNumber={}, 충전P={}",
                 userId, orderNumber, productType.getPointAmount());

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
@@ -9,6 +9,7 @@ import com.fivefy.common.portone.dto.PortoneCancelResponse;
 import com.fivefy.common.portone.dto.PortonePaymentResponse;
 import com.fivefy.common.portone.dto.PortoneWebhookRequest;
 import com.fivefy.domain.billingkey.entity.BillingKey;
+import com.fivefy.domain.billingkey.service.BillingKeyPersistenceService;
 import com.fivefy.domain.cashorder.dto.CashOrderPurchaseResponse;
 import com.fivefy.domain.cashorder.dto.CashOrderRefundRequest;
 import com.fivefy.domain.cashorder.dto.CashOrderResponse;
@@ -48,7 +49,8 @@ public class CashOrderService {
     private final PortoneClient portoneClient;
     private final PortoneWebhookVerifier portoneWebhookVerifier;
     private final ObjectMapper objectMapper;
-    private final CashOrderPersistenceService persistenceService;   // DB 저장 분리
+    private final CashOrderPersistenceService cashOrderPersistenceService;   // DB 저장 분리
+    private final BillingKeyPersistenceService billingKeyPersistenceService;
 
     /**
      * 포인트 충전 주문
@@ -138,8 +140,8 @@ public class CashOrderService {
 
         log.info("[CashOrder] 환불 완료 userId={}, orderNumber={}", userId, request.orderNumber());
 
-        // 3. DB 상태 변경만 트랜잭션으로 처리(기존에 같은 파일에서 실행하던 걸 persistenceService으로 옮김)
-        return persistenceService.saveRefundResult(cashOrder, payment, request.reason());
+        // DB 상태 변경만 트랜잭션으로 처리(기존에 같은 파일에서 실행하던 걸 persistenceService으로 옮김)
+        return cashOrderPersistenceService.saveRefundResult(cashOrder, payment, request.reason());
     }
 
     /**
@@ -290,7 +292,8 @@ public class CashOrderService {
             // 청구 자체가 실패 (네트워크 오류, 카드 만료 등)
             // → 빌링키 비활성화도 DB 작업이므로 persistenceService 위임(billingKey.deactivate();)
             log.error("[정기충전] 포트원 청구 실패 — userId={}, 사유={}", userId, e.getMessage());
-            persistenceService.deactivateBillingKey(billingKey);        // 카드 만료/한도 초과 등 → 비활성화
+            billingKeyPersistenceService.deactivateBillingKey(billingKey.getId());        // 카드 만료/한도 초과 등 → 비활성화
+
             return;
         }
 
@@ -299,12 +302,13 @@ public class CashOrderService {
         // status 체크 대신 payment 객체로 성공 여부 판단
         if (pgResponse.payment() == null) {
             log.warn("[정기충전] 포트원 청구 거절 — userId={}", userId);
-            billingKey.deactivate();
+            billingKeyPersistenceService.deactivateBillingKey(billingKey.getId());
+
             return;
         }
 
         // 포트원 청구 성공 확정 후 DB 작업만 별도 트랜잭션으로
-        persistenceService.saveRecurringChargeResult(billingKey, orderNumber, productType, pgResponse);
+        cashOrderPersistenceService.saveRecurringChargeResult(billingKey, orderNumber, productType, pgResponse);
 
         log.info("[정기충전] 완료 — userId={}, orderNumber={}, 충전P={}",
                 userId, orderNumber, productType.getPointAmount());


### PR DESCRIPTION
## 개요

포트원 외부 API 호출이 @Transactional 범위 안에 있으면,
외부 API 성공 후 DB 저장 실패 시 롤백이 DB만 되돌리고
외부 API는 이미 완료된 상태라 실제 상태와 DB 상태가 영구적으로 불일치하니 분리한다.
단, 이때 너무 많은 역할이 CashOrder와 BillingKey에 쌓이니 persistenceService에 각각 분리한다.


## 변경 사항

- 외부 API 호출은 트랜잭션 밖, DB 저장만 별도 @Transactional로 처리하도록 분리.
- 같은 클래스 내 self-call은 Spring AOP 프록시를 우회해 @Transactional이 무효가 되므로
- DB 전담 클래스(PersistenceService)를 별도 Bean으로 분리.
   - `CashOrderPersistenceService` — CashOrder 관련 DB 작업 전담
   - `BillingKeyPersistenceService` — BillingKey 관련 DB 작업 전담

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)


## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **개선사항**
  * 결제 및 환불 처리 시스템의 안정성을 강화했습니다.
  * 정기 결제 처리 로직을 개선하여 더욱 견고한 오류 처리를 구현했습니다.
  * 데이터베이스 작업의 일관성과 신뢰성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->