### PR TITLE
feat : subscription에서 활성화 구독 확인용

### DIFF
--- a/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/fivefy/domain/subscription/repository/SubscriptionRepository.java
@@ -61,4 +61,15 @@ public interface SubscriptionRepository extends JpaRepository<Subscription, Long
 
     // 테스트 정리용
     void deleteAllByPointOrderIdIn(List<Long> pointOrderIds);
+
+    /**
+     * 코드래빗 조언 : 조건을 만족하는 행이 하나라도 있으면 즉시 멈추고 true 반환
+     * @param pointOrderIds
+     * @param status
+     * @return
+     */
+    boolean existsByPointOrderIdInAndStatus(
+            List<Long> pointOrderIds,
+            SubscriptionStatus status
+    );
 }

--- a/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
@@ -189,8 +189,9 @@ public class SubscriptionService {
                 .toList();
 
         // 구독 존재 여부(활성화, ACTIVE)만 확인
-        return subscriptionRepository.findAllByPointOrderIdIn(pointOrderIds)
-                .stream()
-                .anyMatch(s -> s.getStatus() == SubscriptionStatus.ACTIVE);
+        return subscriptionRepository.existsByPointOrderIdInAndStatus(
+                    pointOrderIds,
+                    SubscriptionStatus.ACTIVE
+        );
     }
 }

--- a/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/fivefy/domain/subscription/service/SubscriptionService.java
@@ -174,4 +174,23 @@ public class SubscriptionService {
                 .orElseThrow(() -> new BusinessException(
                         SubscriptionErrorCode.ERR_SUBSCRIPTION_RECURRING_NOT_FOUND));
     }
+
+    /**
+     * 구독 활성 여부만 boolean으로 반환
+     *
+     * @param userId
+     * @return
+     */
+    public boolean isActiveSubscriber(Long userId) {
+        // userId → pointOrderIds
+        List<Long> pointOrderIds = pointOrderRepository.findAllByUserId(userId)
+                .stream()
+                .map(PointOrder::getId)
+                .toList();
+
+        // 구독 존재 여부(활성화, ACTIVE)만 확인
+        return subscriptionRepository.findAllByPointOrderIdIn(pointOrderIds)
+                .stream()
+                .anyMatch(s -> s.getStatus() == SubscriptionStatus.ACTIVE);
+    }
 }


### PR DESCRIPTION
## 개요
`SubscriptionService`에 `isActiveSubscriber(Long userId)` 메서드를 추가했습니다.

기존에는 외부 도메인에서 특정 유저의 구독 활성 여부를 확인할 수 있는
공개 메서드가 없어, 2-hop 조회 로직이 도메인 외부로 노출될 위험이 있었습니다.
해당 조회를 `SubscriptionService` 안에 캡슐화하여 외부 도메인이
단순 메서드 호출로 구독 여부를 확인할 수 있도록 개선했습니다.

## 관련 이슈
closes #130

## 변경 사항
- `SubscriptionService`에 `isActiveSubscriber(Long userId)` 메서드 추가
- userId → pointOrderIds → ACTIVE 구독 존재 여부를 boolean으로 반환

## 변경 유형
- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법
1. ACTIVE 구독이 있는 유저로 로그인
2. `SubscriptionService.isActiveSubscriber(userId)` 호출 → `true` 반환 확인
3. 구독이 없거나 EXPIRE/CANCELED 상태인 유저로 호출 → `false` 반환 확인

## 체크리스트
- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 사용자의 활성 구독 상태를 확인할 수 있는 기능이 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->