### PR TITLE
feat: BillingAttempt 테이블 추가 및 정기청구 실패 케이스 분리

### DIFF
--- a/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
+++ b/src/main/java/com/fivefy/common/initializer/TestDefaultUserInitializer.java
@@ -121,6 +121,7 @@ public class TestDefaultUserInitializer implements ApplicationRunner {
         LocalDateTime expiryDate = switch (subscriptionPlanType) {
             case FREE -> now.plusDays(3);
             case RECURRING -> now.plusMonths(1);
+            case RECURRING_AUTO -> now.plusMonths(1);
         };
         LocalDateTime nextBillingDate = null;
         if (subscriptionPlanType != SubscriptionPlanType.FREE) {

--- a/src/main/java/com/fivefy/common/portone/PortoneWebhookVerifier.java
+++ b/src/main/java/com/fivefy/common/portone/PortoneWebhookVerifier.java
@@ -10,6 +10,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.Base64;
@@ -37,7 +38,14 @@ public class PortoneWebhookVerifier {
 
         // 타임스탬프 검증 (리플레이 공격 방지)
         long now = Instant.now().getEpochSecond();
-        long sentAt = Long.parseLong(webhookTimestamp);
+        long sentAt;
+        try {
+            // 1단계 : 웹훅 타임스탬프가 아니면 즉시 차단 : 숫자가 아닌 문자나 날짜, 빈값 등
+            sentAt = Long.parseLong(webhookTimestamp);
+        } catch (NumberFormatException e) {
+            throw new BusinessException(PortoneErrorCode.ERR_PORTONE_WEBHOOK_INVALID_TIMESTAMP);
+        }
+        // 2단계 : 숫자인데 현재 시각과 차이가 있음 = 리플레이 공격 차단
         if (Math.abs(now - sentAt) > MAX_TIMESTAMP_DIFF_SECONDS) {
             throw new BusinessException(PortoneErrorCode.ERR_PORTONE_WEBHOOK_TIMESTAMP_EXPIRED);
         }
@@ -71,7 +79,11 @@ public class PortoneWebhookVerifier {
                 ? webhookSignature.split(",")[1]
                 : webhookSignature;
 
-            if (!computed.equals(expected)) {
+            // 바이트 비교
+            if (!MessageDigest.isEqual(
+                computed.getBytes(StandardCharsets.UTF_8),  // 서버가 계산한 서명
+                expected.getBytes(StandardCharsets.UTF_8)   // 포트원이 보낸 서명
+            )) {
                 throw new BusinessException(PortoneErrorCode.ERR_PORTONE_WEBHOOK_SIGNATURE_MISMATCH);
             }
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {

--- a/src/main/java/com/fivefy/common/portone/PortoneWebhookVerifier.java
+++ b/src/main/java/com/fivefy/common/portone/PortoneWebhookVerifier.java
@@ -1,6 +1,8 @@
 package com.fivefy.common.portone;
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.common.portone.config.PortoneProperties;
+import com.fivefy.common.portone.enums.PortoneErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -37,7 +39,7 @@ public class PortoneWebhookVerifier {
         long now = Instant.now().getEpochSecond();
         long sentAt = Long.parseLong(webhookTimestamp);
         if (Math.abs(now - sentAt) > MAX_TIMESTAMP_DIFF_SECONDS) {
-            throw new IllegalArgumentException("웹훅 타임스탬프 만료");
+            throw new BusinessException(PortoneErrorCode.ERR_PORTONE_WEBHOOK_TIMESTAMP_EXPIRED);
         }
 
         // 시그니처 검증 (위변조 방지)
@@ -70,7 +72,7 @@ public class PortoneWebhookVerifier {
                 : webhookSignature;
 
             if (!computed.equals(expected)) {
-                throw new IllegalArgumentException("웹훅 시그니처 불일치");
+                throw new BusinessException(PortoneErrorCode.ERR_PORTONE_WEBHOOK_SIGNATURE_MISMATCH);
             }
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw new RuntimeException("시그니처 검증 중 오류", e);

--- a/src/main/java/com/fivefy/common/portone/enums/PortoneErrorCode.java
+++ b/src/main/java/com/fivefy/common/portone/enums/PortoneErrorCode.java
@@ -15,7 +15,8 @@ public enum PortoneErrorCode implements ErrorCode {
     ERR_PORTONE_BILLING_CHARGE_FAILED(HttpStatus.BAD_REQUEST, "빌링키 자동 청구에 실패했습니다"),
     ERR_PORTONE_BILLING_KEY_DELETE_FAILED(HttpStatus.BAD_REQUEST, "포트원 빌링키 삭제에 실패했습니다"),
     ERR_PORTONE_WEBHOOK_TIMESTAMP_EXPIRED(HttpStatus.UNAUTHORIZED, "웹훅 타임스탬프가 만료됐습니다 (리플레이 공격 의심)"),
-    ERR_PORTONE_WEBHOOK_SIGNATURE_MISMATCH(HttpStatus.UNAUTHORIZED, "웹훅 시그니처가 일치하지 않습니다 (위변조 의심)");
+    ERR_PORTONE_WEBHOOK_SIGNATURE_MISMATCH(HttpStatus.UNAUTHORIZED, "웹훅 시그니처가 일치하지 않습니다 (위변조 의심)"),
+    ERR_PORTONE_WEBHOOK_INVALID_TIMESTAMP(HttpStatus.BAD_REQUEST, "웹훅 타임스탬프 형식이 올바르지 않습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/common/portone/enums/PortoneErrorCode.java
+++ b/src/main/java/com/fivefy/common/portone/enums/PortoneErrorCode.java
@@ -13,7 +13,9 @@ public enum PortoneErrorCode implements ErrorCode {
     ERR_PORTONE_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "포트원 환불에 실패했습니다"),
     ERR_PORTONE_BILLING_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "포트원 빌링키 조회에 실패했습니다"),
     ERR_PORTONE_BILLING_CHARGE_FAILED(HttpStatus.BAD_REQUEST, "빌링키 자동 청구에 실패했습니다"),
-    ERR_PORTONE_BILLING_KEY_DELETE_FAILED(HttpStatus.BAD_REQUEST, "포트원 빌링키 삭제에 실패했습니다");
+    ERR_PORTONE_BILLING_KEY_DELETE_FAILED(HttpStatus.BAD_REQUEST, "포트원 빌링키 삭제에 실패했습니다"),
+    ERR_PORTONE_WEBHOOK_TIMESTAMP_EXPIRED(HttpStatus.UNAUTHORIZED, "웹훅 타임스탬프가 만료됐습니다 (리플레이 공격 의심)"),
+    ERR_PORTONE_WEBHOOK_SIGNATURE_MISMATCH(HttpStatus.UNAUTHORIZED, "웹훅 시그니처가 일치하지 않습니다 (위변조 의심)");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/billingattempt/entity/BillingAttempt.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/entity/BillingAttempt.java
@@ -1,0 +1,73 @@
+package com.fivefy.domain.billingattempt.entity;
+
+import com.fivefy.common.entity.BaseEntity;
+import com.fivefy.domain.billingattempt.enums.BillingAttemptStatus;
+import com.fivefy.domain.billingattempt.enums.BillingFailureReason;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+@Entity
+@Getter
+@Table(name = "billing_attempts")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BillingAttempt extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long subscriptionId;
+
+    @Column(nullable = false)
+    private Long billingKeyId;
+
+    /**
+     * UNIQUE 제약과 함께 월 중복 청구 방지
+     */
+    @Column(nullable = false, length = 7)
+    private String billingCycle;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private BillingAttemptStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private BillingFailureReason failureReason;  // 실패 시에만
+
+    @Column(nullable = false)
+    private LocalDateTime attemptedAt;
+
+    private static final DateTimeFormatter CYCLE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM");
+
+    public static BillingAttempt success(Long subscriptionId, Long billingKeyId) {
+        BillingAttempt attempt = new BillingAttempt();
+        attempt.subscriptionId = subscriptionId;
+        attempt.billingKeyId   = billingKeyId;
+        attempt.billingCycle   = YearMonth.now().format(CYCLE_FORMATTER);
+        attempt.status         = BillingAttemptStatus.SUCCESS;
+        attempt.failureReason  = null;
+        attempt.attemptedAt    = LocalDateTime.now();
+        return attempt;
+    }
+
+    public static BillingAttempt failure(Long subscriptionId, Long billingKeyId,
+                                          BillingFailureReason reason) {
+        BillingAttempt attempt = new BillingAttempt();
+        attempt.subscriptionId = subscriptionId;
+        attempt.billingKeyId   = billingKeyId;
+        attempt.billingCycle   = YearMonth.now().format(CYCLE_FORMATTER);
+        attempt.status         = BillingAttemptStatus.FAILED;
+        attempt.failureReason  = reason;
+        attempt.attemptedAt    = LocalDateTime.now();
+        return attempt;
+    }
+}

--- a/src/main/java/com/fivefy/domain/billingattempt/entity/BillingAttempt.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/entity/BillingAttempt.java
@@ -23,7 +23,7 @@ public class BillingAttempt extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Long subscriptionId;
+    private Long userId;
 
     @Column(nullable = false)
     private Long billingKeyId;
@@ -48,9 +48,9 @@ public class BillingAttempt extends BaseEntity {
     private static final DateTimeFormatter CYCLE_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM");
 
-    public static BillingAttempt success(Long subscriptionId, Long billingKeyId) {
+    public static BillingAttempt success(Long userId, Long billingKeyId) {
         BillingAttempt attempt = new BillingAttempt();
-        attempt.subscriptionId = subscriptionId;
+        attempt.userId         = userId;
         attempt.billingKeyId   = billingKeyId;
         attempt.billingCycle   = YearMonth.now().format(CYCLE_FORMATTER);
         attempt.status         = BillingAttemptStatus.SUCCESS;
@@ -59,10 +59,10 @@ public class BillingAttempt extends BaseEntity {
         return attempt;
     }
 
-    public static BillingAttempt failure(Long subscriptionId, Long billingKeyId,
+    public static BillingAttempt failure(Long userId, Long billingKeyId,
                                           BillingFailureReason reason) {
         BillingAttempt attempt = new BillingAttempt();
-        attempt.subscriptionId = subscriptionId;
+        attempt.userId         = userId;
         attempt.billingKeyId   = billingKeyId;
         attempt.billingCycle   = YearMonth.now().format(CYCLE_FORMATTER);
         attempt.status         = BillingAttemptStatus.FAILED;

--- a/src/main/java/com/fivefy/domain/billingattempt/enums/BillingAttemptStatus.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/enums/BillingAttemptStatus.java
@@ -1,0 +1,6 @@
+package com.fivefy.domain.billingattempt.enums;
+
+public enum BillingAttemptStatus {
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/com/fivefy/domain/billingattempt/enums/BillingFailureReason.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/enums/BillingFailureReason.java
@@ -1,0 +1,9 @@
+package com.fivefy.domain.billingattempt.enums;
+
+public enum BillingFailureReason {
+    CARD_DECLINED,          // 카드 거절 (한도 초과, 분실 신고 등)
+    PG_TIMEOUT,             // PG사 타임아웃
+    BILLING_KEY_INVALID,    // 빌링키 만료/삭제됨
+    DB_ERROR,               // 포트원 성공 + DB 저장 실패 (제일 위험)
+    UNKNOWN                 // 그 외
+}

--- a/src/main/java/com/fivefy/domain/billingattempt/repository/BillingAttemptRepository.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/repository/BillingAttemptRepository.java
@@ -1,0 +1,12 @@
+package com.fivefy.domain.billingattempt.repository;
+
+import com.fivefy.domain.billingattempt.entity.BillingAttempt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BillingAttemptRepository extends JpaRepository<BillingAttempt, Long> {
+
+    Optional<BillingAttempt> findBySubscriptionIdAndBillingCycle(
+            Long subscriptionId, String billingCycle);
+}

--- a/src/main/java/com/fivefy/domain/billingattempt/repository/BillingAttemptRepository.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/repository/BillingAttemptRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface BillingAttemptRepository extends JpaRepository<BillingAttempt, Long> {
 
-    Optional<BillingAttempt> findBySubscriptionIdAndBillingCycle(
-            Long subscriptionId, String billingCycle);
+    Optional<BillingAttempt> findByUserIdAndBillingCycle(
+            Long userId, String billingCycle);
 }

--- a/src/main/java/com/fivefy/domain/billingattempt/service/BillingAttemptPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/service/BillingAttemptPersistenceService.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.billingattempt.service;
 
 import com.fivefy.domain.billingattempt.entity.BillingAttempt;
+import com.fivefy.domain.billingattempt.enums.BillingAttemptStatus;
 import com.fivefy.domain.billingattempt.enums.BillingFailureReason;
 import com.fivefy.domain.billingattempt.repository.BillingAttemptRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -16,17 +20,20 @@ public class BillingAttemptPersistenceService {
 
     private final BillingAttemptRepository billingAttemptRepository;
 
+    private static final DateTimeFormatter CYCLE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM");
+
     /**
      * 실패 기록
      * REQUIRES_NEW — 부모 트랜잭션 롤백과 무관하게 반드시 커밋
      * "이번 달에 이미 실패했다"는 기록이 남아야 재시도 중복 방지가 가능
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void saveFailure(Long subscriptionId, Long billingKeyId,
+    public void saveFailure(Long userId, Long billingKeyId,
                             BillingFailureReason reason) {
-        BillingAttempt attempt = BillingAttempt.failure(subscriptionId, billingKeyId, reason);
+        BillingAttempt attempt = BillingAttempt.failure(userId, billingKeyId, reason);
         billingAttemptRepository.save(attempt);
-        log.info("[BillingAttempt] 실패 기록 subscriptionId={}, reason={}", subscriptionId, reason);
+        log.info("[BillingAttempt] 실패 기록 userId={}, reason={}", userId, reason);
     }
 
     /**
@@ -35,9 +42,23 @@ public class BillingAttemptPersistenceService {
      * 별도 REQUIRES_NEW 불필요 — CashOrder/Payment/PointHistory와 원자적으로 저장
      */
     @Transactional
-    public void saveSuccess(Long subscriptionId, Long billingKeyId) {
-        BillingAttempt attempt = BillingAttempt.success(subscriptionId, billingKeyId);
-        billingAttemptRepository.save(attempt);
-        log.info("[BillingAttempt] 성공 기록 subscriptionId={}", subscriptionId);
+    public void saveSuccess(Long userId, Long billingKeyId) {
+        String currentCycle = YearMonth.now().format(CYCLE_FORMATTER);
+
+        // 이번 달 SUCCESS 기록이 이미 있으면 중복 저장 방지
+        boolean alreadySuccess = billingAttemptRepository
+                .findByUserIdAndBillingCycle(userId, currentCycle)
+                .stream()
+                .anyMatch(a -> a.getStatus() == BillingAttemptStatus.SUCCESS);
+
+        if (alreadySuccess) {
+            // 이미 이번 달 성공했으면 또 저장하지 않음
+            log.warn("[BillingAttempt] 이미 성공 기록 존재 userId={}, cycle={}",
+                    userId, currentCycle);
+            return;
+        }
+
+        billingAttemptRepository.save(BillingAttempt.success(userId, billingKeyId));
+        log.info("[BillingAttempt] 성공 기록 userId={}", userId);
     }
 }

--- a/src/main/java/com/fivefy/domain/billingattempt/service/BillingAttemptPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/billingattempt/service/BillingAttemptPersistenceService.java
@@ -1,0 +1,43 @@
+package com.fivefy.domain.billingattempt.service;
+
+import com.fivefy.domain.billingattempt.entity.BillingAttempt;
+import com.fivefy.domain.billingattempt.enums.BillingFailureReason;
+import com.fivefy.domain.billingattempt.repository.BillingAttemptRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BillingAttemptPersistenceService {
+
+    private final BillingAttemptRepository billingAttemptRepository;
+
+    /**
+     * 실패 기록
+     * REQUIRES_NEW — 부모 트랜잭션 롤백과 무관하게 반드시 커밋
+     * "이번 달에 이미 실패했다"는 기록이 남아야 재시도 중복 방지가 가능
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveFailure(Long subscriptionId, Long billingKeyId,
+                            BillingFailureReason reason) {
+        BillingAttempt attempt = BillingAttempt.failure(subscriptionId, billingKeyId, reason);
+        billingAttemptRepository.save(attempt);
+        log.info("[BillingAttempt] 실패 기록 subscriptionId={}, reason={}", subscriptionId, reason);
+    }
+
+    /**
+     * 성공 기록
+     * saveRecurringChargeResult() 내부 트랜잭션에서 같이 커밋
+     * 별도 REQUIRES_NEW 불필요 — CashOrder/Payment/PointHistory와 원자적으로 저장
+     */
+    @Transactional
+    public void saveSuccess(Long subscriptionId, Long billingKeyId) {
+        BillingAttempt attempt = BillingAttempt.success(subscriptionId, billingKeyId);
+        billingAttemptRepository.save(attempt);
+        log.info("[BillingAttempt] 성공 기록 subscriptionId={}", subscriptionId);
+    }
+}

--- a/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
+++ b/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
@@ -2,6 +2,7 @@ package com.fivefy.domain.billingkey.controller;
 
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
+import com.fivefy.domain.subscription.enums.SubscriptionErrorCode;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.entity.Subscription;
@@ -71,16 +72,17 @@ public class BillingKeyController {
     public ResponseEntity<String> testCharge(
             @AuthenticationPrincipal Long userId
     ) {
+        // 빌링키  체크
         BillingKey billingKey = billingKeyRepository.findByUserIdAndActiveTrue(userId)
-                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ALREADY_DEACTIVATED));
+                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ACTIVE_NOT_FOUND));
 
-        // subscription 변수 선언 추가
+        // subscription 변수 선언 추가(구독 체크)
         Subscription subscription = subscriptionRepository
                 .findByUserIdAndPlanTypeAndStatus(
                         userId,
                         SubscriptionPlanType.RECURRING,
                         SubscriptionStatus.ACTIVE)
-                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_FOUND));
 
         cashOrderService.processRecurringCharge(billingKey, subscription);
 

--- a/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
+++ b/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
@@ -74,17 +74,12 @@ public class BillingKeyController {
     ) {
         // 빌링키  체크
         BillingKey billingKey = billingKeyRepository.findByUserIdAndActiveTrue(userId)
-                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ACTIVE_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(
+                        BillingKeyErrorCode.ERR_BILLING_KEY_ACTIVE_NOT_FOUND)
+                );
 
-        // subscription 변수 선언 추가(구독 체크)
-        Subscription subscription = subscriptionRepository
-                .findByUserIdAndPlanTypeAndStatus(
-                        userId,
-                        SubscriptionPlanType.RECURRING,
-                        SubscriptionStatus.ACTIVE)
-                .orElseThrow(() -> new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_FOUND));
-
-        cashOrderService.processRecurringCharge(billingKey, subscription);
+        // 구독 여부 확인 없이 바로 카드 청구
+        cashOrderService.processRecurringCharge(billingKey);
 
         return ResponseEntity.ok("카드 청구 완료 — 지갑을 조회해서 포인트 충전을 확인하세요.");
     }

--- a/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
+++ b/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
@@ -1,11 +1,15 @@
 package com.fivefy.domain.billingkey.controller;
 
+import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
+import com.fivefy.domain.subscription.enums.SubscriptionStatus;
+import com.fivefy.domain.subscription.entity.Subscription;
 import com.fivefy.domain.billingkey.dto.BillingKeyRegisterRequest;
 import com.fivefy.domain.billingkey.dto.BillingKeyResponse;
 import com.fivefy.domain.billingkey.entity.BillingKey;
 import com.fivefy.domain.billingkey.repository.BillingKeyRepository;
 import com.fivefy.domain.billingkey.service.BillingKeyService;
 import com.fivefy.domain.cashorder.service.CashOrderService;
+import com.fivefy.domain.subscription.repository.SubscriptionRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +24,7 @@ public class BillingKeyController {
     private final BillingKeyService billingKeyService;
     private final BillingKeyRepository billingKeyRepository;
     private final CashOrderService cashOrderService;
+    private final SubscriptionRepository subscriptionRepository;
 
     /**
      * 카드(빌링키) 등록
@@ -67,9 +72,16 @@ public class BillingKeyController {
         BillingKey billingKey = billingKeyRepository.findByUserIdAndActiveTrue(userId)
                 .orElseThrow(() -> new IllegalArgumentException("활성 빌링키가 없습니다. 먼저 카드를 등록하세요."));
 
-        cashOrderService.processRecurringCharge(billingKey);
+        // subscription 변수 선언 추가
+        Subscription subscription = subscriptionRepository
+                .findByUserIdAndPlanTypeAndStatus(
+                        userId,
+                        SubscriptionPlanType.RECURRING,
+                        SubscriptionStatus.ACTIVE)
+                .orElseThrow(() -> new IllegalArgumentException("활성 구독이 없습니다."));
+
+        cashOrderService.processRecurringCharge(billingKey, subscription);
 
         return ResponseEntity.ok("카드 청구 완료 — 지갑을 조회해서 포인트 충전을 확인하세요.");
     }
-
 }

--- a/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
+++ b/src/main/java/com/fivefy/domain/billingkey/controller/BillingKeyController.java
@@ -1,5 +1,7 @@
 package com.fivefy.domain.billingkey.controller;
 
+import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.entity.Subscription;
@@ -70,7 +72,7 @@ public class BillingKeyController {
             @AuthenticationPrincipal Long userId
     ) {
         BillingKey billingKey = billingKeyRepository.findByUserIdAndActiveTrue(userId)
-                .orElseThrow(() -> new IllegalArgumentException("활성 빌링키가 없습니다. 먼저 카드를 등록하세요."));
+                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_ALREADY_DEACTIVATED));
 
         // subscription 변수 선언 추가
         Subscription subscription = subscriptionRepository
@@ -78,7 +80,7 @@ public class BillingKeyController {
                         userId,
                         SubscriptionPlanType.RECURRING,
                         SubscriptionStatus.ACTIVE)
-                .orElseThrow(() -> new IllegalArgumentException("활성 구독이 없습니다."));
+                .orElseThrow(() -> new BusinessException(BillingKeyErrorCode.ERR_BILLING_KEY_NOT_FOUND));
 
         cashOrderService.processRecurringCharge(billingKey, subscription);
 

--- a/src/main/java/com/fivefy/domain/billingkey/enums/BillingKeyErrorCode.java
+++ b/src/main/java/com/fivefy/domain/billingkey/enums/BillingKeyErrorCode.java
@@ -12,7 +12,8 @@ public enum BillingKeyErrorCode implements ErrorCode {
     ERR_BILLING_KEY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 카드입니다"),
     ERR_BILLING_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "빌링키를 찾을 수 없습니다"),
     ERR_BILLING_KEY_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 카드만 삭제할 수 있습니다"),
-    ERR_BILLING_KEY_ALREADY_DEACTIVATED(HttpStatus.BAD_REQUEST, "이미 해지된 빌링키입니다");
+    ERR_BILLING_KEY_ALREADY_DEACTIVATED(HttpStatus.BAD_REQUEST, "이미 해지된 빌링키입니다"),
+    ERR_BILLING_KEY_ACTIVE_NOT_FOUND(HttpStatus.NOT_FOUND, "활성 빌링키가 없습니다. 먼저 카드를 등록하세요"); // 추가
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/cashorder/scheduler/CashOrderScheduler.java
+++ b/src/main/java/com/fivefy/domain/cashorder/scheduler/CashOrderScheduler.java
@@ -49,7 +49,7 @@ public class CashOrderScheduler {
             try {
                 billingKeyRepository.findByUserIdAndActiveTrue(subscription.getUserId())
                         .ifPresentOrElse(
-                                billingKey -> cashOrderService.processRecurringCharge(billingKey),
+                                billingKey -> cashOrderService.processRecurringCharge(billingKey, subscription),
                                 () -> log.warn("[정기충전 스케줄러] 빌링키 없음 — userId={}",
                                         subscription.getUserId())
                         );

--- a/src/main/java/com/fivefy/domain/cashorder/scheduler/CashOrderScheduler.java
+++ b/src/main/java/com/fivefy/domain/cashorder/scheduler/CashOrderScheduler.java
@@ -33,9 +33,10 @@ public class CashOrderScheduler {
         LocalDateTime now = LocalDateTime.now();
         log.info("[정기충전 스케줄러] 실행 시작 — {}", now);
 
+        // 카드 자동 청구 대상은 RECURRING_AUTO만
         List<Subscription> targets = subscriptionRepository
                 .findAllByPlanTypeAndStatusAndNextBillingDateBefore(
-                        SubscriptionPlanType.RECURRING,
+                        SubscriptionPlanType.RECURRING_AUTO,
                         SubscriptionStatus.ACTIVE,
                         now
                 );
@@ -49,7 +50,7 @@ public class CashOrderScheduler {
             try {
                 billingKeyRepository.findByUserIdAndActiveTrue(subscription.getUserId())
                         .ifPresentOrElse(
-                                billingKey -> cashOrderService.processRecurringCharge(billingKey, subscription),
+                                billingKey -> cashOrderService.processRecurringCharge(billingKey),
                                 () -> log.warn("[정기충전 스케줄러] 빌링키 없음 — userId={}",
                                         subscription.getUserId())
                         );

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
@@ -2,8 +2,6 @@ package com.fivefy.domain.cashorder.service;
 
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.billingattempt.service.BillingAttemptPersistenceService;
-import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
-import com.fivefy.domain.billingkey.repository.BillingKeyRepository;
 import com.fivefy.domain.cashorder.dto.CashOrderResponse;
 import com.fivefy.domain.cashorder.entity.CashOrder;
 import com.fivefy.domain.cashorder.enums.CashProductType;
@@ -41,8 +39,8 @@ public class CashOrderPersistenceService {
     private final PaymentRepository paymentRepository;
     private final WalletRepository walletRepository;
     private final PointHistoryRepository pointHistoryRepository;
-    private final BillingKeyRepository billingKeyRepository;
     private final BillingAttemptPersistenceService billingAttemptPersistenceService;
+
 
     /**
      * 환불은 DB 상태 변경만 담당

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.cashorder.service;
 
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.billingattempt.service.BillingAttemptPersistenceService;
 import com.fivefy.domain.billingkey.enums.BillingKeyErrorCode;
 import com.fivefy.domain.billingkey.repository.BillingKeyRepository;
 import com.fivefy.domain.cashorder.dto.CashOrderResponse;
@@ -10,6 +11,7 @@ import com.fivefy.domain.cashorder.repository.CashOrderRepository;
 import com.fivefy.domain.billingkey.entity.BillingKey;
 import com.fivefy.domain.payment.entity.Payment;
 import com.fivefy.domain.payment.repository.PaymentRepository;
+import com.fivefy.domain.subscription.entity.Subscription;
 import com.fivefy.domain.wallet.entity.PointHistory;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.enums.PointHistoryType;
@@ -40,6 +42,7 @@ public class CashOrderPersistenceService {
     private final WalletRepository walletRepository;
     private final PointHistoryRepository pointHistoryRepository;
     private final BillingKeyRepository billingKeyRepository;
+    private final BillingAttemptPersistenceService billingAttemptPersistenceService;
 
     /**
      * 환불은 DB 상태 변경만 담당
@@ -92,6 +95,7 @@ public class CashOrderPersistenceService {
     @Transactional
     public void saveRecurringChargeResult(
             BillingKey billingKey,    // Long userId → BillingKey billingKey 로 변경
+            Subscription subscription,
             String orderNumber,
             CashProductType productType,
             PortoneBillingPaymentResponse pgResponse
@@ -130,6 +134,9 @@ public class CashOrderPersistenceService {
                 cashOrder.getId(),
                 null
         ));
+
+        // 성공 기록 저장
+        billingAttemptPersistenceService.saveSuccess(subscription.getId(), billingKey.getId());
 
         log.info("[정기충전] DB 저장 완료 userId={}, orderNumber={}", userId, orderNumber);
     }

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderPersistenceService.java
@@ -9,7 +9,6 @@ import com.fivefy.domain.cashorder.repository.CashOrderRepository;
 import com.fivefy.domain.billingkey.entity.BillingKey;
 import com.fivefy.domain.payment.entity.Payment;
 import com.fivefy.domain.payment.repository.PaymentRepository;
-import com.fivefy.domain.subscription.entity.Subscription;
 import com.fivefy.domain.wallet.entity.PointHistory;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.enums.PointHistoryType;
@@ -93,7 +92,6 @@ public class CashOrderPersistenceService {
     @Transactional
     public void saveRecurringChargeResult(
             BillingKey billingKey,    // Long userId → BillingKey billingKey 로 변경
-            Subscription subscription,
             String orderNumber,
             CashProductType productType,
             PortoneBillingPaymentResponse pgResponse
@@ -134,7 +132,7 @@ public class CashOrderPersistenceService {
         ));
 
         // 성공 기록 저장
-        billingAttemptPersistenceService.saveSuccess(subscription.getId(), billingKey.getId());
+        billingAttemptPersistenceService.saveSuccess(userId, billingKey.getId());
 
         log.info("[정기충전] DB 저장 완료 userId={}, orderNumber={}", userId, orderNumber);
     }

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
@@ -8,6 +8,8 @@ import com.fivefy.common.portone.dto.PortoneBillingPaymentResponse;
 import com.fivefy.common.portone.dto.PortoneCancelResponse;
 import com.fivefy.common.portone.dto.PortonePaymentResponse;
 import com.fivefy.common.portone.dto.PortoneWebhookRequest;
+import com.fivefy.domain.billingattempt.enums.BillingFailureReason;
+import com.fivefy.domain.billingattempt.service.BillingAttemptPersistenceService;
 import com.fivefy.domain.billingkey.entity.BillingKey;
 import com.fivefy.domain.billingkey.service.BillingKeyPersistenceService;
 import com.fivefy.domain.cashorder.dto.CashOrderPurchaseResponse;
@@ -22,6 +24,7 @@ import com.fivefy.domain.cashorder.repository.CashOrderRepository;
 import com.fivefy.domain.payment.entity.Payment;
 import com.fivefy.domain.payment.enums.PaymentErrorCode;
 import com.fivefy.domain.payment.repository.PaymentRepository;
+import com.fivefy.domain.subscription.entity.Subscription;
 import com.fivefy.domain.wallet.entity.PointHistory;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.enums.PointHistoryType;
@@ -51,6 +54,7 @@ public class CashOrderService {
     private final ObjectMapper objectMapper;
     private final CashOrderPersistenceService cashOrderPersistenceService;   // DB 저장 분리
     private final BillingKeyPersistenceService billingKeyPersistenceService;
+    private final BillingAttemptPersistenceService billingAttemptPersistenceService;
 
     /**
      * 포인트 충전 주문
@@ -262,24 +266,28 @@ public class CashOrderService {
      * 정기 포인트 자동 충전 (빌링키 청구)
      * RecurringChargeScheduler에서 매월 1일 오전 8시 호출
      *
-     * 흐름:
-     * 1. 포트원에 빌링키로 카드 청구 (1,000원)
-     * 2. 청구 성공 시 CashOrder(SUCCESS) + Payment 생성
-     * 3. 지갑에 포인트 충전 (1,500P) + PointHistory 기록
-     * 4. 실패 시 BillingKey 비활성화 (카드 만료/한도 초과 등)
+     * 포트원에 빌링키로 카드 청구 (1,000원)
+     * 청구 성공 시 CashOrder(SUCCESS) + Payment 생성
+     * 지갑에 포인트 충전 (1,500P) + PointHistory 기록
+     * 실패 시 BillingKey 비활성화 (카드 만료/한도 초과 등)
+     *
+     * 실패/성공 지점마다 BillingAttempt 기록
+     *    - portoneClient 예외 발생             : CARD_DECLINED or PG_TIMEOUT
+     *    - pgResponse.payment() == null       : CARD_DECLINED
+     *    - saveRecurringChargeResult 내부 예외 : DB_ERROR
      *
      * @param billingKey 청구할 빌링키 엔티티
      */
     @RedissonLock(key = "'wallet:' + #billingKey.userId")
     @Transactional
-    public void processRecurringCharge(BillingKey billingKey) {
+    public void processRecurringCharge(BillingKey billingKey, Subscription subscription) {
         Long userId = billingKey.getUserId();
         CashProductType productType = CashProductType.PRODUCT_4_RECURRING;
         String orderNumber = "REC-" + UUID.randomUUID().toString().substring(0, 8);
 
         log.info("[정기충전] 시작 userId={}, orderNumber={}", userId, orderNumber);
 
-        // 1. 포트원 빌링키 청구(외부 API 호출)
+        // 포트원 빌링키 청구(외부 API 호출)
         PortoneBillingPaymentResponse pgResponse;
         try {
             pgResponse = portoneClient.chargeWithBillingKey(
@@ -294,10 +302,13 @@ public class CashOrderService {
             log.error("[정기충전] 포트원 청구 실패 — userId={}, 사유={}", userId, e.getMessage());
             billingKeyPersistenceService.deactivateBillingKey(billingKey.getId());        // 카드 만료/한도 초과 등 → 비활성화
 
+            // 실패 기록 (별도 트랜잭션 — 부모 롤백과 무관하게 커밋)
+            billingAttemptPersistenceService.saveFailure(
+                    subscription.getId(), billingKey.getId(), BillingFailureReason.PG_TIMEOUT);
             return;
         }
 
-        // 청구 실패 상태 응답 처리
+        // 응답은 했으나 청구 실패 상태 처리
         // if ("FAILED".equals(pgResponse.status())) {
         // status 체크 대신 payment 객체로 성공 여부 판단
         if (pgResponse.payment() == null) {
@@ -308,7 +319,7 @@ public class CashOrderService {
         }
 
         // 포트원 청구 성공 확정 후 DB 작업만 별도 트랜잭션으로
-        cashOrderPersistenceService.saveRecurringChargeResult(billingKey, orderNumber, productType, pgResponse);
+        cashOrderPersistenceService.saveRecurringChargeResult(billingKey, subscription, orderNumber, productType, pgResponse);
 
         log.info("[정기충전] 완료 — userId={}, orderNumber={}, 충전P={}",
                 userId, orderNumber, productType.getPointAmount());

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
@@ -24,7 +24,6 @@ import com.fivefy.domain.cashorder.repository.CashOrderRepository;
 import com.fivefy.domain.payment.entity.Payment;
 import com.fivefy.domain.payment.enums.PaymentErrorCode;
 import com.fivefy.domain.payment.repository.PaymentRepository;
-import com.fivefy.domain.subscription.entity.Subscription;
 import com.fivefy.domain.wallet.entity.PointHistory;
 import com.fivefy.domain.wallet.entity.Wallet;
 import com.fivefy.domain.wallet.enums.PointHistoryType;
@@ -280,7 +279,7 @@ public class CashOrderService {
      */
     @RedissonLock(key = "'wallet:' + #billingKey.userId")
     @Transactional
-    public void processRecurringCharge(BillingKey billingKey, Subscription subscription) {
+    public void processRecurringCharge(BillingKey billingKey) {
         Long userId = billingKey.getUserId();
         CashProductType productType = CashProductType.PRODUCT_4_RECURRING;
         String orderNumber = "REC-" + UUID.randomUUID().toString().substring(0, 8);
@@ -304,7 +303,7 @@ public class CashOrderService {
 
             // 실패 기록 (별도 트랜잭션 — 부모 롤백과 무관하게 커밋)
             billingAttemptPersistenceService.saveFailure(
-                    subscription.getId(), billingKey.getId(), BillingFailureReason.PG_TIMEOUT);
+                    userId, billingKey.getId(), BillingFailureReason.PG_TIMEOUT);
 
             return;
         }
@@ -318,15 +317,15 @@ public class CashOrderService {
 
             // CARD_DECLINED 실패 기록
             billingAttemptPersistenceService.saveFailure(
-                    subscription.getId(), billingKey.getId(), BillingFailureReason.CARD_DECLINED
+                    userId, billingKey.getId(), BillingFailureReason.CARD_DECLINED
             );
-            
+
             return;
         }
 
         // 포트원 청구 성공 확정 후 DB 작업만 별도 트랜잭션으로
         cashOrderPersistenceService.saveRecurringChargeResult(
-                billingKey, subscription, orderNumber, productType, pgResponse
+                billingKey, orderNumber, productType, pgResponse
         );
 
         log.info("[정기충전] 완료 — userId={}, orderNumber={}, 충전P={}",

--- a/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
+++ b/src/main/java/com/fivefy/domain/cashorder/service/CashOrderService.java
@@ -305,6 +305,7 @@ public class CashOrderService {
             // 실패 기록 (별도 트랜잭션 — 부모 롤백과 무관하게 커밋)
             billingAttemptPersistenceService.saveFailure(
                     subscription.getId(), billingKey.getId(), BillingFailureReason.PG_TIMEOUT);
+
             return;
         }
 
@@ -315,11 +316,18 @@ public class CashOrderService {
             log.warn("[정기충전] 포트원 청구 거절 — userId={}", userId);
             billingKeyPersistenceService.deactivateBillingKey(billingKey.getId());
 
+            // CARD_DECLINED 실패 기록
+            billingAttemptPersistenceService.saveFailure(
+                    subscription.getId(), billingKey.getId(), BillingFailureReason.CARD_DECLINED
+            );
+            
             return;
         }
 
         // 포트원 청구 성공 확정 후 DB 작업만 별도 트랜잭션으로
-        cashOrderPersistenceService.saveRecurringChargeResult(billingKey, subscription, orderNumber, productType, pgResponse);
+        cashOrderPersistenceService.saveRecurringChargeResult(
+                billingKey, subscription, orderNumber, productType, pgResponse
+        );
 
         log.info("[정기충전] 완료 — userId={}, orderNumber={}, 충전P={}",
                 userId, orderNumber, productType.getPointAmount());

--- a/src/main/java/com/fivefy/domain/pointorder/dto/PointOrderPurchaseRequest.java
+++ b/src/main/java/com/fivefy/domain/pointorder/dto/PointOrderPurchaseRequest.java
@@ -9,6 +9,6 @@ import jakarta.validation.constraints.NotNull;
  */
 public record PointOrderPurchaseRequest(
         @NotNull(message = "구독 플랜 타입은 필수입니다")
-        SubscriptionPlanType planType   // FREE / RECURRING
+        SubscriptionPlanType planType   // FREE / RECURRING / RECURRING_AUTO
 ) {}
 

--- a/src/main/java/com/fivefy/domain/pointorder/service/PointOrderService.java
+++ b/src/main/java/com/fivefy/domain/pointorder/service/PointOrderService.java
@@ -76,11 +76,12 @@ public class PointOrderService {
             }
         }
 
-        // 2. RECURRING 중복 가입 방지 (ACTIVE만 체크)
-        if (planType == SubscriptionPlanType.RECURRING) {
+        // 2. RECURRING/RECURRING_AUTO 중복 가입 방지 (ACTIVE만 체크)
+        if (planType == SubscriptionPlanType.RECURRING || planType == SubscriptionPlanType.RECURRING_AUTO) {
             boolean alreadyActive = subscriptionRepository
                     .findAllByUserId(userId).stream()
-                    .anyMatch(s -> s.getPlanType() == SubscriptionPlanType.RECURRING
+                    .anyMatch(s -> (s.getPlanType() == SubscriptionPlanType.RECURRING
+                                        || s.getPlanType() == SubscriptionPlanType.RECURRING_AUTO)
                             && s.getStatus() == SubscriptionStatus.ACTIVE);
             if (alreadyActive) {
                 throw new BusinessException(PointOrderErrorCode.ERR_SUBSCRIPTION_ALREADY_ACTIVE);
@@ -198,7 +199,8 @@ public class PointOrderService {
     private String buildSubscribeContent(SubscriptionPlanType planType, LocalDateTime expiryDate) {
         return switch (planType) {
             case FREE -> "무료 체험 구독이 시작되었습니다. 만료일: " + expiryDate.format(DATE_FORMATTER);
-            case RECURRING -> "정기 구독이 시작되었습니다. 다음 갱신일: " + expiryDate.format(DATE_FORMATTER);
+            case RECURRING -> "단건 구독이 시작되었습니다. 만료일: " + expiryDate.format(DATE_FORMATTER);
+            case RECURRING_AUTO -> "정기 구독이 시작되었습니다. 다음 갱신일: " + expiryDate.format(DATE_FORMATTER);
         };
     }
 }

--- a/src/main/java/com/fivefy/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/fivefy/domain/subscription/controller/SubscriptionController.java
@@ -1,9 +1,11 @@
 package com.fivefy.domain.subscription.controller;
 
 
+import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.pointorder.service.PointOrderService;
 import com.fivefy.domain.subscription.dto.SubscriptionResponse;
 import com.fivefy.domain.subscription.entity.Subscription;
+import com.fivefy.domain.subscription.enums.SubscriptionErrorCode;
 import com.fivefy.domain.subscription.enums.SubscriptionPlanType;
 import com.fivefy.domain.subscription.enums.SubscriptionStatus;
 import com.fivefy.domain.subscription.repository.SubscriptionRepository;
@@ -68,8 +70,8 @@ public class SubscriptionController {
                         SubscriptionPlanType.RECURRING,
                         SubscriptionStatus.ACTIVE
                 )
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "RECURRING(PlanType : 정기구독) + ACTIVE(Status : 활성화) 구독이 없습니다. 먼저 정기구독을 구매하세요."
+                .orElseThrow(() -> new BusinessException(
+                        SubscriptionErrorCode.ERR_SUBSCRIPTION_RECURRING_NOT_FOUND
                 ));
 
         pointOrderService.processRecurringPayment(subscription);
@@ -92,8 +94,9 @@ public class SubscriptionController {
                         userId,
                         SubscriptionPlanType.RECURRING,
                         SubscriptionStatus.ACTIVE)
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "RECURRING + ACTIVE 구독이 없습니다."));
+                .orElseThrow(() -> new BusinessException(
+                        SubscriptionErrorCode.ERR_SUBSCRIPTION_RECURRING_NOT_FOUND
+                ));
 
         sub.skipOneMonth(); // 엔티티 메서드 추가 필요
         subscriptionRepository.save(sub);

--- a/src/main/java/com/fivefy/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/fivefy/domain/subscription/controller/SubscriptionController.java
@@ -67,7 +67,7 @@ public class SubscriptionController {
         Subscription subscription = subscriptionRepository
                 .findByUserIdAndPlanTypeAndStatus(
                         userId,
-                        SubscriptionPlanType.RECURRING,
+                        SubscriptionPlanType.RECURRING_AUTO,
                         SubscriptionStatus.ACTIVE
                 )
                 .orElseThrow(() -> new BusinessException(

--- a/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
@@ -79,13 +79,9 @@ public class Subscription extends BaseEntity {
             // 만료일(구독일 + 1개월)
             subscription.expiryDate = planType.calculateExpiryDate(startDate);
             // 정기 구독 상태이면 다음 갱신일 1개월, 아니라면 null(구독 취소 된 상태. 남은 기간 이용 가능)
-            subscription.nextBillingDate = (planType == SubscriptionPlanType.RECURRING)
+            subscription.nextBillingDate = planType.isAutoRenew()
                     ? startDate.plusMonths(1)
                     : null;
-              // 테스트 용도
-//            subscription.nextBillingDate = (planType == SubscriptionPlanType.RECURRING)
-//                    ? subscription.expiryDate  // 만료일과 동일
-//                    : null;
 
         return subscription;
     }

--- a/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/fivefy/domain/subscription/entity/Subscription.java
@@ -91,7 +91,6 @@ public class Subscription extends BaseEntity {
     }
 
     // 2026-04-30 : 상태 패턴 적용. if문 → state() 교체
-
     /**
      * 구독 취소 - 다음 결제 중단, 만료일까지 이용 가능
      *
@@ -99,17 +98,6 @@ public class Subscription extends BaseEntity {
      * 차단: CANCELED (이미 취소), EXPIRE (이미 만료)
      * 제약: FREE(무료) 플랜 취소 불가, RECURRING(정기 구독) 플랜만 가능
      */
-//    public void cancel() {
-//        if (this.planType == SubscriptionPlanType.FREE) {
-//            throw new BusinessException(SubscriptionErrorCode.ERR_FREE_SUBSCRIPTION_CANNOT_CANCEL);
-//        }
-//        if (this.status != SubscriptionStatus.ACTIVE && this.status != SubscriptionStatus.INACTIVE) {
-//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_INVALID_STATUS_CANCEL);
-//        }
-//
-//        this.status = SubscriptionStatus.CANCELED;
-//        this.nextBillingDate = null;
-//    }
     public void cancel() {
         state().cancel(this);
     }
@@ -122,14 +110,6 @@ public class Subscription extends BaseEntity {
      *
      * 만료 이후 재구독은 별개의 Subscription 객체를 생성한다.
      */
-//    public void expire() {
-//        if (this.status == SubscriptionStatus.EXPIRE) {
-//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_EXPIRED);
-//        }
-//
-//        this.status = SubscriptionStatus.EXPIRE;
-//        this.nextBillingDate = null;
-//    }
     public void expire() {
         state().expire(this);
     }
@@ -142,20 +122,6 @@ public class Subscription extends BaseEntity {
      * 허용: ACTIVE + nextBillingDate 존재
      * 차단: FREE 플랜, 취소된 구독 (nextBillingDate = null)
      */
-//    public void renew() {
-//        if (this.planType != SubscriptionPlanType.RECURRING) {
-//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_RECURRING);
-//        }
-//
-//        if (this.nextBillingDate == null) {
-//            throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_ALREADY_CANCELED);
-//        }
-//
-//        this.nextBillingDate = this.nextBillingDate.plusMonths(1);
-//        this.expiryDate      = this.expiryDate.plusMonths(1);
-//        this.status          = SubscriptionStatus.ACTIVE;
-//    }
-
     public void renew() {
         state().renew(this);
     }

--- a/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
+++ b/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionErrorCode.java
@@ -15,7 +15,8 @@ public enum SubscriptionErrorCode implements ErrorCode {
     ERR_SUBSCRIPTION_NOT_RECURRING(HttpStatus.BAD_REQUEST, "RECURRING 플랜만 갱신할 수 있습니다"),
     ERR_SUBSCRIPTION_ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "취소된 구독은 갱신할 수 없습니다"),
     ERR_SUBSCRIPTION_ALREADY_EXPIRED(HttpStatus.BAD_REQUEST, "이미 만료된 구독입니다"),
-    ERR_SUBSCRIPTION_UNSUPPORTED_STATUS(HttpStatus.BAD_REQUEST, "해당 구독 상태에서는 지원하지 않는 작업입니다");
+    ERR_SUBSCRIPTION_UNSUPPORTED_STATUS(HttpStatus.BAD_REQUEST, "해당 구독 상태에서는 지원하지 않는 작업입니다"),
+    ERR_SUBSCRIPTION_RECURRING_NOT_FOUND(HttpStatus.NOT_FOUND, "RECURRING(정기구독) + ACTIVE(활성화) 구독이 없습니다. 먼저 정기구독을 구매하세요");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionPlanType.java
+++ b/src/main/java/com/fivefy/domain/subscription/enums/SubscriptionPlanType.java
@@ -8,8 +8,9 @@ import java.time.LocalDateTime;
 @Getter
 @RequiredArgsConstructor
 public enum SubscriptionPlanType {
-    FREE(0L,      "3일 체험"),
-    RECURRING(50L, "정기 구독");
+    FREE(0L,  "3일 체험"),                       // 무료(1회)     : 다음 갱신일 없음
+    RECURRING(50L, "정기 구독"),                 // 포인트 단건    : 다음 갱신일 없음
+    RECURRING_AUTO(50L, "정기 구독 (카드 자동)"); // 카드 자동      : 다음 갱신일 있음
 
     private final Long price;
     private final String description;
@@ -22,9 +23,13 @@ public enum SubscriptionPlanType {
      */
     public LocalDateTime calculateExpiryDate(LocalDateTime startDate) {
         return switch (this) {
-            case FREE     -> startDate.plusDays(3);     // 무료 플랜 3일
-            case RECURRING -> startDate.plusMonths(1);  // 정기 결제
-            //case RECURRING -> startDate.plusMinutes(1);  // 테스트: 1분
+            case FREE -> startDate.plusDays(3);
+            case RECURRING, RECURRING_AUTO -> startDate.plusMonths(1);
         };
+    }
+
+    // 카드 자동 청구 방식인지 여부 : 다음 갱신일
+    public boolean isAutoRenew() {
+        return this == RECURRING_AUTO;
     }
 }

--- a/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
@@ -35,6 +35,7 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
             LocalDateTime now
     );
 
+
     // [테스트 전용] 구독 포인트 차감 수동 실행(단건 조회, 취소용)
     Optional<Subscription> findByUserIdAndPlanTypeAndStatus(
             Long userId,

--- a/src/main/java/com/fivefy/domain/subscription/state/ActiveState.java
+++ b/src/main/java/com/fivefy/domain/subscription/state/ActiveState.java
@@ -43,12 +43,12 @@ public class ActiveState implements SubscriptionState {
 
     /**
      * ACTIVE 유지 + 기간 연장
-     * - RECURRING 플랜만 가능
+     * - 재갱신은 정기 결제 플랜만 가능
      * - nextBillingDate 없으면 이미 취소된 상태
      */
     @Override
     public void renew(Subscription subscription) {
-        if (subscription.getPlanType() != SubscriptionPlanType.RECURRING) {
+        if (subscription.getPlanType() != SubscriptionPlanType.RECURRING_AUTO) {
             throw new BusinessException(SubscriptionErrorCode.ERR_SUBSCRIPTION_NOT_RECURRING);
         }
 

--- a/src/main/resources/db/migration/V4__add_billing_attempts.sql
+++ b/src/main/resources/db/migration/V4__add_billing_attempts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE billing_attempts
+(
+    id              BIGINT AUTO_INCREMENT NOT NULL,
+    created_at      datetime     NULL,
+    subscription_id BIGINT       NOT NULL,
+    billing_key_id  BIGINT       NOT NULL,
+    billing_cycle   VARCHAR(7)   NOT NULL,
+    status          VARCHAR(20)  NOT NULL,
+    failure_reason  VARCHAR(50)  NULL,
+    attempted_at    datetime     NOT NULL,
+    CONSTRAINT pk_billing_attempts PRIMARY KEY (id),
+    CONSTRAINT uc_billing_attempts_cycle
+        UNIQUE (subscription_id, billing_cycle)
+);
+
+CREATE INDEX idx_billing_attempts_subscription_id
+    ON billing_attempts (subscription_id);
+
+CREATE INDEX idx_billing_attempts_billing_key_id
+    ON billing_attempts (billing_key_id);

--- a/src/main/resources/db/migration/V4__add_billing_attempts.sql
+++ b/src/main/resources/db/migration/V4__add_billing_attempts.sql
@@ -2,19 +2,17 @@ CREATE TABLE billing_attempts
 (
     id              BIGINT AUTO_INCREMENT NOT NULL,
     created_at      datetime     NULL,
-    subscription_id BIGINT       NOT NULL,
+    user_id         BIGINT       NOT NULL,
     billing_key_id  BIGINT       NOT NULL,
     billing_cycle   VARCHAR(7)   NOT NULL,
     status          VARCHAR(20)  NOT NULL,
     failure_reason  VARCHAR(50)  NULL,
     attempted_at    datetime     NOT NULL,
-    CONSTRAINT pk_billing_attempts PRIMARY KEY (id),
-    CONSTRAINT uc_billing_attempts_cycle
-        UNIQUE (subscription_id, billing_cycle)
+    CONSTRAINT pk_billing_attempts PRIMARY KEY (id)
 );
 
-CREATE INDEX idx_billing_attempts_subscription_id
-    ON billing_attempts (subscription_id);
+CREATE INDEX idx_billing_attempts_user_id
+    ON billing_attempts (user_id);
 
 CREATE INDEX idx_billing_attempts_billing_key_id
     ON billing_attempts (billing_key_id);

--- a/src/test/java/com/fivefy/FivefyApplicationTests.java
+++ b/src/test/java/com/fivefy/FivefyApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-// @SpringBootTest
+@SpringBootTest
 @ActiveProfiles("test")
 class FivefyApplicationTests {
 

--- a/src/test/java/com/fivefy/FivefyApplicationTests.java
+++ b/src/test/java/com/fivefy/FivefyApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+// @SpringBootTest
 @ActiveProfiles("test")
 class FivefyApplicationTests {
 

--- a/src/test/java/com/fivefy/domain/subscription/entity/SubscriptionTest.java
+++ b/src/test/java/com/fivefy/domain/subscription/entity/SubscriptionTest.java
@@ -30,7 +30,7 @@ class SubscriptionTest {
     @Test
     @DisplayName("RECURRING 구독 생성 시 nextBillingDate가 1개월 후로 설정된다")
     void create_RECURRING_nextBillingDate_1개월후() {
-        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING_AUTO, NOW);
 
         assertThat(subscription.getNextBillingDate()).isNotNull();
         assertThat(subscription.getNextBillingDate()).isAfter(NOW);
@@ -51,7 +51,7 @@ class SubscriptionTest {
     @Test
     @DisplayName("ACTIVE 상태에서 cancel() 호출 시 CANCELED로 전이되고 nextBillingDate가 null이 된다")
     void cancel_ACTIVE에서_CANCELED로() {
-        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING_AUTO, NOW);
 
         subscription.cancel();
 
@@ -86,6 +86,14 @@ class SubscriptionTest {
 
         assertThatThrownBy(() -> subscription.cancel())
                 .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("RECURRING 구독 생성 시 nextBillingDate는 null이다")
+    void create_RECURRING_nextBillingDate_null() {
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+
+        assertThat(subscription.getNextBillingDate()).isNull();
     }
 
     // ─────────────────────────────────────────
@@ -132,7 +140,7 @@ class SubscriptionTest {
     @Test
     @DisplayName("RECURRING 구독에서 renew() 호출 시 expiryDate와 nextBillingDate가 1개월 연장된다")
     void renew_날짜_1개월_연장() {
-        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING, NOW);
+        Subscription subscription = Subscription.create(1L, 1L, SubscriptionPlanType.RECURRING_AUTO, NOW);
         LocalDateTime beforeExpiry = subscription.getExpiryDate();
         LocalDateTime beforeBilling = subscription.getNextBillingDate();
 


### PR DESCRIPTION
## 개요

- 청구 실패 시 스케줄러 로그에만 남아 "몇 번 실패했는지", "왜 실패했는지"를 코드에서 추적할 수 있도록 BillingAttempt 테이블 추가했습니다.
   - 정기청구 시도 결과를 DB에 기록하는 billing_attempts 테이블을 추가(V4__migration)
   - 실패 케이스별로 원인을 분리해 저장

## 변경 사항

**신규 파일**
- V4__add_billing_attempts.sql : billing_attempts 테이블 생성, (subscription_id, billing_cycle) UNIQUE 제약으로 월 중복 청구 방지
- BillingAttempt : 정기청구 시도 엔티티
- BillingAttemptStatus : SUCCESS / FAILED
- BillingFailureReason : CARD_DECLINED / PG_TIMEOUT / BILLING_KEY_INVALID / DB_ERROR / UNKNOWN
- BillingAttemptRepository
- BillingAttemptPersistenceService : 실패 기록은 REQUIRES_NEW 트랜잭션으로 부모 롤백과 무관하게 커밋

**수정 파일**

- CashOrderService.processRecurringCharge() : 실패 케이스별 BillingAttempt 기록 추가
   - portoneClient 예외 발생 → PG_TIMEOUT 기록
   - pgResponse.payment() == null → CARD_DECLINED 기록
- CashOrderPersistenceService.saveRecurringChargeResult() : 청구 성공 시 BillingAttempt 성공 기록 추가 
- BillingKeyErrorCode : ERR_BILLING_KEY_ACTIVE_NOT_FOUND 추가
- SubscriptionErrorCode : ERR_SUBSCRIPTION_RECURRING_NOT_FOUND, ERR_SUBSCRIPTION_ACTIVE_NOT_FOUND 추가
- BillingKeyController.testCharge() : 잘못 연결된 에러코드 수정
- PortoneWebhookVerifier : IllegalArgumentException → BusinessException 교체
## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 자동 청구 구독 플랜 추가 (정기 구독 카드 자동 결제)
  * 결제 시도 기록 추적 시스템 추가 (성공/실패 사유 저장)

* **버그 수정**
  * 웹훅 타임스탐프 유효성 검증 개선
  * 웹훅 서명 검증에 상수 시간 비교 적용으로 보안 강화
  * 오류 메시지 명확화 (활성 빌링키 미존재, 정기구독 미존재 등)

* **데이터베이스**
  * 결제 시도 기록 저장을 위한 테이블 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->