### PR TITLE
feat: LLM 인용 파싱 실패 시 빈 카드 반환 및 메트릭 기록

### DIFF
--- a/src/main/java/com/fivefy/ai/observability/AiBusinessMetrics.java
+++ b/src/main/java/com/fivefy/ai/observability/AiBusinessMetrics.java
@@ -62,4 +62,16 @@ public class AiBusinessMetrics {
                 .publishPercentiles(0.5, 0.95, 0.99)
                 .register(meterRegistry));
     }
+
+    public void recordCitationParseFailed() {
+        Counter.builder("ai.citation.parse_failed")
+                .description("LLM이 파싱 가능한 [N] 인용구를 생성하는 데 실패하였습니다")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordCitationParseSuccess(int citedCount) {
+        meterRegistry.counter("ai.citation.parse_success").increment();
+        meterRegistry.summary("ai.citation.cited_count").record(citedCount);
+    }
 }

--- a/src/main/java/com/fivefy/ai/service/RecommendationService.java
+++ b/src/main/java/com/fivefy/ai/service/RecommendationService.java
@@ -86,8 +86,10 @@ public class RecommendationService {
             metrics.recordLatency(rerankTimer, RECOMMENDATION, "rerank");
 
             // ─── 4. 메타데이터 join ───
+            Timer.Sample metadataTimer = metrics.startTimer();
             List<RecommendationResponse.RecommendedTrack> tracks =
                     enrichWithMetadata(finalIds, userVector, candidateVectors);
+            metrics.recordLatency(metadataTimer, RECOMMENDATION, "metadata_join");
 
             metrics.recordResultCount(RECOMMENDATION, tracks.size());
             metrics.recordCall(RECOMMENDATION, true);

--- a/src/main/java/com/fivefy/domain/chat/service/ChatService.java
+++ b/src/main/java/com/fivefy/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.fivefy.domain.chat.service;
 
+import com.fivefy.ai.observability.AiBusinessMetrics;
 import com.fivefy.domain.chat.dto.etc.ChatSetupResult;
 import com.fivefy.domain.chat.dto.event.ChatStreamEvent;
 import com.fivefy.ai.dto.etc.RetrievedTrack;
@@ -27,6 +28,9 @@ public class ChatService {
     private final CitationExtractor citationExtractor;
     @Qualifier("anthropicChatClient")
     private final ChatClient chatClient;
+    private final AiBusinessMetrics metrics;
+
+    private static final int MAX_CARDS_PER_MESSAGE = 8;
 
     public Flux<ChatStreamEvent> sendMessage(Long userId, Long sessionId, String userMessage) {
         // ─── 1. 세션 확보 + 유저 메시지 저장 (트랜잭션) ───
@@ -75,9 +79,23 @@ public class ChatService {
             // LLM이 실제로 인용한 트랙만 골라냄
             List<RetrievedTrack> citedTracks = citationExtractor.filterCited(retrieved, responseText);
 
-            // LLM이 [N] 인용을 안 했거나 매칭 실패 시 fallback: 후보 전체 노출
-            // (사용자가 카드 영역을 비어있는 상태로 보면 더 어색함)
-            List<RetrievedTrack> tracksToShow = citedTracks.isEmpty() ? retrieved : citedTracks;
+            List<RetrievedTrack> tracksToShow;
+            if (citedTracks.isEmpty()) {
+                // LLM이 [N] 인용 형식을 어긴 경우 — 카드 미노출
+                // 후보 전체 노출 시 텍스트와 카드 불일치 위험
+                tracksToShow = List.of();
+                metrics.recordCitationParseFailed();
+                log.warn("LLM citation parsing failed, sessionId={}, responseLength={}",
+                        setup.session().getId(), responseText.length());
+            } else {
+                tracksToShow = citedTracks;
+                metrics.recordCitationParseSuccess(citedTracks.size());
+
+                // citedTracks 리스트도 상한 적용
+                if (tracksToShow.size() > MAX_CARDS_PER_MESSAGE) {
+                    tracksToShow = tracksToShow.subList(0, MAX_CARDS_PER_MESSAGE);
+                }
+            }
 
             Long assistantMessageId = commandService.saveAssistantMessage(
                     setup.session().getId(), responseText, tracksToShow);

--- a/src/test/java/com/fivefy/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/fivefy/domain/chat/service/ChatServiceTest.java
@@ -1,0 +1,160 @@
+package com.fivefy.domain.chat.service;
+
+import com.fivefy.ai.dto.etc.RetrievedTrack;
+import com.fivefy.ai.observability.AiBusinessMetrics;
+import com.fivefy.ai.service.CitationExtractor;
+import com.fivefy.ai.service.ConversationContextBuilder;
+import com.fivefy.ai.service.RagPromptBuilder;
+import com.fivefy.domain.chat.dto.etc.ChatSetupResult;
+import com.fivefy.domain.chat.dto.event.ChatStreamEvent;
+import com.fivefy.domain.chat.entity.ChatSession;
+import com.fivefy.domain.chat.enums.ChatStreamEventType;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+    @InjectMocks
+    private ChatService chatService;
+
+    @Mock private ChatCommandService commandService;
+    @Mock private ChatRetrievalService retrievalService;
+    @Mock private ConversationContextBuilder contextBuilder;
+    @Mock private RagPromptBuilder promptBuilder;
+    @Mock private ChatSummarizer summarizer;
+    @Mock private CitationExtractor citationExtractor;
+    @Mock private ChatModel chatModel;
+    @Mock private AiBusinessMetrics metrics;
+
+    @BeforeEach
+    void setUp() {
+        ChatClient chatClient = ChatClient.create(chatModel);
+
+        chatService = new ChatService(
+                commandService,
+                retrievalService,
+                contextBuilder,
+                promptBuilder,
+                summarizer,
+                citationExtractor,
+                chatClient,
+                metrics
+        );
+    }
+
+    @Test
+    @DisplayName("LLM 응답에 인용이 없을 경우 빈 트랙 리스트를 반환하고 실패 메트릭을 기록한다")
+    void shouldReturnEmptyTracksWhenCitationIsMissing() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 100L;
+        String userMessage = "추천해줘";
+        String mockLlmResponse = "여기 추천 리스트입니다.";
+        RetrievedTrack mockTrack = new RetrievedTrack(
+                1L,
+                "Song Title",
+                "Artist Name",
+                "Album Name",
+                "Pop",
+                2024,
+                "https://example.com"
+        );
+        given(promptBuilder.build(anyList())).willReturn("You are a helpful assistant...");
+        ChatSession mockSession = org.mockito.Mockito.mock(ChatSession.class);
+        given(mockSession.getId()).willReturn(sessionId);
+        given(commandService.setupSession(anyLong(), anyLong(), anyString()))
+                .willReturn(new ChatSetupResult(mockSession, false));
+        List<RetrievedTrack> retrieved = List.of(mockTrack  );
+        given(retrievalService.retrieve(anyString())).willReturn(retrieved);
+        ChatResponse chatResponse = new ChatResponse(List.of(
+                new Generation(new AssistantMessage(mockLlmResponse))
+        ));
+        given(chatModel.stream(any(Prompt.class))).willReturn(Flux.just(chatResponse));
+        given(citationExtractor.filterCited(eq(retrieved), eq(mockLlmResponse)))
+                .willReturn(List.of());
+        given(commandService.saveAssistantMessage(eq(sessionId), eq(mockLlmResponse), anyList()))
+                .willReturn(500L);
+
+        // when
+        List<ChatStreamEvent> events = chatService.sendMessage(userId, sessionId, userMessage)
+                .collectList()
+                .block();
+
+        // then
+        assertThat(events).isNotNull();
+        ChatStreamEvent tracksEvent = events.stream()
+                .filter(e -> e.type() == ChatStreamEventType.TRACKS)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("TRACKS 이벤트가 누락되었습니다."));
+        assertThat((List<?>) tracksEvent.data()).isEmpty();
+        verify(metrics).recordCitationParseFailed();
+        verify(commandService).saveAssistantMessage(eq(sessionId), eq(mockLlmResponse), argThat(List::isEmpty));
+    }
+
+    @Test
+    @DisplayName("인용된 트랙이 8개를 초과하면 최대 8개까지만 노출한다")
+    void shouldTruncateTracksWhenCitedExceedsLimit() {
+        // given
+        Long sessionId = 100L;
+        String mockLlmResponse = "여기 10곡을 추천합니다 [1]...[10]";
+        List<RetrievedTrack> tenTracks = java.util.stream.IntStream.rangeClosed(1, 10)
+                .mapToObj(i -> new RetrievedTrack((long) i, "Title" + i, "Artist", "Album", "Pop", 2024, "url"))
+                .toList();
+        given(promptBuilder.build(anyList())).willReturn("System Prompt");
+        ChatSession mockSession = mock(ChatSession.class);
+        given(mockSession.getId()).willReturn(sessionId);
+        given(commandService.setupSession(anyLong(), anyLong(), anyString()))
+                .willReturn(new ChatSetupResult(mockSession, false));
+        given(retrievalService.retrieve(anyString())).willReturn(tenTracks);
+        ChatResponse chatResponse = new ChatResponse(List.of(new Generation(new AssistantMessage(mockLlmResponse))));
+        given(chatModel.stream(any(Prompt.class))).willReturn(Flux.just(chatResponse));
+        given(citationExtractor.filterCited(eq(tenTracks), eq(mockLlmResponse))).willReturn(tenTracks);
+        given(commandService.saveAssistantMessage(eq(sessionId), eq(mockLlmResponse), anyList())).willReturn(500L);
+
+        // when
+        List<ChatStreamEvent> events = chatService.sendMessage(1L, sessionId, "10곡 추천해줘")
+                .collectList()
+                .block();
+
+        // then
+        ChatStreamEvent tracksEvent = Objects.requireNonNull(events).stream()
+                .filter(e -> e.type() == ChatStreamEventType.TRACKS)
+                .findFirst()
+                .orElseThrow();
+        assertThat(tracksEvent.data())
+                .asInstanceOf(InstanceOfAssertFactories.LIST)
+                .hasSize(8)
+                .first()
+                .isInstanceOf(RetrievedTrack.class);
+        assertThat(tracksEvent.data())
+                .asInstanceOf(InstanceOfAssertFactories.list(RetrievedTrack.class))
+                .hasSize(8)
+                .element(7)
+                .extracting(RetrievedTrack::title)
+                .isEqualTo("Title8");
+        verify(metrics).recordCitationParseSuccess(10);
+        verify(commandService).saveAssistantMessage(eq(sessionId), eq(mockLlmResponse), argThat(list -> list.size() == 8));
+    }
+}


### PR DESCRIPTION
## 개요

> LLM이 [N] 인용 형식을 따르지 않았을 때의 동작을 개선합니다.
기존에는 후보 트랙 전체를 fallback으로 노출했으나, 이는 LLM 응답 텍스트와 카드 목록 간 불일치를 유발할 수 있었습니다.
이번 PR에서는 파싱 실패 시 빈 리스트를 반환하고, 성공/실패 모두 메트릭으로 기록합니다.
아울러 인용 성공 시에도 카드 노출 상한(MAX_CARDS_PER_MESSAGE = 8)을 적용합니다.

## 변경 사항

- feat ChatService — 인용 파싱 실패 분기 처리
  - 인용 파싱 실패 시 List.of() 반환, 카드 영역 비노출로 변경
  - 인용 성공 시 MAX_CARDS_PER_MESSAGE = 8 초과분 truncate 적용
  - 각 분기에서 AiBusinessMetrics 주입 후 성공/실패 메트릭 기록
  - 파싱 실패 시 sessionId, responseLength 포함 경고 로그 출력
- feat AiBusinessMetrics — 인용 메트릭 추가
  - recordCitationParseFailed() — ai.citation.parse_failed 카운터
  - recordCitationParseSuccess(int citedCount) — ai.citation.parse_success 카운터 + ai.citation.cited_count summary
  - feat RecommendationService — metadata_join 레이턴시 측정
  - enrichWithMetadata() 호출 전후 타이머 추가
- test ChatServiceTest 신규 추가
  - 인용 누락 시 빈 트랙 반환 + recordCitationParseFailed() 호출 검증
  - 인용 10개 시 카드 8개 truncate + saveAssistantMessage에 8개 전달 검증

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인용 파싱의 성공 및 실패를 추적하는 메트릭 기록 기능 추가
  * 메타데이터 처리 단계의 성능 레이턴시 측정 추가
  * 어시스턴트 메시지당 최대 인용 카드 수를 8개로 제한

* **테스트**
  * 인용 누락 및 초과 상황에 대한 서비스 동작 검증 테스트 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/132)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->