### PR TITLE
refactor: 알림 및 검색 성능 개선

### DIFF
--- a/src/main/java/com/fivefy/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/fivefy/domain/follow/repository/FollowRepository.java
@@ -3,6 +3,7 @@ package com.fivefy.domain.follow.repository;
 import com.fivefy.domain.follow.entity.Follow;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,5 +16,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     Page<Follow> findAllByUserId(Long userId, Pageable pageable);
 
     // 알림 수신 동의 팔로워 페이징 조회 (RabbitMQ Consumer 청크 처리용)
-    Page<Follow> findAllByArtistIdAndNotificationEnabledTrue(Long artistId, Pageable pageable);
+    Slice<Follow> findAllByArtistIdAndNotificationEnabledTrue(Long artistId, Pageable pageable);
 }

--- a/src/main/java/com/fivefy/domain/notification/consumer/PublishTrackConsumer.java
+++ b/src/main/java/com/fivefy/domain/notification/consumer/PublishTrackConsumer.java
@@ -45,13 +45,14 @@ public class PublishTrackConsumer {
 
     @RabbitListener(
             queues = NotificationRabbitConfig.PUBLISH_TRACK_QUEUE,
-            concurrency = "3-10",
+            concurrency = "5-10",
             ackMode = "MANUAL"
     )
     public void consume(String message, Channel channel,
                         @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag,
                         @Header(value = "x-death", required = false) List<Map<String, Object>> xDeath) {
         String dedupKey = null;
+        long start = System.currentTimeMillis();
 
         try {
             PublishTrackChunkEvent event = objectMapper.readValue(message, PublishTrackChunkEvent.class);
@@ -108,6 +109,8 @@ public class PublishTrackConsumer {
 
             log.info("PUBLISH_TRACK 청크 처리 완료: trackId={}, 청크 size={}",
                     event.trackId(), event.userIds().size());
+            log.info("청크 처리 완료 — trackId={}, size={}, 소요={}ms",
+                    event.trackId(), event.userIds().size(), System.currentTimeMillis() - start);
 
             channel.basicAck(deliveryTag, false); // 성공 → ACK
 

--- a/src/main/java/com/fivefy/domain/notification/repository/NotificationBulkRepository.java
+++ b/src/main/java/com/fivefy/domain/notification/repository/NotificationBulkRepository.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Repository;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -26,7 +25,7 @@ public class NotificationBulkRepository {
      * 대량 알림 Bulk INSERT
      * IDENTITY 전략으로 JPA saveAll() 배치 불가 → JDBC 직접 구현
      *
-     * @return 삽입된 행 수
+     * @return 시도한 행 수
      */
     public int bulkInsert(List<Long> userIds, NotificationType type,
                           String content, NotificationChannel channel,
@@ -43,7 +42,7 @@ public class NotificationBulkRepository {
 
         Timestamp now = Timestamp.valueOf(LocalDateTime.now());
 
-        int[][] results = jdbcTemplate.batchUpdate(sql, userIds, BATCH_SIZE,
+        jdbcTemplate.batchUpdate(sql, userIds, BATCH_SIZE,
                 (ps, userId) -> {
                     ps.setLong(1, userId);
                     ps.setString(2, type.name());
@@ -54,11 +53,7 @@ public class NotificationBulkRepository {
                     ps.setString(7, userId + ":PUBLISH_TRACK:" + trackId);
                 });
 
-        int totalInserted = Arrays.stream(results)
-                .flatMapToInt(Arrays::stream)
-                .sum();
-
-        log.info("Bulk INSERT 완료: {}건", totalInserted);
-        return totalInserted;
+        log.info("Bulk INSERT 시도: {}건", userIds.size());
+        return userIds.size();
     }
 }

--- a/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/fivefy/domain/notification/service/NotificationService.java
@@ -25,6 +25,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -124,8 +125,9 @@ public class NotificationService {
             int page = 0;
             int totalChunks = 0;
             long chunkIndex = 0L;
-            Page<Follow> chunk;
+            Slice<Follow> chunk;
 
+            long start = System.currentTimeMillis();
             do {
                 chunk = followRepository.findAllByArtistIdAndNotificationEnabledTrue(
                         event.artistId(), PageRequest.of(page++, CHUNK_SIZE));
@@ -153,6 +155,8 @@ public class NotificationService {
                 totalChunks++;
 
             } while (chunk.hasNext());
+            log.info("PUBLISH_TRACK 발행 완료 — artistId={}, 총 청크={}, 소요={}ms",
+                    event.artistId(), totalChunks, System.currentTimeMillis() - start);
 
             log.info("PUBLISH_TRACK RabbitMQ 발행 완료: artistId={}, trackId={}, 총 청크 수={}",
                     event.artistId(), event.trackId(), totalChunks);

--- a/src/main/java/com/fivefy/domain/search/dto/SearchCacheDto.java
+++ b/src/main/java/com/fivefy/domain/search/dto/SearchCacheDto.java
@@ -1,0 +1,32 @@
+package com.fivefy.domain.search.dto;
+
+import com.fivefy.domain.search.dto.response.SearchAlbumResponse;
+import com.fivefy.domain.search.dto.response.SearchArtistResponse;
+import com.fivefy.domain.search.dto.response.SearchResponse;
+import com.fivefy.domain.search.dto.response.SearchTrackResponse;
+
+import java.util.List;
+
+public record SearchCacheDto(
+        List<SearchArtistResponse> artists,
+        List<SearchTrackResponse> tracks,
+        List<SearchAlbumResponse> albums,
+        boolean tracksHasNext,
+        boolean albumsHasNext,
+        long tracksTotalElements,
+        long albumsTotalElements,
+        Integer resultCount
+) {
+    public static SearchCacheDto from(SearchResponse response) {
+        return new SearchCacheDto(
+                response.artists(),
+                response.tracks().getContent(),
+                response.albums().getContent(),
+                response.tracks().hasNext(),
+                response.albums().hasNext(),
+                response.tracks().getTotalElements(),
+                response.albums().getTotalElements(),
+                response.resultCount()
+        );
+    }
+}

--- a/src/main/java/com/fivefy/domain/search/dto/cache/SearchCacheDto.java
+++ b/src/main/java/com/fivefy/domain/search/dto/cache/SearchCacheDto.java
@@ -1,4 +1,4 @@
-package com.fivefy.domain.search.dto;
+package com.fivefy.domain.search.dto.cache;
 
 import com.fivefy.domain.search.dto.response.SearchAlbumResponse;
 import com.fivefy.domain.search.dto.response.SearchArtistResponse;

--- a/src/main/java/com/fivefy/domain/search/repository/SearchQueryRepositoryImpl.java
+++ b/src/main/java/com/fivefy/domain/search/repository/SearchQueryRepositoryImpl.java
@@ -77,22 +77,35 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
             return new PageImpl<>(results, pageable, total);
         }
 
+        // OR → UNION 분리로 fulltext 인덱스 활성화
         List<Track> results = em.createNativeQuery(
-                        "SELECT * FROM tracks" +
-                                " WHERE (MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) OR artist_id IN (:ids))" +
-                                " AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                        "SELECT * FROM (" +
+                                " SELECT * FROM tracks" +
+                                "  WHERE MATCH(title) AGAINST(:keyword IN BOOLEAN MODE)" +
+                                "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                " UNION DISTINCT" +
+                                " SELECT * FROM tracks" +
+                                "  WHERE artist_id IN (" + joinedIds + ")" +
+                                "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                ") AS combined" +
                                 " ORDER BY " + orderClause +
                                 " LIMIT :offset, :size",
                         Track.class)
                 .setParameter("keyword", keyword)
-                .setParameter("ids", ids)
                 .setParameter("offset", pageable.getOffset())
                 .setParameter("size", pageable.getPageSize())
                 .getResultList();
 
         Long total = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM tracks WHERE (MATCH(title) AGAINST(? IN BOOLEAN MODE) OR artist_id IN (" + joinedIds + "))" +
-                        " AND deleted_at IS NULL AND status = 'PUBLISHED'",
+                "SELECT COUNT(*) FROM (" +
+                        " SELECT id FROM tracks" +
+                        "  WHERE MATCH(title) AGAINST(? IN BOOLEAN MODE)" +
+                        "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                        " UNION DISTINCT" +
+                        " SELECT id FROM tracks" +
+                        "  WHERE artist_id IN (" + joinedIds + ")" +
+                        "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                        ") AS combined",
                 Long.class, keyword);
 
         return new PageImpl<>(results, pageable, total);
@@ -128,21 +141,33 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
         }
 
         List<Album> results = em.createNativeQuery(
-                        "SELECT * FROM albums" +
-                                " WHERE (MATCH(title) AGAINST(:keyword IN BOOLEAN MODE) OR artist_id IN (:ids))" +
-                                " AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                        "SELECT * FROM (" +
+                                " SELECT * FROM albums" +
+                                "  WHERE MATCH(title) AGAINST(:keyword IN BOOLEAN MODE)" +
+                                "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                " UNION DISTINCT" +
+                                " SELECT * FROM albums" +
+                                "  WHERE artist_id IN (" + joinedIds + ")" +
+                                "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                                ") AS combined" +
                                 " ORDER BY " + orderClause +
                                 " LIMIT :offset, :size",
                         Album.class)
                 .setParameter("keyword", keyword)
-                .setParameter("ids", ids)
                 .setParameter("offset", pageable.getOffset())
                 .setParameter("size", pageable.getPageSize())
                 .getResultList();
 
         Long total = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM albums WHERE (MATCH(title) AGAINST(? IN BOOLEAN MODE) OR artist_id IN (" + joinedIds + "))" +
-                        " AND deleted_at IS NULL AND status = 'PUBLISHED'",
+                "SELECT COUNT(*) FROM (" +
+                        " SELECT id FROM albums" +
+                        "  WHERE MATCH(title) AGAINST(? IN BOOLEAN MODE)" +
+                        "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                        " UNION DISTINCT" +
+                        " SELECT id FROM albums" +
+                        "  WHERE artist_id IN (" + joinedIds + ")" +
+                        "  AND deleted_at IS NULL AND status = 'PUBLISHED'" +
+                        ") AS combined",
                 Long.class, keyword);
 
         return new PageImpl<>(results, pageable, total);
@@ -187,7 +212,6 @@ public class SearchQueryRepositoryImpl implements SearchQueryRepository {
                 WHEN %s LIKE '%s%%' THEN 1
                 ELSE 0
             END DESC,
-            MATCH(%s) AGAINST('%s' IN NATURAL LANGUAGE MODE) DESC,
             id DESC
             """, safeColumn, sanitized, safeColumn, sanitized, safeColumn, sanitized);
     }

--- a/src/main/java/com/fivefy/domain/search/service/SearchService.java
+++ b/src/main/java/com/fivefy/domain/search/service/SearchService.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.search.service;
 
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.search.dto.SearchCacheDto;
 import com.fivefy.domain.search.dto.response.SearchAlbumResponse;
 import com.fivefy.domain.search.dto.response.SearchArtistResponse;
 import com.fivefy.domain.search.dto.response.SearchResponse;
@@ -13,6 +14,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import tools.jackson.databind.ObjectMapper;
+import java.time.Duration;
 
 import java.util.List;
 
@@ -22,9 +27,13 @@ import java.util.List;
 public class SearchService {
 
     private static final int ARTIST_LIMIT = 5;
+    private static final Duration SEARCH_CACHE_TTL = Duration.ofMinutes(5);
 
     private final SearchQueryRepository searchQueryRepository;
     private final SearchHistoryService searchHistoryService;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
 
     @Transactional(readOnly = true)
     public SearchResponse search(String keyword, Pageable pageable, Long userId) {
@@ -34,6 +43,12 @@ public class SearchService {
             throw new BusinessException(SearchErrorCode.ERR_SEARCH_KEYWORD_BLANK);
         }
 
+        // 캐시 조회
+        String cacheKey = "search:" + trimmedKeyword + ":page:" + pageable.getPageNumber();
+        SearchResponse cached = getFromCache(cacheKey, pageable);
+        if (cached != null) return cached;
+
+        // DB 조회
         List<SearchArtistResponse> artists = searchQueryRepository
                 .searchArtists(trimmedKeyword, ARTIST_LIMIT)
                 .stream().map(SearchArtistResponse::from).toList();
@@ -49,7 +64,11 @@ public class SearchService {
         Page<SearchAlbumResponse> albums = searchQueryRepository
                 .searchAlbums(trimmedKeyword, artistIds, pageable)
                 .map(SearchAlbumResponse::from);
+
         SearchResponse response = SearchResponse.of(artists, tracks, albums);
+
+        // 캐시 저장
+        saveToCache(cacheKey, response);
 
         try {
             searchHistoryService.saveSearchHistory(userId, trimmedKeyword, response.resultCount());
@@ -58,5 +77,34 @@ public class SearchService {
         }
 
         return response;
+    }
+
+    private SearchResponse getFromCache(String cacheKey, Pageable pageable) {
+        try {
+            String cached = stringRedisTemplate.opsForValue().get(cacheKey);
+            if (cached == null) return null;
+
+            SearchCacheDto dto = objectMapper.readValue(cached, SearchCacheDto.class);
+
+            Page<SearchTrackResponse> tracks = new PageImpl<>(
+                    dto.tracks(), pageable, dto.tracksTotalElements());
+            Page<SearchAlbumResponse> albums = new PageImpl<>(
+                    dto.albums(), pageable, dto.albumsTotalElements());
+
+            return new SearchResponse(dto.artists(), tracks, albums, dto.resultCount());
+        } catch (Exception e) {
+            log.warn("검색 캐시 조회 실패 — DB 조회로 폴백: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private void saveToCache(String cacheKey, SearchResponse response) {
+        try {
+            SearchCacheDto dto = SearchCacheDto.from(response);
+            stringRedisTemplate.opsForValue().set(
+                    cacheKey, objectMapper.writeValueAsString(dto), SEARCH_CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("검색 캐시 저장 실패: {}", e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/fivefy/domain/search/service/SearchService.java
+++ b/src/main/java/com/fivefy/domain/search/service/SearchService.java
@@ -44,7 +44,10 @@ public class SearchService {
         }
 
         // 캐시 조회
-        String cacheKey = "search:" + trimmedKeyword + ":page:" + pageable.getPageNumber();
+        String cacheKey = "search:" + trimmedKeyword
+                + ":page:" + pageable.getPageNumber()
+                + ":" + pageable.getPageSize()
+                + ":" + pageable.getSort();
         SearchResponse cached = getFromCache(cacheKey, pageable);
         if (cached != null) return cached;
 

--- a/src/main/java/com/fivefy/domain/search/service/SearchService.java
+++ b/src/main/java/com/fivefy/domain/search/service/SearchService.java
@@ -1,7 +1,7 @@
 package com.fivefy.domain.search.service;
 
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.domain.search.dto.SearchCacheDto;
+import com.fivefy.domain.search.dto.cache.SearchCacheDto;
 import com.fivefy.domain.search.dto.response.SearchAlbumResponse;
 import com.fivefy.domain.search.dto.response.SearchArtistResponse;
 import com.fivefy.domain.search.dto.response.SearchResponse;


### PR DESCRIPTION
## 개요

알림 및 검색 도메인의 성능 개선 작업입니다.

- **PUBLISH_TRACK 대량 알림 발송 성능 개선** (Page → Slice 페이지네이션)
- **검색 조회 성능 개선** (OR → UNION 분리 + Redis 캐싱)
- **bulk insert 로그 음수 출력 수정** (rewriteBatchedStatements 적용에 따른 후속 정리)

## 변경 사항

### refactor(notification): Page → Slice 변경으로 PUBLISH_TRACK 발행 성능 개선

- `FollowRepository.findAllByArtistIdAndNotificationEnabledTrue` 반환 타입을 `Page<Follow>` → `Slice<Follow>`로 변경
- `Page` 기반 페이지네이션이 매 페이지마다 실행하던 불필요한 `count` 쿼리 제거
- 트랙 발매 알림에서 전체 팔로워 수가 필요하지 않으므로 `Slice`로 충분 (`LIMIT + 1` 전략)

### feat(search): 검색조회 Redis 캐시 적용 및 query OR → UNION 적용

- `EXPLAIN ANALYZE` 결과, fulltext 인덱스와 일반 B-Tree 인덱스를 `OR`로 결합한 쿼리에서 옵티마이저가 fulltext 인덱스를 사용하지 못하던 문제 발견
- `OR` 조건을 `UNION DISTINCT`로 분리하여 fulltext / B-Tree 인덱스가 각각 동작하도록 변경
- 동시 부하 환경에서 fulltext 버퍼 경합으로 성능이 다시 저하되는 문제 → Redis 캐싱 도입으로 해결
- 캐시 키: `search:{keyword}:page:{pageNumber}`, TTL 5분
- 캐시 조회/저장 실패 시 예외를 삼켜 DB 폴백 동작 (Redis 장애 시 검색 전체 장애 방지)
- 측정 결과:
  - 단일 사용자(VU=1) avg: 4,720ms → 78ms (약 60배 단축)
  - 동시 부하(VU=10) p(95): 30,270ms → 17.27ms (약 1,750배 단축)

### fix(notification): correct misleading negative count in bulk insert log

- `rewriteBatchedStatements=true` 적용 후 `JdbcTemplate.batchUpdate`가 `Statement.SUCCESS_NO_INFO(-2)`를 반환하면서 `"Bulk INSERT 완료: -2000건"`이라는 음수가 로그에 출력되던 문제 해결
- multi-value INSERT로 재작성되면 개별 row의 영향 row 수를 알 수 없으므로, INSERT 시도 건수(`userIds.size()`) 기준으로 로깅하도록 변경
- 사용되지 않는 `int[][] results` 변수 및 `Arrays` import 제거
- Javadoc `@return`을 "삽입된 행 수" → "시도한 행 수"로 갱신

## 변경 유형

- [x] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 검색 결과에 Redis 캐싱 적용으로 응답 속도 향상

* **개선 사항**
  * 알림 처리 동시성 및 검색 쿼리 최적화
  * 처리 시간 모니터링 추가로 성능 추적 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->