### PR TITLE
fix: 등록 신청 처리 동시성 제어 및 중복 신청 검증 정책 보강

### DIFF
--- a/scripts/performance/music-read-load-test.js
+++ b/scripts/performance/music-read-load-test.js
@@ -1,0 +1,74 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080';
+const TRACK_ID = __ENV.TRACK_ID || '28';
+const PAGE = __ENV.PAGE || '0';
+const SIZE = __ENV.SIZE || '20';
+
+export const options = {
+    vus: Number(__ENV.VUS || 10),
+    duration: __ENV.DURATION || '30s',
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        http_req_duration: ['p(95)<500'],
+        checks: ['rate>0.99'],
+    },
+};
+
+export function setup() {
+    const trackDetailUrl = `${BASE_URL}/api/tracks/${TRACK_ID}`;
+
+    const response = http.get(trackDetailUrl);
+
+    check(response, {
+        'track detail warm-up status is 200': (res) => res.status === 200,
+    });
+}
+
+export default function () {
+    getPublicTracks();
+    getTrackDetail();
+    getTrackComments();
+
+    sleep(1);
+}
+
+function getPublicTracks() {
+    const url = `${BASE_URL}/api/tracks?page=${PAGE}&size=${SIZE}`;
+    const response = http.get(url, {
+        tags: {
+            api: 'public_tracks',
+        },
+    });
+
+    check(response, {
+        'public tracks status is 200': (res) => res.status === 200,
+    });
+}
+
+function getTrackDetail() {
+    const url = `${BASE_URL}/api/tracks/${TRACK_ID}`;
+    const response = http.get(url, {
+        tags: {
+            api: 'track_detail',
+        },
+    });
+
+    check(response, {
+        'track detail status is 200': (res) => res.status === 200,
+    });
+}
+
+function getTrackComments() {
+    const url = `${BASE_URL}/api/tracks/${TRACK_ID}/comments?page=${PAGE}&size=${SIZE}`;
+    const response = http.get(url, {
+        tags: {
+            api: 'track_comments',
+        },
+    });
+
+    check(response, {
+        'track comments status is 200': (res) => res.status === 200,
+    });
+}

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumApplicationQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumApplicationQueryRepository.java
@@ -12,7 +12,9 @@ import java.util.List;
  */
 public interface AlbumApplicationQueryRepository {
 
-    boolean existsActiveApplication(Long requesterUserId, Long artistId, String title);
+    boolean existsPendingApplication(Long requesterUserId, Long artistId, String title);
+
+    boolean existsApprovedApplication(Long requesterUserId, Long artistId, String title);
 
     List<AlbumApplication> searchMyAlbumApplications(Long requesterUserId);
 

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumApplicationQueryRepositoryImpl.java
@@ -24,11 +24,11 @@ public class AlbumApplicationQueryRepositoryImpl implements AlbumApplicationQuer
     private final JPAQueryFactory queryFactory;
 
     /**
-     * 진행 중이거나 승인된 동일 앨범 신청 존재 여부 조회
+     * 진행 중인 동일 앨범 신청 존재 여부 조회
      */
     @Override
-    public boolean existsActiveApplication(Long requesterUserId, Long artistId, String title) {
-        // PENDING 또는 APPROVED 상태의 동일 앨범 신청 존재 여부 확인
+    public boolean existsPendingApplication(Long requesterUserId, Long artistId, String title) {
+        // PENDING 상태의 상태의 동일 앨범 신청 존재 여부 확인
         Integer result = queryFactory
                 .selectOne()
                 .from(albumApplication)
@@ -36,13 +36,30 @@ public class AlbumApplicationQueryRepositoryImpl implements AlbumApplicationQuer
                         albumApplication.requesterUserId.eq(requesterUserId),
                         albumApplication.artistId.eq(artistId),
                         albumApplication.title.eq(title),
-                        albumApplication.status.in(
-                                ApplicationStatus.PENDING,
-                                ApplicationStatus.APPROVED
-                        )
+                        albumApplication.status.eq(ApplicationStatus.PENDING)
                 )
                 .fetchFirst();
-        // 존재 여부 반환
+
+        return result != null;
+    }
+
+    /**
+     * 승인된 동일 앨범 신청 존재 여부 조회
+     */
+    @Override
+    public boolean existsApprovedApplication(Long requesterUserId, Long artistId, String title) {
+        // APPROVED 상태의 동일 앨범 신청 존재 여부 확인
+        Integer result = queryFactory
+                .selectOne()
+                .from(albumApplication)
+                .where(
+                        albumApplication.requesterUserId.eq(requesterUserId),
+                        albumApplication.artistId.eq(artistId),
+                        albumApplication.title.eq(title),
+                        albumApplication.status.eq(ApplicationStatus.APPROVED)
+                )
+                .fetchFirst();
+
         return result != null;
     }
 

--- a/src/main/java/com/fivefy/domain/album/repository/AlbumApplicationRepository.java
+++ b/src/main/java/com/fivefy/domain/album/repository/AlbumApplicationRepository.java
@@ -1,7 +1,17 @@
 package com.fivefy.domain.album.repository;
 
 import com.fivefy.domain.album.entity.AlbumApplication;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface AlbumApplicationRepository extends JpaRepository<AlbumApplication, Long>, AlbumApplicationQueryRepository {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select aa from AlbumApplication aa where aa.id = :applicationId")
+    Optional<AlbumApplication> findByIdForUpdate(@Param("applicationId") Long applicationId);
 }

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -22,6 +22,7 @@ import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -70,7 +71,7 @@ public class AlbumService {
         validateDuplicateAlbumApplication(userId, request.artistId(), request.title());
 
         // 등록 신청 생성 및 저장
-        AlbumApplication savedApplication = albumApplicationRepository.save(
+        AlbumApplication savedApplication = saveAlbumApplication(
                 AlbumApplication.create(
                         userId,
                         request.artistId(),
@@ -350,5 +351,16 @@ public class AlbumService {
         }
 
         return LocalDateTime.now().plusDays(publishDelayDays);
+    }
+
+    // 앨범 등록 신청 저장
+    private AlbumApplication saveAlbumApplication(AlbumApplication application) {
+        try {
+            return albumApplicationRepository.saveAndFlush(application);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(
+                    AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_ALREADY_EXISTS
+            );
+        }
     }
 }

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -67,7 +67,7 @@ public class AlbumService {
         validatePublishDelayDays(request.publishDelayDays());
 
         // 중복 신청 검증
-        validateDuplicateActiveApplication(userId, request.artistId(), request.title());
+        validateDuplicateAlbumApplication(userId, request.artistId(), request.title());
 
         // 등록 신청 생성 및 저장
         AlbumApplication savedApplication = albumApplicationRepository.save(
@@ -288,10 +288,16 @@ public class AlbumService {
     }
 
     // 중복 신청 검증
-    private void validateDuplicateActiveApplication(Long userId, Long artistId, String title) {
-        if (albumApplicationRepository.existsActiveApplication(userId, artistId, title)) {
+    private void validateDuplicateAlbumApplication(Long userId, Long artistId, String title) {
+        if (albumApplicationRepository.existsPendingApplication(userId, artistId, title)) {
             throw new BusinessException(
                     AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_ALREADY_EXISTS
+            );
+        }
+
+        if (albumApplicationRepository.existsApprovedApplication(userId, artistId, title)) {
+            throw new BusinessException(
+                    AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_ALREADY_PROCESSED
             );
         }
     }

--- a/src/main/java/com/fivefy/domain/album/service/AlbumService.java
+++ b/src/main/java/com/fivefy/domain/album/service/AlbumService.java
@@ -132,7 +132,7 @@ public class AlbumService {
      */
     @Transactional
     public AlbumApplicationApproveResponse approveAlbumApplication(Long adminId, Long applicationId) {
-        AlbumApplication application = findAlbumApplication(applicationId);
+        AlbumApplication application = findAlbumApplicationForUpdate(applicationId);
 
         // 상태 전이는 엔티티에 위임
         application.approve(adminId);
@@ -152,7 +152,7 @@ public class AlbumService {
             Long applicationId,
             String rejectionReason
     ) {
-        AlbumApplication application = findAlbumApplication(applicationId);
+        AlbumApplication application = findAlbumApplicationForUpdate(applicationId);
 
         // 상태 전이는 엔티티에 위임
         application.reject(adminId, rejectionReason);
@@ -233,6 +233,14 @@ public class AlbumService {
     // 앨범 등록 신청 조회
     private AlbumApplication findAlbumApplication(Long applicationId) {
         return albumApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(
+                        AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_NOT_FOUND
+                ));
+    }
+
+    // 앨범 등록 신청 조회 (비관적 락)
+    private AlbumApplication findAlbumApplicationForUpdate(Long applicationId) {
+        return albumApplicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(
                         AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_NOT_FOUND
                 ));

--- a/src/main/java/com/fivefy/domain/artist/enums/ArtistApplicationErrorCode.java
+++ b/src/main/java/com/fivefy/domain/artist/enums/ArtistApplicationErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ArtistApplicationErrorCode implements ErrorCode {
     ERR_ARTIST_APPLICATION_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 아티스트 등록 신청입니다"),
-    ERR_ARTIST_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리중이거나 승인된 아티스트 등록 신청입니다"),
+    ERR_ARTIST_APPLICATION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 처리중인 아티스트 등록 신청이 존재합니다"),
     ERR_ARTIST_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 아티스트 등록 신청입니다"),
     ERR_ARTIST_APPLICATION_DETAIL_FORBIDDEN(HttpStatus.FORBIDDEN, "본인 또는 관리자만 아티스트 등록 신청을 상세 조회할 수 있습니다");
 

--- a/src/main/java/com/fivefy/domain/artist/repository/ArtistApplicationQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/artist/repository/ArtistApplicationQueryRepository.java
@@ -13,7 +13,9 @@ import java.util.List;
  */
 public interface ArtistApplicationQueryRepository {
 
-    boolean existsActiveApplication(Long requesterUserId, String requestedName, ArtistType artistType);
+    boolean existsPendingApplication(Long requesterUserId, String requestedName, ArtistType artistType);
+
+    boolean existsApprovedApplication(Long requesterUserId, String requestedName, ArtistType artistType);
 
     List<ArtistApplication> searchMyArtistApplications(Long requesterUserId);
 

--- a/src/main/java/com/fivefy/domain/artist/repository/ArtistApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/artist/repository/ArtistApplicationQueryRepositoryImpl.java
@@ -26,11 +26,11 @@ public class ArtistApplicationQueryRepositoryImpl implements ArtistApplicationQu
     private final JPAQueryFactory queryFactory;
 
     /**
-     * 동일 유저 + 이름 + 타입 기준으로 진행 중/승인된 신청 존재 여부 조회
+     * 진행 중인 동일 아티스트 신청 존재 여부 조회
      */
     @Override
-    public boolean existsActiveApplication(Long requesterUserId, String requestedName, ArtistType artistType) {
-        // 중복 신청 방지를 위해 PENDING/APPROVED 상태만 검사
+    public boolean existsPendingApplication(Long requesterUserId, String requestedName, ArtistType artistType) {
+        // PENDING 상태의 동일 아티스트 신청 존재 여부 확인
         Integer result = queryFactory
                 .selectOne()
                 .from(artistApplication)
@@ -38,13 +38,30 @@ public class ArtistApplicationQueryRepositoryImpl implements ArtistApplicationQu
                         artistApplication.requesterUserId.eq(requesterUserId),
                         artistApplication.requestedName.eq(requestedName),
                         artistApplication.artistType.eq(artistType),
-                        artistApplication.status.in(
-                                ApplicationStatus.PENDING,
-                                ApplicationStatus.APPROVED
-                        )
+                        artistApplication.status.eq(ApplicationStatus.PENDING)
                 )
                 .fetchFirst();
-        // 결과 존재 여부로 boolean 반환
+
+        return result != null;
+    }
+
+    /**
+     * 승인된 동일 아티스트 신청 존재 여부 조회
+     */
+    @Override
+    public boolean existsApprovedApplication(Long requesterUserId, String requestedName, ArtistType artistType) {
+        // APPROVED 상태의 동일 아티스트 신청 존재 여부 확인
+        Integer result = queryFactory
+                .selectOne()
+                .from(artistApplication)
+                .where(
+                        artistApplication.requesterUserId.eq(requesterUserId),
+                        artistApplication.requestedName.eq(requestedName),
+                        artistApplication.artistType.eq(artistType),
+                        artistApplication.status.eq(ApplicationStatus.APPROVED)
+                )
+                .fetchFirst();
+
         return result != null;
     }
 

--- a/src/main/java/com/fivefy/domain/artist/repository/ArtistApplicationRepository.java
+++ b/src/main/java/com/fivefy/domain/artist/repository/ArtistApplicationRepository.java
@@ -1,8 +1,18 @@
 package com.fivefy.domain.artist.repository;
 
 import com.fivefy.domain.artist.entity.ArtistApplication;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface ArtistApplicationRepository
         extends JpaRepository<ArtistApplication, Long>, ArtistApplicationQueryRepository {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select aa from ArtistApplication aa where aa.id = :applicationId")
+    Optional<ArtistApplication> findByIdForUpdate(@Param("applicationId") Long applicationId);
 }

--- a/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
@@ -19,6 +19,7 @@ import com.fivefy.domain.user.enums.UserErrorCode;
 import com.fivefy.domain.user.enums.UserRole;
 import com.fivefy.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -52,7 +53,7 @@ public class ArtistService {
         validateDuplicateArtistApplication(userId, request.requestedName(), request.artistType());
 
         // 등록 신청 생성 및 저장
-        ArtistApplication savedApplication = artistApplicationRepository.save(
+        ArtistApplication savedApplication = saveArtistApplication(
                 ArtistApplication.create(
                         userId,
                         request.requestedName(),
@@ -328,5 +329,16 @@ public class ArtistService {
                 application.getBio(),
                 application.getProfileImageUrl()
         );
+    }
+
+    // 아티스트 등록 신청 저장
+    private ArtistApplication saveArtistApplication(ArtistApplication application) {
+        try {
+            return artistApplicationRepository.saveAndFlush(application);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(
+                    ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_ALREADY_EXISTS
+            );
+        }
     }
 }

--- a/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
@@ -49,7 +49,7 @@ public class ArtistService {
         findUser(userId);
 
         // 중복 신청 검증
-        validateDuplicateActiveApplication(userId, request.requestedName(), request.artistType());
+        validateDuplicateArtistApplication(userId, request.requestedName(), request.artistType());
 
         // 등록 신청 생성 및 저장
         ArtistApplication savedApplication = artistApplicationRepository.save(
@@ -278,10 +278,16 @@ public class ArtistService {
     // =========================
 
     // 중복 신청 검증
-    private void validateDuplicateActiveApplication(Long userId, String requestedName, ArtistType artistType) {
-        if (artistApplicationRepository.existsActiveApplication(userId, requestedName, artistType)) {
+    private void validateDuplicateArtistApplication(Long userId, String requestedName, ArtistType artistType) {
+        if (artistApplicationRepository.existsPendingApplication(userId, requestedName, artistType)) {
             throw new BusinessException(
                     ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_ALREADY_EXISTS
+            );
+        }
+
+        if (artistApplicationRepository.existsApprovedApplication(userId, requestedName, artistType)) {
+            throw new BusinessException(
+                    ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_ALREADY_PROCESSED
             );
         }
     }

--- a/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
+++ b/src/main/java/com/fivefy/domain/artist/service/ArtistService.java
@@ -113,7 +113,7 @@ public class ArtistService {
      */
     @Transactional
     public ArtistApplicationApproveResponse approveArtistApplication(Long adminId, Long applicationId) {
-        ArtistApplication application = findArtistApplication(applicationId);
+        ArtistApplication application = findArtistApplicationForUpdate(applicationId);
 
         // 상태 전이는 엔티티에 위임
         application.approve(adminId);
@@ -133,7 +133,7 @@ public class ArtistService {
             Long applicationId,
             ArtistApplicationRejectRequest request
     ) {
-        ArtistApplication application = findArtistApplication(applicationId);
+        ArtistApplication application = findArtistApplicationForUpdate(applicationId);
 
         // 상태 전이는 엔티티에 위임
         application.reject(adminId, request.rejectionReason());
@@ -260,6 +260,14 @@ public class ArtistService {
     // 아티스트 등록 신청 조회
     private ArtistApplication findArtistApplication(Long applicationId) {
         return artistApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(
+                        ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_NOT_FOUND
+                ));
+    }
+
+    // 아티스트 등록 신청 조회 (비관적 락)
+    private ArtistApplication findArtistApplicationForUpdate(Long applicationId) {
+        return artistApplicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(
                         ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_NOT_FOUND
                 ));

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepository.java
@@ -24,6 +24,14 @@ public interface TrackApplicationQueryRepository {
             String title
     );
 
+    boolean existsApprovedOfficialReleaseApplication(
+            Long requesterUserId,
+            Long artistId,
+            Long albumId,
+            Long trackNumber,
+            String title
+    );
+
     List<TrackApplication> searchMyTrackApplications(Long requesterUserId);
 
     Page<TrackApplication> searchTrackApplications(

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationQueryRepositoryImpl.java
@@ -80,6 +80,33 @@ public class TrackApplicationQueryRepositoryImpl implements TrackApplicationQuer
     }
 
     /**
+     * 정식 발매 Approved 중복 신청 여부 조회
+     */
+    @Override
+    public boolean existsApprovedOfficialReleaseApplication(
+            Long requesterUserId,
+            Long artistId,
+            Long albumId,
+            Long trackNumber,
+            String title
+    ) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(trackApplication)
+                .where(
+                        trackApplication.requesterUserId.eq(requesterUserId),
+                        trackApplication.status.eq(ApplicationStatus.APPROVED),
+                        trackApplication.trackType.eq(TrackType.OFFICIAL_RELEASE),
+                        trackApplication.artistId.eq(artistId),
+                        trackApplication.albumId.eq(albumId),
+                        officialReleaseDuplicateCondition(trackNumber, title)
+                )
+                .fetchFirst();
+
+        return result != null;
+    }
+
+    /**
      * 내 트랙 등록 신청 목록 조회
      */
     @Override

--- a/src/main/java/com/fivefy/domain/track/repository/TrackApplicationRepository.java
+++ b/src/main/java/com/fivefy/domain/track/repository/TrackApplicationRepository.java
@@ -1,7 +1,17 @@
 package com.fivefy.domain.track.repository;
 
 import com.fivefy.domain.track.entity.TrackApplication;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface TrackApplicationRepository extends JpaRepository<TrackApplication, Long>, TrackApplicationQueryRepository {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select ta from TrackApplication ta where ta.id = :applicationId")
+    Optional<TrackApplication> findByIdForUpdate(@Param("applicationId") Long applicationId);
 }

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -489,6 +489,18 @@ public class TrackService {
                     TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS
             );
         }
+
+        if (trackApplicationRepository.existsApprovedOfficialReleaseApplication(
+                requesterUserId,
+                artistId,
+                albumId,
+                trackNumber,
+                title
+        )) {
+            throw new BusinessException(
+                    TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED
+            );
+        }
     }
 
     // 상세 조회 권한 검증

--- a/src/main/java/com/fivefy/domain/track/service/TrackService.java
+++ b/src/main/java/com/fivefy/domain/track/service/TrackService.java
@@ -197,7 +197,7 @@ public class TrackService {
      */
     @Transactional
     public TrackApplicationApproveResponse approveTrackApplication(Long adminId, Long applicationId) {
-        TrackApplication application = findTrackApplication(applicationId);
+        TrackApplication application = findTrackApplicationForUpdate(applicationId);
 
         // OFFICIAL_RELEASE는 승인 시점에도 연관 리소스 유효성 재확인
         if (application.getTrackType() == TrackType.OFFICIAL_RELEASE) {
@@ -236,7 +236,7 @@ public class TrackService {
             Long applicationId,
             String rejectionReason
     ) {
-        TrackApplication application = findTrackApplication(applicationId);
+        TrackApplication application = findTrackApplicationForUpdate(applicationId);
 
         // 상태 전이는 엔티티에 위임
         application.reject(adminId, rejectionReason);
@@ -389,6 +389,13 @@ public class TrackService {
     // 트랙 등록 신청 조회
     private TrackApplication findTrackApplication(Long applicationId) {
         return trackApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new BusinessException(
+                        TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND));
+    }
+
+    // 트랙 등록 신청 조회 (비관적 락)
+    private TrackApplication findTrackApplicationForUpdate(Long applicationId) {
+        return trackApplicationRepository.findByIdForUpdate(applicationId)
                 .orElseThrow(() -> new BusinessException(
                         TrackApplicationErrorCode.ERR_TRACK_APPLICATION_NOT_FOUND));
     }

--- a/src/main/resources/db/migration/V5__add_application_duplicate_constraints.sql
+++ b/src/main/resources/db/migration/V5__add_application_duplicate_constraints.sql
@@ -1,0 +1,25 @@
+ALTER TABLE album_applications
+    ADD COLUMN active_duplicate_key VARCHAR(500)
+        GENERATED ALWAYS AS (
+            CASE
+                WHEN status IN ('PENDING', 'APPROVED')
+                    THEN CONCAT(requester_user_id, ':', artist_id, ':', title)
+                ELSE NULL
+                END
+            ) STORED;
+
+CREATE UNIQUE INDEX uq_album_application_active_duplicate_key
+    ON album_applications (active_duplicate_key);
+
+ALTER TABLE artist_applications
+    ADD COLUMN active_duplicate_key VARCHAR(500)
+        GENERATED ALWAYS AS (
+            CASE
+                WHEN status IN ('PENDING', 'APPROVED')
+                    THEN CONCAT(requester_user_id, ':', requested_name, ':', artist_type)
+                ELSE NULL
+                END
+            ) STORED;
+
+CREATE UNIQUE INDEX uq_artist_application_active_duplicate_key
+    ON artist_applications (active_duplicate_key);

--- a/src/main/resources/db/migration/V5__add_application_duplicate_constraints.sql
+++ b/src/main/resources/db/migration/V5__add_application_duplicate_constraints.sql
@@ -8,8 +8,10 @@ ALTER TABLE album_applications
                 END
             ) STORED;
 
-CREATE UNIQUE INDEX uq_album_application_active_duplicate_key
-    ON album_applications (active_duplicate_key);
+ALTER TABLE album_applications
+    ADD UNIQUE INDEX uq_album_application_active_duplicate_key (active_duplicate_key),
+    ALGORITHM=INPLACE,
+    LOCK=NONE;
 
 ALTER TABLE artist_applications
     ADD COLUMN active_duplicate_key VARCHAR(500)
@@ -21,5 +23,7 @@ ALTER TABLE artist_applications
                 END
             ) STORED;
 
-CREATE UNIQUE INDEX uq_artist_application_active_duplicate_key
-    ON artist_applications (active_duplicate_key);
+ALTER TABLE artist_applications
+    ADD UNIQUE INDEX uq_artist_application_active_duplicate_key (active_duplicate_key),
+    ALGORITHM=INPLACE,
+    LOCK=NONE;

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -126,7 +127,7 @@ class AlbumServiceTest {
             ReflectionTestUtils.setField(savedApplication, "id", 1L);
             ReflectionTestUtils.setField(savedApplication, "createdAt", LocalDateTime.of(2026, 4, 16, 16, 0, 0));
 
-            when(albumApplicationRepository.save(any(AlbumApplication.class)))
+            when(albumApplicationRepository.saveAndFlush(any(AlbumApplication.class)))
                     .thenReturn(savedApplication);
 
             AlbumApplicationResponse response =
@@ -386,6 +387,45 @@ class AlbumServiceTest {
             assertThatThrownBy(() -> albumService.createAlbumApplication(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_ALREADY_PROCESSED.getMessage());
+        }
+
+        @Test
+        @DisplayName("동시 중복 신청으로 저장 충돌이 발생하면 앨범 등록 신청 생성 실패")
+        void createAlbumApplication_fail_whenDuplicateSaveConflict() {
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumApplicationCreateRequest request = new AlbumApplicationCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumApplicationRepository.existsPendingApplication(userId, artistId, request.title()))
+                    .thenReturn(false);
+            when(albumApplicationRepository.existsApprovedApplication(userId, artistId, request.title()))
+                    .thenReturn(false);
+            when(albumApplicationRepository.saveAndFlush(any(AlbumApplication.class)))
+                    .thenThrow(new DataIntegrityViolationException("duplicate album application"));
+
+            assertThatThrownBy(() -> albumService.createAlbumApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_ALREADY_EXISTS.getMessage());
         }
     }
 

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -110,7 +110,9 @@ class AlbumServiceTest {
             ReflectionTestUtils.setField(artist, "id", artistId);
 
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
-            when(albumApplicationRepository.existsActiveApplication(userId, artistId, request.title()))
+            when(albumApplicationRepository.existsPendingApplication(userId, artistId, request.title()))
+                    .thenReturn(false);
+            when(albumApplicationRepository.existsApprovedApplication(userId, artistId, request.title()))
                     .thenReturn(false);
 
             AlbumApplication savedApplication = AlbumApplication.create(
@@ -316,7 +318,7 @@ class AlbumServiceTest {
 
         @Test
         @DisplayName("동일한 진행 중 신청이 이미 있으면 앨범 등록 신청 생성 실패")
-        void createAlbumApplication_fail_whenAlreadyExists() {
+        void createAlbumApplication_fail_whenPendingApplicationAlreadyExists() {
             Long userId = 1L;
             Long artistId = 10L;
 
@@ -341,7 +343,7 @@ class AlbumServiceTest {
             ReflectionTestUtils.setField(artist, "id", artistId);
 
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
-            when(albumApplicationRepository.existsActiveApplication(userId, artistId, request.title()))
+            when(albumApplicationRepository.existsPendingApplication(userId, artistId, request.title()))
                     .thenReturn(true);
 
             assertThatThrownBy(() -> albumService.createAlbumApplication(userId, request))

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -350,6 +350,43 @@ class AlbumServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_ALREADY_EXISTS.getMessage());
         }
+
+        @Test
+        @DisplayName("동일한 처리 완료 신청이 이미 있으면 앨범 등록 신청 생성 실패")
+        void createAlbumApplication_fail_whenApprovedApplicationAlreadyExists() {
+            Long userId = 1L;
+            Long artistId = 10L;
+
+            AlbumApplicationCreateRequest request = new AlbumApplicationCreateRequest(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    0
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
+
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumApplicationRepository.existsPendingApplication(userId, artistId, request.title()))
+                    .thenReturn(false);
+            when(albumApplicationRepository.existsApprovedApplication(userId, artistId, request.title()))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> albumService.createAlbumApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(AlbumApplicationErrorCode.ERR_ALBUM_APPLICATION_ALREADY_PROCESSED.getMessage());
+        }
     }
 
     @Nested

--- a/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
+++ b/src/test/java/com/fivefy/domain/album/service/AlbumServiceTest.java
@@ -663,7 +663,7 @@ class AlbumServiceTest {
             );
             ReflectionTestUtils.setField(savedAlbum, "id", 1000L);
 
-            when(albumApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(albumApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(albumRepository.save(any(Album.class))).thenReturn(savedAlbum);
 
             AlbumApplicationApproveResponse response =
@@ -701,7 +701,7 @@ class AlbumServiceTest {
             );
             ReflectionTestUtils.setField(savedAlbum, "id", 1000L);
 
-            when(albumApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(albumApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(albumRepository.save(any(Album.class))).thenReturn(savedAlbum);
 
             AlbumApplicationApproveResponse response =
@@ -720,7 +720,7 @@ class AlbumServiceTest {
             Long adminId = 1L;
             Long applicationId = 10L;
 
-            when(albumApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+            when(albumApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> albumService.approveAlbumApplication(adminId, applicationId))
                     .isInstanceOf(BusinessException.class)
@@ -744,7 +744,7 @@ class AlbumServiceTest {
             ReflectionTestUtils.setField(application, "id", applicationId);
             application.approve(adminId);
 
-            when(albumApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(albumApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
 
             assertThatThrownBy(() -> albumService.approveAlbumApplication(adminId, applicationId))
                     .isInstanceOf(BusinessException.class)
@@ -773,7 +773,7 @@ class AlbumServiceTest {
             );
             ReflectionTestUtils.setField(application, "id", applicationId);
 
-            when(albumApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(albumApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
 
             AlbumApplicationRejectResponse response =
                     albumService.rejectAlbumApplication(adminId, applicationId, rejectionReason);
@@ -791,7 +791,7 @@ class AlbumServiceTest {
             Long adminId = 1L;
             Long applicationId = 10L;
 
-            when(albumApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+            when(albumApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> albumService.rejectAlbumApplication(adminId, applicationId, "사유"))
                     .isInstanceOf(BusinessException.class)
@@ -815,7 +815,7 @@ class AlbumServiceTest {
             ReflectionTestUtils.setField(application, "id", applicationId);
             application.approve(adminId);
 
-            when(albumApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(albumApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
 
             assertThatThrownBy(() -> albumService.rejectAlbumApplication(adminId, applicationId, "사유"))
                     .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
@@ -540,7 +540,7 @@ class ArtistServiceTest {
             );
             ReflectionTestUtils.setField(savedArtist, "id", 100L);
 
-            when(artistApplicationRepository.findById(applicationId))
+            when(artistApplicationRepository.findByIdForUpdate(applicationId))
                     .thenReturn(Optional.of(application));
             when(artistRepository.save(any(Artist.class)))
                     .thenReturn(savedArtist);
@@ -562,7 +562,7 @@ class ArtistServiceTest {
             Long adminId = 1L;
             Long applicationId = 10L;
 
-            when(artistApplicationRepository.findById(applicationId))
+            when(artistApplicationRepository.findByIdForUpdate(applicationId))
                     .thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> artistService.approveArtistApplication(adminId, applicationId))
@@ -586,7 +586,7 @@ class ArtistServiceTest {
             ReflectionTestUtils.setField(application, "id", applicationId);
             application.approve(adminId);
 
-            when(artistApplicationRepository.findById(applicationId))
+            when(artistApplicationRepository.findByIdForUpdate(applicationId))
                     .thenReturn(Optional.of(application));
 
             assertThatThrownBy(() -> artistService.approveArtistApplication(adminId, applicationId))
@@ -617,7 +617,7 @@ class ArtistServiceTest {
             );
             ReflectionTestUtils.setField(application, "id", applicationId);
 
-            when(artistApplicationRepository.findById(applicationId))
+            when(artistApplicationRepository.findByIdForUpdate(applicationId))
                     .thenReturn(Optional.of(application));
 
             ArtistApplicationRejectResponse response =
@@ -640,7 +640,7 @@ class ArtistServiceTest {
             ArtistApplicationRejectRequest request =
                     new ArtistApplicationRejectRequest("정보 부족");
 
-            when(artistApplicationRepository.findById(applicationId))
+            when(artistApplicationRepository.findByIdForUpdate(applicationId))
                     .thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> artistService.rejectArtistApplication(adminId, applicationId, request))
@@ -667,7 +667,7 @@ class ArtistServiceTest {
             ReflectionTestUtils.setField(application, "id", applicationId);
             application.reject(adminId, "기존 거절 사유");
 
-            when(artistApplicationRepository.findById(applicationId))
+            when(artistApplicationRepository.findByIdForUpdate(applicationId))
                     .thenReturn(Optional.of(application));
 
             assertThatThrownBy(() -> artistService.rejectArtistApplication(adminId, applicationId, request))

--- a/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
@@ -90,7 +90,12 @@ class ArtistServiceTest {
 
             User user = mock(User.class);
             when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
-            when(artistApplicationRepository.existsActiveApplication(
+            when(artistApplicationRepository.existsPendingApplication(
+                    userId,
+                    request.requestedName(),
+                    request.artistType()
+            )).thenReturn(false);
+            when(artistApplicationRepository.existsApprovedApplication(
                     userId,
                     request.requestedName(),
                     request.artistType()
@@ -145,8 +150,8 @@ class ArtistServiceTest {
         }
 
         @Test
-        @DisplayName("중복 신청이면 실패")
-        void createArtistApplication_fail_whenAlreadyExists() {
+        @DisplayName("진행 중인 중복 신청이면 실패")
+        void createArtistApplication_fail_whenPendingApplicationExists() {
             Long userId = 1L;
 
             ArtistApplicationCreateRequest request = new ArtistApplicationCreateRequest(
@@ -158,7 +163,7 @@ class ArtistServiceTest {
 
             User user = mock(User.class);
             when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
-            when(artistApplicationRepository.existsActiveApplication(
+            when(artistApplicationRepository.existsPendingApplication(
                     userId,
                     request.requestedName(),
                     request.artistType()
@@ -167,6 +172,36 @@ class ArtistServiceTest {
             assertThatThrownBy(() -> artistService.createArtistApplication(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_ALREADY_EXISTS.getMessage());
+        }
+
+        @Test
+        @DisplayName("승인된 중복 신청이면 실패")
+        void createArtistApplication_fail_whenApprovedApplicationExists() {
+            Long userId = 1L;
+
+            ArtistApplicationCreateRequest request = new ArtistApplicationCreateRequest(
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/profile.jpg"
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+            when(artistApplicationRepository.existsPendingApplication(
+                    userId,
+                    request.requestedName(),
+                    request.artistType()
+            )).thenReturn(false);
+            when(artistApplicationRepository.existsApprovedApplication(
+                    userId,
+                    request.requestedName(),
+                    request.artistType()
+            )).thenReturn(true);
+
+            assertThatThrownBy(() -> artistService.createArtistApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_ALREADY_PROCESSED.getMessage());
         }
     }
 

--- a/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
+++ b/src/test/java/com/fivefy/domain/artist/service/ArtistServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -115,7 +116,7 @@ class ArtistServiceTest {
                     LocalDateTime.of(2026, 4, 14, 22, 30, 0)
             );
 
-            when(artistApplicationRepository.save(any(ArtistApplication.class)))
+            when(artistApplicationRepository.saveAndFlush(any(ArtistApplication.class)))
                     .thenReturn(savedApplication);
 
             ArtistApplicationResponse response =
@@ -284,6 +285,38 @@ class ArtistServiceTest {
             assertThatThrownBy(() -> artistService.getMyArtistApplications(userId))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("동시 중복 신청으로 저장 충돌이 발생하면 아티스트 등록 신청 생성 실패")
+        void createArtistApplication_fail_whenDuplicateSaveConflict() {
+            Long userId = 1L;
+
+            ArtistApplicationCreateRequest request = new ArtistApplicationCreateRequest(
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/profile.jpg"
+            );
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+            when(artistApplicationRepository.existsPendingApplication(
+                    userId,
+                    request.requestedName(),
+                    request.artistType()
+            )).thenReturn(false);
+            when(artistApplicationRepository.existsApprovedApplication(
+                    userId,
+                    request.requestedName(),
+                    request.artistType()
+            )).thenReturn(false);
+            when(artistApplicationRepository.saveAndFlush(any(ArtistApplication.class)))
+                    .thenThrow(new DataIntegrityViolationException("duplicate artist application"));
+
+            assertThatThrownBy(() -> artistService.createArtistApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ArtistApplicationErrorCode.ERR_ARTIST_APPLICATION_ALREADY_EXISTS.getMessage());
         }
     }
 

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -260,6 +260,13 @@ class TrackServiceTest {
                     request.trackNumber(),
                     request.title()
             )).thenReturn(false);
+            when(trackApplicationRepository.existsApprovedOfficialReleaseApplication(
+                    userId,
+                    artistId,
+                    albumId,
+                    request.trackNumber(),
+                    request.title()
+            )).thenReturn(false);
 
             TrackApplication savedApplication = TrackApplication.create(
                     userId,
@@ -720,75 +727,141 @@ class TrackServiceTest {
                     .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_EXISTS.getMessage());
         }
 
-        @Nested
-        @DisplayName("내 트랙 등록 신청 목록 조회")
-        class GetMyTrackApplications {
+        @Test
+        @DisplayName("동일한 처리 완료 신청이 이미 있으면 정식 발매 트랙 등록 신청 생성 실패")
+        void createOfficialTrackApplication_fail_whenAlreadyProcessed() {
+            Long userId = 1L;
+            Long artistId = 10L;
+            Long albumId = 100L;
 
-            @Test
-            @DisplayName("내 트랙 등록 신청 목록 조회 성공")
-            void getMyTrackApplications_success() {
-                Long userId = 1L;
+            OfficialTrackApplicationCreateRequest request =
+                    new OfficialTrackApplicationCreateRequest(
+                            artistId,
+                            albumId,
+                            1L,
+                            "밤편지",
+                            "가사",
+                            "BALLAD",
+                            "https://example.com/audio.mp3",
+                            230L,
+                            "feat. 10cm",
+                            3
+                    );
 
-                User user = mock(User.class);
-                when(userRepository.findByIdAndDeletedAtIsNull(userId))
-                        .thenReturn(Optional.of(user));
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
 
-                TrackApplication application1 = mock(TrackApplication.class);
-                TrackApplication application2 = mock(TrackApplication.class);
+            Artist artist = Artist.create(
+                    userId,
+                    "아이유",
+                    ArtistType.SOLO,
+                    "가수",
+                    "https://example.com/artist.jpg"
+            );
+            ReflectionTestUtils.setField(artist, "id", artistId);
 
-                when(trackApplicationRepository.searchMyTrackApplications(userId))
-                        .thenReturn(List.of(application1, application2));
+            Album album = Album.create(
+                    artistId,
+                    "Love poem",
+                    "앨범 설명",
+                    "https://example.com/cover.jpg",
+                    null
+            );
+            ReflectionTestUtils.setField(album, "id", albumId);
 
-                when(application1.getId()).thenReturn(1L);
-                when(application2.getId()).thenReturn(2L);
+            when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
+            when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
 
-                when(application1.getTrackType()).thenReturn(TrackType.FREE_CREATION);
-                when(application2.getTrackType()).thenReturn(TrackType.OFFICIAL_RELEASE);
+            when(trackApplicationRepository.existsPendingOfficialReleaseApplication(
+                    userId,
+                    artistId,
+                    albumId,
+                    request.trackNumber(),
+                    request.title()
+            )).thenReturn(false);
 
-                when(application1.getStatus()).thenReturn(ApplicationStatus.PENDING);
-                when(application2.getStatus()).thenReturn(ApplicationStatus.PENDING);
+            when(trackApplicationRepository.existsApprovedOfficialReleaseApplication(
+                    userId,
+                    artistId,
+                    albumId,
+                    request.trackNumber(),
+                    request.title()
+            )).thenReturn(true);
 
-                when(application1.getCreatedAt()).thenReturn(LocalDateTime.now());
-                when(application2.getCreatedAt()).thenReturn(LocalDateTime.now());
+            assertThatThrownBy(() -> trackService.createOfficialTrackApplication(userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(TrackApplicationErrorCode.ERR_TRACK_APPLICATION_ALREADY_PROCESSED.getMessage());
+        }
+    }
 
-                List<TrackApplicationResponse> response =
-                        trackService.getMyTrackApplications(userId);
+    @Nested
+    @DisplayName("내 트랙 등록 신청 목록 조회")
+    class GetMyTrackApplications {
 
-                assertThat(response).hasSize(2);
-                assertThat(response.get(0).applicationId()).isEqualTo(1L);
-                assertThat(response.get(1).applicationId()).isEqualTo(2L);
-            }
+        @Test
+        @DisplayName("내 트랙 등록 신청 목록 조회 성공")
+        void getMyTrackApplications_success() {
+            Long userId = 1L;
 
-            @Test
-            @DisplayName("존재하지 않는 유저면 목록 조회 실패")
-            void getMyTrackApplications_fail_whenUserNotFound() {
-                Long userId = 1L;
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
 
-                when(userRepository.findByIdAndDeletedAtIsNull(userId))
-                        .thenReturn(Optional.empty());
+            TrackApplication application1 = mock(TrackApplication.class);
+            TrackApplication application2 = mock(TrackApplication.class);
 
-                assertThatThrownBy(() -> trackService.getMyTrackApplications(userId))
-                        .isInstanceOf(BusinessException.class)
-                        .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
-            }
+            when(trackApplicationRepository.searchMyTrackApplications(userId))
+                    .thenReturn(List.of(application1, application2));
 
-            @Test
-            @DisplayName("등록 신청이 없으면 빈 리스트 반환")
-            void getMyTrackApplications_empty() {
-                Long userId = 1L;
+            when(application1.getId()).thenReturn(1L);
+            when(application2.getId()).thenReturn(2L);
 
-                User user = mock(User.class);
-                when(userRepository.findByIdAndDeletedAtIsNull(userId))
-                        .thenReturn(Optional.of(user));
+            when(application1.getTrackType()).thenReturn(TrackType.FREE_CREATION);
+            when(application2.getTrackType()).thenReturn(TrackType.OFFICIAL_RELEASE);
 
-                when(trackApplicationRepository.searchMyTrackApplications(userId))
-                        .thenReturn(List.of());
+            when(application1.getStatus()).thenReturn(ApplicationStatus.PENDING);
+            when(application2.getStatus()).thenReturn(ApplicationStatus.PENDING);
 
-                List<TrackApplicationResponse> response =
-                        trackService.getMyTrackApplications(userId);
+            when(application1.getCreatedAt()).thenReturn(LocalDateTime.now());
+            when(application2.getCreatedAt()).thenReturn(LocalDateTime.now());
 
-                assertThat(response).isEmpty();
-            }
+            List<TrackApplicationResponse> response =
+                    trackService.getMyTrackApplications(userId);
+
+            assertThat(response).hasSize(2);
+            assertThat(response.get(0).applicationId()).isEqualTo(1L);
+            assertThat(response.get(1).applicationId()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저면 목록 조회 실패")
+        void getMyTrackApplications_fail_whenUserNotFound() {
+            Long userId = 1L;
+
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> trackService.getMyTrackApplications(userId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(UserErrorCode.ERR_USER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("등록 신청이 없으면 빈 리스트 반환")
+        void getMyTrackApplications_empty() {
+            Long userId = 1L;
+
+            User user = mock(User.class);
+            when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                    .thenReturn(Optional.of(user));
+
+            when(trackApplicationRepository.searchMyTrackApplications(userId))
+                    .thenReturn(List.of());
+
+            List<TrackApplicationResponse> response =
+                    trackService.getMyTrackApplications(userId);
+
+            assertThat(response).isEmpty();
         }
     }
 

--- a/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/track/service/TrackServiceTest.java
@@ -1134,7 +1134,7 @@ class TrackServiceTest {
             savedTrack.publish();
             ReflectionTestUtils.setField(savedTrack, "id", 1000L);
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
             when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
@@ -1206,7 +1206,7 @@ class TrackServiceTest {
             );
             ReflectionTestUtils.setField(savedTrack, "id", 1000L);
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
             when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
@@ -1227,7 +1227,7 @@ class TrackServiceTest {
             Long adminId = 1L;
             Long applicationId = 10L;
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> trackService.approveTrackApplication(adminId, applicationId))
                     .isInstanceOf(BusinessException.class)
@@ -1277,7 +1277,7 @@ class TrackServiceTest {
             );
             ReflectionTestUtils.setField(album, "id", albumId);
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
 
@@ -1318,7 +1318,7 @@ class TrackServiceTest {
             );
             ReflectionTestUtils.setField(savedTrack, "id", 1000L);
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(trackRepository.save(any(Track.class))).thenReturn(savedTrack);
 
             TrackApplicationApproveResponse response =
@@ -1369,7 +1369,7 @@ class TrackServiceTest {
                     LocalDateTime.of(2026, 4, 20, 12, 0, 0)
             );
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
 
             assertThatThrownBy(() -> trackService.approveTrackApplication(adminId, applicationId))
@@ -1411,7 +1411,7 @@ class TrackServiceTest {
             ReflectionTestUtils.setField(artist, "id", artistId);
             artist.deactivate();
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
 
             assertThatThrownBy(() -> trackService.approveTrackApplication(adminId, applicationId))
@@ -1466,7 +1466,7 @@ class TrackServiceTest {
                     LocalDateTime.of(2026, 4, 20, 12, 0, 0)
             );
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
 
@@ -1517,7 +1517,7 @@ class TrackServiceTest {
             );
             ReflectionTestUtils.setField(album, "id", albumId);
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
             when(artistRepository.findById(artistId)).thenReturn(Optional.of(artist));
             when(albumRepository.findById(albumId)).thenReturn(Optional.of(album));
 
@@ -1554,7 +1554,7 @@ class TrackServiceTest {
             );
             ReflectionTestUtils.setField(application, "id", applicationId);
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
 
             TrackApplicationRejectResponse response =
                     trackService.rejectTrackApplication(adminId, applicationId, rejectionReason);
@@ -1572,7 +1572,8 @@ class TrackServiceTest {
             Long adminId = 1L;
             Long applicationId = 10L;
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.empty());
+            when(trackApplicationRepository.findByIdForUpdate(applicationId))
+                    .thenReturn(Optional.empty());
 
             assertThatThrownBy(() ->
                     trackService.rejectTrackApplication(adminId, applicationId, "사유")
@@ -1604,7 +1605,7 @@ class TrackServiceTest {
             ReflectionTestUtils.setField(application, "id", applicationId);
             application.approve(adminId);
 
-            when(trackApplicationRepository.findById(applicationId)).thenReturn(Optional.of(application));
+            when(trackApplicationRepository.findByIdForUpdate(applicationId)).thenReturn(Optional.of(application));
 
             assertThatThrownBy(() ->
                     trackService.rejectTrackApplication(adminId, applicationId, "사유")


### PR DESCRIPTION
## 개요
- 아티스트/앨범/트랙 등록 신청 승인·거절 처리에 비관적 락 적용
- 진행 중 신청과 승인 완료 신청의 중복 검증 기준 분리
- 동시 중복 신청 저장 충돌 방지를 위한 DB unique 제약 및 예외 변환 추가
- 음악 조회 API 성능 확인용 k6 부하 테스트 스크립트 추가

## 변경 사항

### 등록 신청 동시성 제어
- 아티스트 등록 신청 승인·거절 조회를 `findByIdForUpdate` 기반으로 변경
- 앨범 등록 신청 승인·거절 조회를 `findByIdForUpdate` 기반으로 변경
- 트랙 등록 신청 승인·거절 조회를 `findByIdForUpdate` 기반으로 변경
- 동일 신청에 대한 중복 승인/거절 요청 시 상태 전이 정합성 보호

### 중복 신청 검증 정책 보강
- 아티스트 등록 신청 중복 검증을 PENDING / APPROVED 기준으로 분리
- 앨범 등록 신청 중복 검증을 PENDING / APPROVED 기준으로 분리
- PENDING 중복은 기존 중복 신청 예외로 처리
- APPROVED 중복은 이미 처리된 신청 예외로 처리
- 정식 발매 트랙 신청도 승인 완료 신청 중복 여부 추가 검증
- 아티스트 등록 신청 중복 메시지를 진행 중 신청 기준으로 정리

### DB 제약 및 저장 충돌 처리
- 아티스트/앨범 등록 신청 테이블에 `active_duplicate_key` generated column 추가
- PENDING / APPROVED 상태의 중복 신청 방지를 위한 unique index 추가
- 등록 신청 저장 시 `saveAndFlush` 적용
- 동시 중복 신청으로 `DataIntegrityViolationException` 발생 시 중복 신청 예외로 변환

### 마이그레이션 영향 범위
- 대상 테이블은 `album_applications`, `artist_applications`
- 각 테이블에 `active_duplicate_key` generated column과 unique index 추가
- MySQL partial unique index 미지원으로 generated column 기반 중복 키 사용
- `PENDING` / `APPROVED` 상태만 중복 제한 대상이며, `REJECTED` 상태는 재신청 가능
- unique index 생성은 기존 `V3__add_performance_indexes.sql` 패턴과 동일하게 `ALGORITHM=INPLACE`, `LOCK=NONE` 적용
- 기존 integrated seed 기준으로 아티스트/앨범 신청명은 application id 기반으로 생성되어 중복 충돌 가능성이 낮음

### 롤백 절차
문제 발생 시 아래 순서로 추가 제약 제거

```sql
ALTER TABLE album_applications
    DROP INDEX uq_album_application_active_duplicate_key,
    DROP COLUMN active_duplicate_key;

ALTER TABLE artist_applications
    DROP INDEX uq_artist_application_active_duplicate_key,
    DROP COLUMN active_duplicate_key;
```

### 조회 및 성능 검증
- 공개 트랙 목록, 트랙 상세, 트랙 댓글 조회 대상 k6 스크립트 추가
- 트랙 상세 조회 warm-up 후 반복 조회 흐름 구성
- API별 `api` tag 지정으로 성능 결과 분리 가능

### 테스트 보강
- 비관적 락 적용에 맞춰 승인·거절 테스트 mock 기준 수정
- 아티스트/앨범 승인 완료 중복 신청 실패 케이스 추가
- 아티스트/앨범 동시 중복 신청 저장 충돌 실패 케이스 추가
- 정식 발매 트랙 승인 완료 중복 신청 실패 케이스 추가
- 기존 내 트랙 등록 신청 목록 조회 테스트 구조 정리

## 변경 유형
- [x] 오류 수정
- [x] DB 제약 [추가](url)
- [x] 성능 검증 추가
- [x] 테스트 코드 수정

## 테스트 방법
```bash
./gradlew test --tests "com.fivefy.domain.artist.service.ArtistServiceTest"
./gradlew test --tests "com.fivefy.domain.album.service.AlbumServiceTest"
./gradlew test --tests "com.fivefy.domain.track.service.TrackServiceTest"
k6 run scripts/performance/music-read-load-test.js
```

실제 API 동시 요청 검증 완료

- 앨범 등록 신청 10건 동시 요청
  - 1건 `201 CREATED`
  - 9건 `409 CONFLICT`
  - DB row 1건 생성 확인
- 아티스트 등록 신청 10건 동시 요청
  - 1건 `201 CREATED`
  - 9건 `409 CONFLICT`
  - DB row 1건 생성 확인

## 체크리스트
- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [x] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 앨범, 아티스트, 트랙 신청 시 중복 제출 감지 개선 및 더 명확한 오류 메시지 제공

* **개선 사항**
  * 데이터 무결성 강화를 위한 데이터베이스 제약 조건 추가
  * 시스템 안정성 및 성능 모니터링 인프라 구축

<!-- end of auto-generated comment: release notes by coderabbit.ai -->