### PR TITLE
refactor: audioKey 기반 Playback audioUrl 생성 구조 개선

### DIFF
--- a/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
+++ b/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
@@ -1,8 +1,11 @@
 package com.fivefy.common.storage;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -11,9 +14,20 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class S3AudioStorageConfig {
 
     @Bean
-    public S3Client s3Client(AudioStorageProperties properties) {
+    public S3Client s3Client(
+            AudioStorageProperties properties,
+            @Value("${cloud.aws.credentials.access-key}") String accessKey,
+            @Value("${cloud.aws.credentials.secret-key}") String secretKey
+    ) {
+
+        AwsBasicCredentials credentials =
+                AwsBasicCredentials.create(accessKey, secretKey);
+
         return S3Client.builder()
                 .region(Region.of(properties.region()))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(credentials)
+                )
                 .build();
     }
 }

--- a/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
+++ b/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
@@ -1,11 +1,8 @@
 package com.fivefy.common.storage;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 

--- a/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
+++ b/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
@@ -14,20 +14,9 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class S3AudioStorageConfig {
 
     @Bean
-    public S3Client s3Client(
-            AudioStorageProperties properties,
-            @Value("${cloud.aws.credentials.access-key}") String accessKey,
-            @Value("${cloud.aws.credentials.secret-key}") String secretKey
-    ) {
-
-        AwsBasicCredentials credentials =
-                AwsBasicCredentials.create(accessKey, secretKey);
-
+    public S3Client s3Client(AudioStorageProperties properties) {
         return S3Client.builder()
                 .region(Region.of(properties.region()))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(credentials)
-                )
                 .build();
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
@@ -2,6 +2,9 @@ package com.fivefy.domain.playback.service;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * CloudFront 기반 audio URL 생성 서비스
@@ -14,7 +17,7 @@ public class AudioUrlService {
     public AudioUrlService(
             @Value("${cloudfront.audio-domain}") String cloudFrontDomain
     ) {
-        this.cloudFrontDomain = cloudFrontDomain;
+        this.cloudFrontDomain = normalizeDomain(cloudFrontDomain);
     }
 
     public String createAudioUrl(String audioKey) {
@@ -22,6 +25,17 @@ public class AudioUrlService {
             return null;
         }
 
-        return cloudFrontDomain + "/" + audioKey;
+        String encodedKey =
+                UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
+
+        return cloudFrontDomain + "/" + encodedKey;
+    }
+
+    private String normalizeDomain(String domain) {
+        if (domain.endsWith("/")) {
+            return domain.substring(0, domain.length() - 1);
+        }
+
+        return domain;
     }
 }

--- a/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
@@ -7,30 +7,39 @@ import org.springframework.web.util.UriUtils;
 import java.nio.charset.StandardCharsets;
 
 /**
- * CloudFront 기반 audio URL 생성 서비스
+ * 저장된 audioKey를 실제 재생 가능한 audioUrl로 변환하는 서비스
  */
 @Service
 public class AudioUrlService {
 
+    // CloudFront 또는 S3 접근 도메인
     private final String cloudFrontDomain;
 
     public AudioUrlService(
             @Value("${cloudfront.audio-domain}") String cloudFrontDomain
     ) {
+        // URL 중복 방지를 위해 마지막 "/" 제거
         this.cloudFrontDomain = normalizeDomain(cloudFrontDomain);
     }
 
+    /**
+     * audioKey를 기반으로 실제 접근 가능한 audioUrl 생성
+     */
     public String createAudioUrl(String audioKey) {
+        // audioKey가 없으면 URL 생성 불가
         if (audioKey == null || audioKey.isBlank()) {
             return null;
         }
 
+        // 공백, 한글 등의 특수문자 인코딩 처리
         String encodedKey =
                 UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
 
+        // 도메인 + audioKey 조합
         return cloudFrontDomain + "/" + encodedKey;
     }
 
+    // URL 중복 방지를 위해 마지막 "/" 제거
     private String normalizeDomain(String domain) {
         if (domain.endsWith("/")) {
             return domain.substring(0, domain.length() - 1);

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -69,7 +69,7 @@ public class PlaybackService {
 
         Playback savedPlayback = playbackRepository.save(playback);
 
-        // audio 재생 URL 생성
+        // 실제 재생 가능한 audioUrl 생성
         String audioUrl = createAudioUrl(savedPlayback.getTrackId());
 
         return PlaybackResponse.from(savedPlayback, audioUrl);
@@ -79,12 +79,12 @@ public class PlaybackService {
     public PlaybackResponse pause(Long userId, PlaybackPauseRequest request) {
         Playback playback = getOwnedPlayback(userId, request.id());
 
-        // 재생 중인 playback만 일시정지 가능
+        // 재생 중 상태만 pause 가능
         if (!playback.isPlaying()) {
             throw new BusinessException(PlaybackErrorCode.CURRENT_PLAYBACK_NOT_FOUND);
         }
 
-        // 클라이언트 재생 시간을 기준으로 일시정지 처리
+        // 클라이언트 기준 재생 시간 저장
         playback.pause(request.playedDuration());
         return PlaybackResponse.from(playback);
     }
@@ -93,12 +93,12 @@ public class PlaybackService {
     public PlaybackResponse stop(Long userId, PlaybackStopRequest request) {
         Playback playback = getOwnedPlayback(userId, request.id());
 
-        // 재생/일시정지 상태의 playback만 종료 가능
+        // 재생/일시정지 상태만 stop 가능
         if (!playback.isPlaying() && !playback.isPaused()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
 
-        // 클라이언트 재생 시간을 기준으로 종료 처리
+        // 클라이언트 기준 재생 시간 저장
         playback.stop(request.playedDuration());
         return PlaybackResponse.from(playback);
     }
@@ -107,7 +107,7 @@ public class PlaybackService {
     public PlaybackResponse skip(Long userId, PlaybackSkipRequest request) {
         Playback currentPlayback = getOwnedPlayback(userId, request.id());
 
-        // 재생/일시정지 상태의 playback만 skip 가능
+        // 재생/일시정지 상태만 skip 가능
         if (!currentPlayback.isPlaying() && !currentPlayback.isPaused()) {
             throw new BusinessException(PlaybackErrorCode.INVALID_PLAYBACK_STATE);
         }
@@ -120,14 +120,14 @@ public class PlaybackService {
             throw new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_FOUND);
         }
 
-        // 현재 트랙 기준 다음 트랙 계산
+        // 다음 재생 트랙 계산
         Long nextTrackId = resolveNextTrackId(playlistTracks, currentPlayback.getTrackId());
 
         // 현재 playback skip 처리
         currentPlayback.skip(request.playedDuration());
         playbackRepository.save(currentPlayback);
 
-        // 다음 트랙 playback 생성
+        // 다음 playback 생성
         Playback nextPlayback = Playback.create(
                 currentPlayback.getPlaylistId(),
                 nextTrackId,
@@ -138,7 +138,7 @@ public class PlaybackService {
 
         Playback savedNextPlayback = playbackRepository.save(nextPlayback);
 
-        // 다음 트랙 audio 재생 URL 생성
+        // 다음 곡 audioUrl 생성
         String audioUrl = createAudioUrl(savedNextPlayback.getTrackId());
 
         return PlaybackResponse.from(savedNextPlayback, audioUrl);
@@ -151,13 +151,13 @@ public class PlaybackService {
     }
 
     private Playback handlePlay(Playback playback, PlaybackPlayRequest request) {
-        // 일시정지 상태 playback 재개
+        // pause 상태면 이어서 재생
         if (playback.isPaused()) {
             playback.resume();
             return playback;
         }
 
-        // 종료된 playback 이후 새 playback 생성
+        // 종료된 playback이면 새 playback 생성
         if (playback.isStopped() || playback.isCompleted() || playback.isSkipped()) {
             return Playback.create(
                     request.playlistId(),
@@ -172,13 +172,13 @@ public class PlaybackService {
     }
 
     private Playback getOwnedPlayback(Long userId, Long playbackId) {
-        // 사용자 소유 playback 조회
+        // 사용자 본인 playback 조회
         return playbackRepository.findByIdAndUserId(playbackId, userId)
                 .orElseThrow(() -> new BusinessException(PlaybackErrorCode.PLAYBACK_NOT_FOUND));
     }
 
     private Long resolveNextTrackId(List<PlaylistTrack> playlistTracks, Long currentTrackId) {
-        // 현재 트랙 기준 다음 트랙 계산 (마지막 트랙이면 처음으로 순환)
+        // 마지막 곡이면 처음 곡으로 순환
         for (int i = 0; i < playlistTracks.size(); i++) {
             if (playlistTracks.get(i).getTrackId().equals(currentTrackId)) {
                 int nextIndex = (i + 1) % playlistTracks.size();
@@ -197,6 +197,7 @@ public class PlaybackService {
     }
 
     private String createAudioUrl(Long trackId) {
+        // track 조회 후 audioKey 기반 URL 생성
         Track track = trackRepository.findById(trackId)
                 .orElseThrow(() -> new BusinessException(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH));
 

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -12,6 +12,8 @@ import com.fivefy.domain.playback.enums.PlaybackStatus;
 import com.fivefy.domain.playback.repository.PlaybackRepository;
 import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
 import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
+import com.fivefy.domain.track.entity.Track;
+import com.fivefy.domain.track.repository.TrackRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,7 @@ public class PlaybackService {
     private final PlaybackRepository playbackRepository;
     private final PlaylistTrackRepository playlistTrackRepository;
     private final AudioUrlService audioUrlService;
+    private final TrackRepository trackRepository;
 
     @Transactional
     public PlaybackResponse play(Long userId, PlaybackPlayRequest request) {
@@ -67,7 +70,7 @@ public class PlaybackService {
         Playback savedPlayback = playbackRepository.save(playback);
 
         // audio 재생 URL 생성
-        String audioUrl = audioUrlService.createAudioUrl("example.mp3");
+        String audioUrl = createAudioUrl(savedPlayback.getTrackId());
 
         return PlaybackResponse.from(savedPlayback, audioUrl);
     }
@@ -136,7 +139,7 @@ public class PlaybackService {
         Playback savedNextPlayback = playbackRepository.save(nextPlayback);
 
         // 다음 트랙 audio 재생 URL 생성
-        String audioUrl = audioUrlService.createAudioUrl("example.mp3");
+        String audioUrl = createAudioUrl(savedNextPlayback.getTrackId());
 
         return PlaybackResponse.from(savedNextPlayback, audioUrl);
     }
@@ -191,5 +194,12 @@ public class PlaybackService {
         if (!playlistTrackRepository.existsByPlaylistIdAndTrackId(playlistId, trackId)) {
             throw new BusinessException(PlaybackErrorCode.PLAYLIST_TRACK_NOT_INCLUDED);
         }
+    }
+
+    private String createAudioUrl(Long trackId) {
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new BusinessException(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH));
+
+        return audioUrlService.createAudioUrl(track.getAudioKey());
     }
 }

--- a/src/test/java/com/fivefy/domain/playback/controller/PlaybackControllerTest.java
+++ b/src/test/java/com/fivefy/domain/playback/controller/PlaybackControllerTest.java
@@ -409,7 +409,7 @@ class PlaybackControllerTest extends RestDocsSupport {
                     LocalDateTime.now(),
                     LocalDateTime.now(),
                     null,
-                    "https://example.com/audio.mp3"
+                    null
             );
 
             given(playbackService.skip(any(), any(PlaybackSkipRequest.class)))
@@ -446,7 +446,7 @@ class PlaybackControllerTest extends RestDocsSupport {
                                     fieldWithPath("data.startedAt").type(STRING).description("재생 시작 시각"),
                                     fieldWithPath("data.lastPlayedAt").type(STRING).description("마지막 재생 시각"),
                                     fieldWithPath("data.endedAt").type(NULL).description("재생 종료 시각"),
-                                    fieldWithPath("data.audioUrl").type(STRING).description("오디오 파일 URL")
+                                    fieldWithPath("data.audioUrl").type(NULL).description("오디오 파일 URL")
                             )
                     ));
         }

--- a/src/test/java/com/fivefy/domain/playback/entity/PlaybackTest.java
+++ b/src/test/java/com/fivefy/domain/playback/entity/PlaybackTest.java
@@ -374,4 +374,35 @@ class PlaybackTest {
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
     }
+
+    @Test
+    @DisplayName("기존 playedDuration보다 작은 값이면 예외 발생")
+    void pause_invalid_playedDuration_decreased() {
+        // given
+        Playback playback =
+                Playback.create(1L, 10L, 1L, "session-1", "device-1");
+
+        ReflectionTestUtils.setField(playback, "playedDuration", 30);
+
+        // when & then
+        assertThatThrownBy(() -> playback.pause(10))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+    }
+
+    @Test
+    @DisplayName("기존 playedDuration이 null이면 비교 검증을 수행하지 않는다")
+    void pausePlayedDurationNullSkipValidation() {
+        // given
+        Playback playback =
+                Playback.create(1L, 10L, 1L, "session-1", "device-1");
+
+        ReflectionTestUtils.setField(playback, "playedDuration", null);
+
+        // when
+        playback.pause(10);
+
+        // then
+        assertThat(playback.getPlayedDuration()).isEqualTo(10);
+    }
 }

--- a/src/test/java/com/fivefy/domain/playback/service/AudioUrlServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playback/service/AudioUrlServiceTest.java
@@ -57,7 +57,7 @@ class AudioUrlServiceTest {
     }
 
     @Test
-    @DisplayName("audioKey 앞뒤에 공백이 있어도 그대로 URL을 생성한다")
+    @DisplayName("audioKey 앞뒤에 공백이 있으면 인코딩된 URL을 생성한다")
     void createAudioUrlWithSpaceInKey() {
         // given
         String audioKey = " tracks/test.mp3 ";
@@ -67,6 +67,40 @@ class AudioUrlServiceTest {
 
         // then
         assertThat(result)
-                .isEqualTo("https://cdn.fivefy.com/ tracks/test.mp3 ");
+                .isEqualTo("https://cdn.fivefy.com/%20tracks/test.mp3%20");
+    }
+
+    @Test
+    @DisplayName("CloudFront 도메인 끝에 슬래시가 없어도 정상적으로 audioUrl을 생성한다")
+    void createAudioUrlWithoutTrailingSlash() {
+        // given
+        AudioUrlService service =
+                new AudioUrlService("https://cdn.fivefy.com");
+
+        String audioKey = "tracks/test.mp3";
+
+        // when
+        String result = service.createAudioUrl(audioKey);
+
+        // then
+        assertThat(result)
+                .isEqualTo("https://cdn.fivefy.com/tracks/test.mp3");
+    }
+
+    @Test
+    @DisplayName("CloudFront 도메인 끝에 슬래시가 있으면 제거 후 audioUrl을 생성한다")
+    void createAudioUrlWithTrailingSlashDomain() {
+        // given
+        AudioUrlService service =
+                new AudioUrlService("https://cdn.fivefy.com/");
+
+        String audioKey = "tracks/test.mp3";
+
+        // when
+        String result = service.createAudioUrl(audioKey);
+
+        // then
+        assertThat(result)
+                .isEqualTo("https://cdn.fivefy.com/tracks/test.mp3");
     }
 }

--- a/src/test/java/com/fivefy/domain/playback/service/PlaybackServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playback/service/PlaybackServiceTest.java
@@ -12,6 +12,8 @@ import com.fivefy.domain.playback.enums.PlaybackStatus;
 import com.fivefy.domain.playback.repository.PlaybackRepository;
 import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
 import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
+import com.fivefy.domain.track.entity.Track;
+import com.fivefy.domain.track.repository.TrackRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +41,20 @@ class PlaybackServiceTest {
     @Mock private PlaybackRepository playbackRepository;
     @Mock private PlaylistTrackRepository playlistTrackRepository;
     @Mock private AudioUrlService audioUrlService;
+    @Mock private TrackRepository trackRepository;
+
+    private void givenTrackAudioUrl(Long trackId) {
+        Track track = mock(Track.class);
+
+        given(trackRepository.findById(trackId))
+                .willReturn(Optional.of(track));
+
+        given(track.getAudioKey())
+                .willReturn("example.mp3");
+
+        given(audioUrlService.createAudioUrl("example.mp3"))
+                .willReturn("https://example.com/audio.mp3");
+    }
 
     @Nested
     @DisplayName("재생 시작")
@@ -68,8 +84,7 @@ class PlaybackServiceTest {
                     userId, 1L, 10L, "session-1"
             )).willReturn(Optional.empty());
             given(playbackRepository.save(any(Playback.class))).willReturn(playback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(10L);
 
             // when
             PlaybackResponse result = playbackService.play(userId, request);
@@ -119,8 +134,7 @@ class PlaybackServiceTest {
                     userId, 1L, 10L, "session-1"
             )).willReturn(Optional.of(playback));
             given(playbackRepository.save(any(Playback.class))).willReturn(playback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(10L);
 
             // when
             PlaybackResponse result = playbackService.play(userId, request);
@@ -153,8 +167,7 @@ class PlaybackServiceTest {
                     userId, 1L, 10L, "session-1"
             )).willReturn(Optional.of(stoppedPlayback));
             given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(10L);
 
             // when
             PlaybackResponse result = playbackService.play(userId, request);
@@ -187,8 +200,7 @@ class PlaybackServiceTest {
                     userId, 1L, 10L, "session-1"
             )).willReturn(Optional.of(completedPlayback));
             given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(10L);
 
             // when
             PlaybackResponse result = playbackService.play(userId, request);
@@ -221,8 +233,7 @@ class PlaybackServiceTest {
                     userId, 1L, 10L, "session-1"
             )).willReturn(Optional.of(skippedPlayback));
             given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(10L);
 
             // when
             PlaybackResponse result = playbackService.play(userId, request);
@@ -296,8 +307,7 @@ class PlaybackServiceTest {
                     userId, 1L, 10L, "session-1"
             )).willReturn(Optional.of(existingPlayingPlayback));
             given(playbackRepository.save(any(Playback.class))).willReturn(newPlayback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(10L);
 
             // when
             PlaybackResponse result = playbackService.play(userId, request);
@@ -449,6 +459,48 @@ class PlaybackServiceTest {
             assertThatThrownBy(() -> playbackService.play(userId, request))
                     .isInstanceOf(BusinessException.class)
                     .hasMessage(PlaybackErrorCode.INVALID_PLAYBACK_STATE.getMessage());
+        }
+
+        @Test
+        @DisplayName("audioUrl 생성 시 트랙이 없으면 예외 발생")
+        void createAudioUrlTrackNotFound() {
+            // given
+            Long userId = 1L;
+
+            PlaybackPlayRequest request =
+                    new PlaybackPlayRequest(1L, 10L, "session-1", "device-1");
+
+            given(playlistTrackRepository.existsByPlaylistIdAndTrackId(1L, 10L))
+                    .willReturn(true);
+
+            given(playbackRepository.findTopByUserIdAndSessionIdAndStatusOrderByIdDesc(
+                    userId,
+                    "session-1",
+                    PlaybackStatus.PLAYING
+            )).willReturn(Optional.empty());
+
+            given(playbackRepository.findTopByUserIdAndPlaylistIdAndTrackIdAndSessionIdOrderByIdDesc(
+                    userId,
+                    1L,
+                    10L,
+                    "session-1"
+            )).willReturn(Optional.empty());
+
+            Playback playback =
+                    Playback.create(1L, 10L, userId, "session-1", "device-1");
+
+            given(playbackRepository.save(any(Playback.class)))
+                    .willReturn(playback);
+
+            given(trackRepository.findById(10L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() ->
+                    playbackService.play(userId, request)
+            )
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(PlaybackErrorCode.PLAYBACK_TRACK_MISMATCH.getMessage());
         }
     }
 
@@ -623,8 +675,7 @@ class PlaybackServiceTest {
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
                     .willReturn(List.of(currentTrack, nextTrack));
             given(playbackRepository.save(any(Playback.class))).willReturn(nextPlayback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(20L);
 
             // when
             PlaybackResponse result = playbackService.skip(userId, request);
@@ -659,8 +710,7 @@ class PlaybackServiceTest {
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
                     .willReturn(List.of(firstTrack, lastTrack));
             given(playbackRepository.save(any(Playback.class))).willReturn(nextPlayback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(10L);
 
             // when
             PlaybackResponse result = playbackService.skip(userId, request);
@@ -775,8 +825,7 @@ class PlaybackServiceTest {
             given(playlistTrackRepository.findAllByPlaylistIdOrderByPositionAsc(1L))
                     .willReturn(List.of(currentTrack, nextTrack));
             given(playbackRepository.save(any(Playback.class))).willReturn(nextPlayback);
-            given(audioUrlService.createAudioUrl("example.mp3"))
-                    .willReturn("https://example.com/audio.mp3");
+            givenTrackAudioUrl(20L);
 
             // when
             PlaybackResponse result = playbackService.skip(userId, request);


### PR DESCRIPTION
## 개요

> Playback 응답에서 고정된 audioUrl을 내려주던 구조를 개선하여,  
저장된 audioKey를 기반으로 실제 재생 가능한 접근용 audioUrl을 생성하도록 변경하였습니다.

> 추가적으로 관련 테스트를 보강하고,  
Playback 도메인 JaCoCo 커버리지 100%를 달성하였습니다.

## 변경 사항

- Playback 응답 audioUrl 생성 방식 개선
- 고정 audioUrl 응답 방식 제거
- `audioKey` 기반 접근 가능한 audioUrl 생성 적용
- Playback 재생 요청 시 trackId를 기준으로 Track 조회 후 audioKey 사용
- AudioUrlService URL 인코딩 처리 추가
- AudioUrlService domain slash 정규화 처리 추가
- PlaybackService audioUrl 생성 테스트 추가
- AudioUrlService URL 생성 및 예외 케이스 테스트 추가
- PlaybackController API 명세 테스트 수정
- Playback 도메인 JaCoCo 커버리지 100% 달성

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

> audioKey 기반 audioUrl 생성 로직과 Playback 응답 매핑을 검증합니다.

### audioKey 기반 audioUrl 생성 검증

- Playback 재생 요청 후 audioKey 기반 `audioUrl` 응답 반환 확인
- Playback skip 요청 시 다음 곡의 audioKey 기반 `audioUrl` 응답 반환 확인
- Track 조회 후 저장된 audioKey를 사용해 접근 가능한 audioUrl 생성 확인
- URL 인코딩 처리 확인
- domain slash 정규화 확인
- 잘못된 audioKey 입력 시 null 반환 확인

### 테스트 및 커버리지 확인

- PlaybackService audioUrl 생성 테스트 확인
- AudioUrlService URL 생성 테스트 확인
- PlaybackController API 명세 테스트 확인
- Playback 도메인 JaCoCo 커버리지 100% 확인

## 스크린샷
- Playback 응답 audioUrl 반환 결과
<img width="1515" height="1165" alt="image" src="https://github.com/user-attachments/assets/9bb35d61-c505-4b4a-a5c9-a6d51eb6c9fd" />

- Playback 도메인 테스트 커버리지 (100%)
<img width="1732" height="387" alt="image" src="https://github.com/user-attachments/assets/45046eea-0d83-4f59-9756-3848b272f2a3" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트