### PR TITLE
test: 좋아요 / 팔로우 / 검색 / 알림 rest docs 적용

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1249,6 +1249,263 @@ include::{snippets}/popular-chart-test-generate/http-response.adoc[]
 
 ---
 
+== Like API
+
+=== 좋아요 등록
+
+include::{snippets}/like-create/http-request.adoc[]
+include::{snippets}/like-create/request-fields.adoc[]
+include::{snippets}/like-create/http-response.adoc[]
+include::{snippets}/like-create/response-fields.adoc[]
+
+==== 에러 케이스 - targetId 누락
+
+include::{snippets}/like-create-invalid-targetId/http-request.adoc[]
+include::{snippets}/like-create-invalid-targetId/request-fields.adoc[]
+include::{snippets}/like-create-invalid-targetId/http-response.adoc[]
+include::{snippets}/like-create-invalid-targetId/response-fields.adoc[]
+
+==== 에러 케이스 - targetType 누락
+
+include::{snippets}/like-create-invalid-targetType/http-request.adoc[]
+include::{snippets}/like-create-invalid-targetType/request-fields.adoc[]
+include::{snippets}/like-create-invalid-targetType/http-response.adoc[]
+include::{snippets}/like-create-invalid-targetType/response-fields.adoc[]
+
+==== 에러 케이스 - 중복 좋아요
+
+include::{snippets}/like-create-duplicate/http-request.adoc[]
+include::{snippets}/like-create-duplicate/request-fields.adoc[]
+include::{snippets}/like-create-duplicate/http-response.adoc[]
+include::{snippets}/like-create-duplicate/response-fields.adoc[]
+
+---
+
+=== 좋아요 목록 조회
+
+include::{snippets}/like-list/http-request.adoc[]
+include::{snippets}/like-list/query-parameters.adoc[]
+include::{snippets}/like-list/http-response.adoc[]
+include::{snippets}/like-list/response-fields.adoc[]
+
+---
+
+=== 좋아요 취소
+
+include::{snippets}/like-delete/http-request.adoc[]
+include::{snippets}/like-delete/path-parameters.adoc[]
+include::{snippets}/like-delete/http-response.adoc[]
+include::{snippets}/like-delete/response-fields.adoc[]
+
+==== 에러 케이스 - 좋아요 없음
+
+include::{snippets}/like-delete-not-found/http-request.adoc[]
+include::{snippets}/like-delete-not-found/path-parameters.adoc[]
+include::{snippets}/like-delete-not-found/http-response.adoc[]
+include::{snippets}/like-delete-not-found/response-fields.adoc[]
+
+---
+
+== Follow API
+
+=== 팔로우 등록
+
+include::{snippets}/follow-create/http-request.adoc[]
+include::{snippets}/follow-create/request-fields.adoc[]
+include::{snippets}/follow-create/http-response.adoc[]
+include::{snippets}/follow-create/response-fields.adoc[]
+
+==== 에러 케이스 - 요청 검증 실패
+
+include::{snippets}/follow-create-invalid/http-request.adoc[]
+include::{snippets}/follow-create-invalid/request-fields.adoc[]
+include::{snippets}/follow-create-invalid/http-response.adoc[]
+include::{snippets}/follow-create-invalid/response-fields.adoc[]
+
+==== 에러 케이스 - 중복 팔로우
+
+include::{snippets}/follow-create-duplicate/http-request.adoc[]
+include::{snippets}/follow-create-duplicate/request-fields.adoc[]
+include::{snippets}/follow-create-duplicate/http-response.adoc[]
+include::{snippets}/follow-create-duplicate/response-fields.adoc[]
+
+---
+
+=== 팔로우 목록 조회
+
+include::{snippets}/follow-list/http-request.adoc[]
+include::{snippets}/follow-list/query-parameters.adoc[]
+include::{snippets}/follow-list/http-response.adoc[]
+include::{snippets}/follow-list/response-fields.adoc[]
+
+---
+
+=== 팔로우 취소
+
+include::{snippets}/follow-delete/http-request.adoc[]
+include::{snippets}/follow-delete/path-parameters.adoc[]
+include::{snippets}/follow-delete/http-response.adoc[]
+include::{snippets}/follow-delete/response-fields.adoc[]
+
+==== 에러 케이스 - 팔로우 없음
+
+include::{snippets}/follow-delete-not-found/http-request.adoc[]
+include::{snippets}/follow-delete-not-found/path-parameters.adoc[]
+include::{snippets}/follow-delete-not-found/http-response.adoc[]
+include::{snippets}/follow-delete-not-found/response-fields.adoc[]
+
+---
+
+=== 팔로우 알림 설정 토글
+
+include::{snippets}/follow-toggle-notification/http-request.adoc[]
+include::{snippets}/follow-toggle-notification/path-parameters.adoc[]
+include::{snippets}/follow-toggle-notification/http-response.adoc[]
+include::{snippets}/follow-toggle-notification/response-fields.adoc[]
+
+==== 에러 케이스 - 팔로우 없음
+
+include::{snippets}/follow-toggle-notification-not-found/http-request.adoc[]
+include::{snippets}/follow-toggle-notification-not-found/path-parameters.adoc[]
+include::{snippets}/follow-toggle-notification-not-found/http-response.adoc[]
+include::{snippets}/follow-toggle-notification-not-found/response-fields.adoc[]
+
+---
+
+== Search API
+
+=== 통합 검색
+
+include::{snippets}/search/http-request.adoc[]
+include::{snippets}/search/query-parameters.adoc[]
+include::{snippets}/search/http-response.adoc[]
+include::{snippets}/search/response-fields.adoc[]
+
+==== 에러 케이스 - 공백 키워드
+
+include::{snippets}/search-blank-keyword/http-request.adoc[]
+include::{snippets}/search-blank-keyword/query-parameters.adoc[]
+include::{snippets}/search-blank-keyword/http-response.adoc[]
+include::{snippets}/search-blank-keyword/response-fields.adoc[]
+
+---
+
+=== 최근 검색 기록 조회
+
+include::{snippets}/search-histories-get/http-request.adoc[]
+include::{snippets}/search-histories-get/http-response.adoc[]
+include::{snippets}/search-histories-get/response-fields.adoc[]
+
+---
+
+=== 최근 검색 기록 전체 삭제
+
+include::{snippets}/search-histories-delete-all/http-request.adoc[]
+include::{snippets}/search-histories-delete-all/http-response.adoc[]
+include::{snippets}/search-histories-delete-all/response-fields.adoc[]
+
+---
+
+=== 최근 검색 기록 개별 삭제
+
+include::{snippets}/search-histories-delete-one/http-request.adoc[]
+include::{snippets}/search-histories-delete-one/query-parameters.adoc[]
+include::{snippets}/search-histories-delete-one/http-response.adoc[]
+include::{snippets}/search-histories-delete-one/response-fields.adoc[]
+
+---
+
+== Notification API
+
+=== 실시간 알림 구독 (SSE)
+
+include::{snippets}/notification-subscribe/http-request.adoc[]
+include::{snippets}/notification-subscribe/request-headers.adoc[]
+include::{snippets}/notification-subscribe/http-response.adoc[]
+
+NOTE: 응답은 `text/event-stream` 스트리밍 형식으로 전송됩니다. 별도의 응답 바디 스키마는 제공되지 않습니다.
+
+---
+
+=== 알림 목록 조회
+
+include::{snippets}/notification-list/http-request.adoc[]
+include::{snippets}/notification-list/query-parameters.adoc[]
+include::{snippets}/notification-list/http-response.adoc[]
+include::{snippets}/notification-list/response-fields.adoc[]
+
+---
+
+=== 읽지 않은 알림 수 조회
+
+include::{snippets}/notification-unread-count/http-request.adoc[]
+include::{snippets}/notification-unread-count/http-response.adoc[]
+include::{snippets}/notification-unread-count/response-fields.adoc[]
+
+---
+
+=== 알림 읽음 처리
+
+include::{snippets}/notification-read/http-request.adoc[]
+include::{snippets}/notification-read/path-parameters.adoc[]
+include::{snippets}/notification-read/http-response.adoc[]
+include::{snippets}/notification-read/response-fields.adoc[]
+
+==== 에러 케이스 - 알림 없음
+
+include::{snippets}/notification-read-not-found/http-request.adoc[]
+include::{snippets}/notification-read-not-found/path-parameters.adoc[]
+include::{snippets}/notification-read-not-found/http-response.adoc[]
+include::{snippets}/notification-read-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 권한 없음
+
+include::{snippets}/notification-read-unauthorized/http-request.adoc[]
+include::{snippets}/notification-read-unauthorized/path-parameters.adoc[]
+include::{snippets}/notification-read-unauthorized/http-response.adoc[]
+include::{snippets}/notification-read-unauthorized/response-fields.adoc[]
+
+---
+
+=== 전체 알림 읽음 처리
+
+include::{snippets}/notification-read-all/http-request.adoc[]
+include::{snippets}/notification-read-all/http-response.adoc[]
+include::{snippets}/notification-read-all/response-fields.adoc[]
+
+---
+
+=== 알림 삭제
+
+include::{snippets}/notification-delete/http-request.adoc[]
+include::{snippets}/notification-delete/path-parameters.adoc[]
+include::{snippets}/notification-delete/http-response.adoc[]
+include::{snippets}/notification-delete/response-fields.adoc[]
+
+==== 에러 케이스 - 알림 없음
+
+include::{snippets}/notification-delete-not-found/http-request.adoc[]
+include::{snippets}/notification-delete-not-found/path-parameters.adoc[]
+include::{snippets}/notification-delete-not-found/http-response.adoc[]
+include::{snippets}/notification-delete-not-found/response-fields.adoc[]
+
+==== 에러 케이스 - 권한 없음
+
+include::{snippets}/notification-delete-unauthorized/http-request.adoc[]
+include::{snippets}/notification-delete-unauthorized/path-parameters.adoc[]
+include::{snippets}/notification-delete-unauthorized/http-response.adoc[]
+include::{snippets}/notification-delete-unauthorized/response-fields.adoc[]
+
+---
+
+=== 전체 알림 삭제
+
+include::{snippets}/notification-delete-all/http-request.adoc[]
+include::{snippets}/notification-delete-all/http-response.adoc[]
+include::{snippets}/notification-delete-all/response-fields.adoc[]
+
+---
+
 == 도메인 API
 
 === 기능

--- a/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
@@ -195,6 +195,7 @@ class FollowControllerTest extends RestDocsSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("팔로우 취소 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("follow-delete",
                             pathParameters(
                                     parameterWithName("artistId").description("취소할 아티스트 ID")
@@ -216,6 +217,7 @@ class FollowControllerTest extends RestDocsSupport {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message").value(
                             FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("follow-delete-not-found",
                             pathParameters(
                                     parameterWithName("artistId").description("취소할 아티스트 ID")

--- a/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/fivefy/domain/follow/controller/FollowControllerTest.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.follow.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.follow.dto.request.FollowCreateRequest;
 import com.fivefy.domain.follow.dto.response.FollowCreateResponse;
@@ -10,16 +11,14 @@ import com.fivefy.domain.follow.service.FollowService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,92 +28,130 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(FollowController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class FollowControllerTest {
+class FollowControllerTest extends RestDocsSupport {
 
-    @Autowired private MockMvc mockMvc;
-    @Autowired private ObjectMapper objectMapper;
+    @MockitoBean
+    private FollowService followService;
 
-    @MockitoBean private FollowService followService;
-    @MockitoBean private JwtUtil jwtUtil;
-    @MockitoBean private StringRedisTemplate stringRedisTemplate;
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private StringRedisTemplate stringRedisTemplate;
 
     private static final Long ARTIST_ID = 2L;
+    private static final Long FOLLOW_ID = 1L;
 
     @Nested
-    @DisplayName("팔로우 등록")
+    @WithMockUser
+    @DisplayName("팔로우 등록 API")
     class CreateFollow {
 
         @Test
         @DisplayName("팔로우 등록 성공 시 201 반환")
         void createFollow_success() throws Exception {
-            // given
             FollowCreateRequest request = new FollowCreateRequest(ARTIST_ID);
-            FollowCreateResponse response = new FollowCreateResponse(1L, ARTIST_ID, true, LocalDateTime.now());
+            FollowCreateResponse response = new FollowCreateResponse(
+                    FOLLOW_ID, ARTIST_ID, true,
+                    LocalDateTime.of(2026, 5, 13, 10, 0, 0)
+            );
 
             given(followService.createFollow(any(), eq(ARTIST_ID))).willReturn(response);
 
-            // when & then
             mockMvc.perform(post("/api/follows")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("팔로우 등록 성공"))
-                    .andExpect(jsonPath("$.data.artistId").value(ARTIST_ID));
+                    .andExpect(jsonPath("$.data.artistId").value(ARTIST_ID))
+                    .andDo(document("follow-create",
+                            requestFields(
+                                    followCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    followCreateResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("artistId null 시 400 반환")
         void createFollow_invalidRequest() throws Exception {
-            // given
             FollowCreateRequest request = new FollowCreateRequest(null);
 
-            // when & then
             mockMvc.perform(post("/api/follows")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("follow-create-invalid",
+                            requestFields(
+                                    fieldWithPath("artistId").type(NULL).description("아티스트 ID (값 없음)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("중복 팔로우 시 409 반환")
         void createFollow_duplicate() throws Exception {
-            // given
             FollowCreateRequest request = new FollowCreateRequest(ARTIST_ID);
             given(followService.createFollow(any(), eq(ARTIST_ID)))
                     .willThrow(new BusinessException(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS));
 
-            // when & then
             mockMvc.perform(post("/api/follows")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS.getMessage()))
+                    .andDo(document("follow-create-duplicate",
+                            requestFields(
+                                    followCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("팔로우 목록 조회")
+    @WithMockUser
+    @DisplayName("팔로우 목록 조회 API")
     class GetFollows {
 
         @Test
         @DisplayName("팔로우 목록 조회 성공 시 200 반환")
         void getFollows_success() throws Exception {
-            // given
-            FollowGetResponse followGetResponse = new FollowGetResponse(1L, ARTIST_ID, true);
+            FollowGetResponse followGetResponse = new FollowGetResponse(
+                    FOLLOW_ID, ARTIST_ID, true
+            );
             PageImpl<FollowGetResponse> page = new PageImpl<>(
                     List.of(followGetResponse), PageRequest.of(0, 20), 1
             );
 
             given(followService.getFollows(any(), any())).willReturn(page);
 
-            // when & then
             mockMvc.perform(get("/api/follows")
                             .param("page", "0")
                             .param("size", "20"))
@@ -122,69 +159,177 @@ class FollowControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("팔로우 목록 조회 성공"))
                     .andExpect(jsonPath("$.data.content[0].artistId").value(ARTIST_ID))
-                    .andExpect(jsonPath("$.data.totalElements").value(1));
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andDo(document("follow-list",
+                            queryParameters(
+                                    parameterWithName("page")
+                                            .description("페이지 번호 (0부터 시작)").optional(),
+                                    parameterWithName("size")
+                                            .description("페이지 크기 (기본 20)").optional(),
+                                    parameterWithName("sort")
+                                            .description("정렬 조건 (기본 artistId,asc)").optional()
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    pageResponseFields()
+                            ).and(
+                                    followListContentResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("팔로우 취소")
+    @WithMockUser
+    @DisplayName("팔로우 취소 API")
     class DeleteFollow {
 
         @Test
         @DisplayName("팔로우 취소 성공 시 200 반환")
         void deleteFollow_success() throws Exception {
-            // given
             doNothing().when(followService).deleteFollow(any(), eq(ARTIST_ID));
 
-            // when & then
-            mockMvc.perform(delete("/api/follows/{artistId}", ARTIST_ID))
+            mockMvc.perform(delete("/api/follows/{artistId}", ARTIST_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("팔로우 취소 성공"));
+                    .andExpect(jsonPath("$.message").value("팔로우 취소 성공"))
+                    .andDo(document("follow-delete",
+                            pathParameters(
+                                    parameterWithName("artistId").description("취소할 아티스트 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("존재하지 않는 팔로우 취소 시 404 반환")
         void deleteFollow_notFound() throws Exception {
-            // given
             doThrow(new BusinessException(FollowErrorCode.ERR_FOLLOW_NOT_FOUND))
                     .when(followService).deleteFollow(any(), eq(ARTIST_ID));
 
-            // when & then
-            mockMvc.perform(delete("/api/follows/{artistId}", ARTIST_ID))
+            mockMvc.perform(delete("/api/follows/{artistId}", ARTIST_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()))
+                    .andDo(document("follow-delete-not-found",
+                            pathParameters(
+                                    parameterWithName("artistId").description("취소할 아티스트 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("알림 설정 토글")
+    @WithMockUser
+    @DisplayName("알림 설정 토글 API")
     class ToggleNotification {
 
         @Test
         @DisplayName("알림 설정 토글 성공 시 200 반환")
         void toggleNotification_success() throws Exception {
-            // given
             doNothing().when(followService).toggleNotification(any(), eq(ARTIST_ID));
 
-            // when & then
-            mockMvc.perform(patch("/api/follows/{artistId}/notifications", ARTIST_ID))
+            mockMvc.perform(patch("/api/follows/{artistId}/notifications", ARTIST_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("알림 설정 변경 성공"));
+                    .andExpect(jsonPath("$.message").value("알림 설정 변경 성공"))
+                    .andDo(document("follow-toggle-notification",
+                            pathParameters(
+                                    parameterWithName("artistId").description("아티스트 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("존재하지 않는 팔로우 토글 시 404 반환")
         void toggleNotification_notFound() throws Exception {
-            // given
             doThrow(new BusinessException(FollowErrorCode.ERR_FOLLOW_NOT_FOUND))
                     .when(followService).toggleNotification(any(), eq(ARTIST_ID));
 
-            // when & then
-            mockMvc.perform(patch("/api/follows/{artistId}/notifications", ARTIST_ID))
+            mockMvc.perform(patch("/api/follows/{artistId}/notifications", ARTIST_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            FollowErrorCode.ERR_FOLLOW_NOT_FOUND.getMessage()))
+                    .andDo(document("follow-toggle-notification-not-found",
+                            pathParameters(
+                                    parameterWithName("artistId").description("아티스트 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
+    }
+
+    // ===== RestDocs helper methods =====
+
+    private FieldDescriptor[] baseSuccessResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("응답 메시지")
+        };
+    }
+
+    private FieldDescriptor[] baseErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("에러 메시지")
+        };
+    }
+
+    private FieldDescriptor[] validationErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+        };
+    }
+
+    private FieldDescriptor[] pageResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.page").type(NUMBER).description("현재 페이지"),
+                fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
+                fieldWithPath("data.totalElements").type(NUMBER).description("전체 데이터 수"),
+                fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수")
+        };
+    }
+
+    private FieldDescriptor[] followCreateRequestFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("artistId").type(NUMBER).description("팔로우할 아티스트 ID")
+        };
+    }
+
+    private FieldDescriptor[] followCreateResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.id").type(NUMBER).description("생성된 팔로우 ID"),
+                fieldWithPath("data.artistId").type(NUMBER).description("팔로우한 아티스트 ID"),
+                fieldWithPath("data.notificationEnabled").type(BOOLEAN).description("알림 설정 여부"),
+                fieldWithPath("data.createdAt").type(STRING).description("팔로우 생성 시각")
+        };
+    }
+
+    private FieldDescriptor[] followListContentResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.content").type(ARRAY).description("팔로우 목록"),
+                fieldWithPath("data.content[].id").type(NUMBER).description("팔로우 ID"),
+                fieldWithPath("data.content[].artistId").type(NUMBER).description("아티스트 ID"),
+                fieldWithPath("data.content[].notificationEnabled").type(BOOLEAN).description("알림 설정 여부")
+        };
     }
 }

--- a/src/test/java/com/fivefy/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/fivefy/domain/like/controller/LikeControllerTest.java
@@ -244,6 +244,7 @@ class LikeControllerTest extends RestDocsSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("좋아요 취소 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("like-delete",
                             pathParameters(
                                     parameterWithName("likeId").description("취소할 좋아요 ID")
@@ -265,6 +266,7 @@ class LikeControllerTest extends RestDocsSupport {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message").value(
                             LikeErrorCode.ERR_LIKE_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("like-delete-not-found",
                             pathParameters(
                                     parameterWithName("likeId").description("취소할 좋아요 ID")

--- a/src/test/java/com/fivefy/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/fivefy/domain/like/controller/LikeControllerTest.java
@@ -1,7 +1,9 @@
 package com.fivefy.domain.like.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.common.filter.LastActiveAtFilter;
 import com.fivefy.domain.like.dto.request.LikeCreateRequest;
 import com.fivefy.domain.like.dto.response.LikeCreateResponse;
 import com.fivefy.domain.like.dto.response.LikeGetResponse;
@@ -11,16 +13,14 @@ import com.fivefy.domain.like.service.LikeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
-import tools.jackson.databind.ObjectMapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,107 +30,157 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(LikeController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class LikeControllerTest {
+class LikeControllerTest extends RestDocsSupport {
 
-    @Autowired private MockMvc mockMvc;
-    @Autowired private ObjectMapper objectMapper;
+    @MockitoBean
+    private LikeService likeService;
 
-    @MockitoBean private LikeService likeService;
-    @MockitoBean private JwtUtil jwtUtil;
-    @MockitoBean private StringRedisTemplate stringRedisTemplate;
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private StringRedisTemplate stringRedisTemplate;
 
     private static final Long TRACK_ID = 2L;
     private static final Long LIKE_ID = 4L;
 
     @Nested
-    @DisplayName("좋아요 등록")
+    @WithMockUser
+    @DisplayName("좋아요 등록 API")
     class CreateLike {
 
         @Test
         @DisplayName("좋아요 등록 성공 시 201 반환")
         void createLike_success() throws Exception {
-            // given
             LikeCreateRequest request = new LikeCreateRequest(TRACK_ID, TargetType.TRACK);
-            LikeCreateResponse response = new LikeCreateResponse(LIKE_ID, TRACK_ID, TargetType.TRACK, LocalDateTime.now());
+            LikeCreateResponse response = new LikeCreateResponse(
+                    LIKE_ID, TRACK_ID, TargetType.TRACK,
+                    LocalDateTime.of(2026, 5, 13, 10, 0, 0)
+            );
 
-            given(likeService.createLike(eq(TRACK_ID), eq(TargetType.TRACK), any())).willReturn(response);
+            given(likeService.createLike(eq(TRACK_ID), eq(TargetType.TRACK), any()))
+                    .willReturn(response);
 
-            // when & then
             mockMvc.perform(post("/api/likes")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("좋아요 등록 성공"))
                     .andExpect(jsonPath("$.data.targetId").value(TRACK_ID))
-                    .andExpect(jsonPath("$.data.targetType").value("TRACK"));
+                    .andExpect(jsonPath("$.data.targetType").value("TRACK"))
+                    .andDo(document("like-create",
+                            requestFields(
+                                    likeCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    likeCreateResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("targetId null 시 400 반환")
         void createLike_targetIdNull() throws Exception {
-            // given
             LikeCreateRequest request = new LikeCreateRequest(null, TargetType.TRACK);
 
-            // when & then
             mockMvc.perform(post("/api/likes")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("like-create-invalid-targetId",
+                            requestFields(
+                                    fieldWithPath("targetId").type(NULL).description("좋아요 대상 ID (값 없음)"),
+                                    fieldWithPath("targetType").type(STRING).description("대상 타입 (TRACK / ALBUM)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("targetType null 시 400 반환")
         void createLike_targetTypeNull() throws Exception {
-            // given
             LikeCreateRequest request = new LikeCreateRequest(TRACK_ID, null);
 
-            // when & then
             mockMvc.perform(post("/api/likes")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("like-create-invalid-targetType",
+                            requestFields(
+                                    fieldWithPath("targetId").type(NUMBER).description("좋아요 대상 ID"),
+                                    fieldWithPath("targetType").type(NULL).description("대상 타입 (값 없음)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            ).and(
+                                    validationErrorResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("중복 좋아요 시 409 반환")
         void createLike_duplicate() throws Exception {
-            // given
             LikeCreateRequest request = new LikeCreateRequest(TRACK_ID, TargetType.TRACK);
             given(likeService.createLike(eq(TRACK_ID), eq(TargetType.TRACK), any()))
                     .willThrow(new BusinessException(LikeErrorCode.ERR_LIKE_ALREADY_EXISTS));
 
-            // when & then
             mockMvc.perform(post("/api/likes")
+                            .with(csrf().asHeader())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
                     .andExpect(status().isConflict())
-                    .andExpect(jsonPath("$.message").value(LikeErrorCode.ERR_LIKE_ALREADY_EXISTS.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            LikeErrorCode.ERR_LIKE_ALREADY_EXISTS.getMessage()))
+                    .andDo(document("like-create-duplicate",
+                            requestFields(
+                                    likeCreateRequestFields()
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("좋아요 목록 조회")
+    @WithMockUser
+    @DisplayName("좋아요 목록 조회 API")
     class GetLikes {
 
         @Test
         @DisplayName("좋아요 목록 조회 성공 시 200 반환")
         void getLikes_success() throws Exception {
-            // given
-            LikeGetResponse likeGetResponse = new LikeGetResponse(LIKE_ID, TRACK_ID, TargetType.TRACK, "title", "artist", LocalDateTime.now());
+            LikeGetResponse likeGetResponse = new LikeGetResponse(
+                    LIKE_ID, TRACK_ID, TargetType.TRACK, "Love poem", "아이유",
+                    LocalDateTime.of(2026, 5, 13, 10, 0, 0)
+            );
             PageImpl<LikeGetResponse> page = new PageImpl<>(
                     List.of(likeGetResponse), PageRequest.of(0, 20), 1
             );
 
             given(likeService.getLikes(any(), any(), any())).willReturn(page);
 
-            // when & then
             mockMvc.perform(get("/api/likes")
                             .param("page", "0")
                             .param("size", "20"))
@@ -138,59 +188,155 @@ class LikeControllerTest {
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("좋아요 목록 조회 성공"))
                     .andExpect(jsonPath("$.data.content[0].targetId").value(TRACK_ID))
-                    .andExpect(jsonPath("$.data.totalElements").value(1));
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andDo(document("like-list",
+                            queryParameters(
+                                    parameterWithName("targetType")
+                                            .description("대상 타입 필터 (TRACK / ALBUM, 선택)").optional(),
+                                    parameterWithName("page")
+                                            .description("페이지 번호 (0부터 시작)").optional(),
+                                    parameterWithName("size")
+                                            .description("페이지 크기 (기본 20)").optional()
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    pageResponseFields()
+                            ).and(
+                                    likeListContentResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("targetType 필터링 조회 성공 시 200 반환")
         void getLikes_withTargetTypeFilter() throws Exception {
-            // given
-            LikeGetResponse likeGetResponse = new LikeGetResponse(LIKE_ID, TRACK_ID, TargetType.TRACK, "title", "artist", LocalDateTime.now());
+            LikeGetResponse likeGetResponse = new LikeGetResponse(
+                    LIKE_ID, TRACK_ID, TargetType.TRACK, "Love poem", "아이유",
+                    LocalDateTime.of(2026, 5, 13, 10, 0, 0)
+            );
             PageImpl<LikeGetResponse> page = new PageImpl<>(
                     List.of(likeGetResponse), PageRequest.of(0, 20), 1
             );
 
             given(likeService.getLikes(any(), eq(TargetType.TRACK), any())).willReturn(page);
 
-            // when & then
             mockMvc.perform(get("/api/likes")
                             .param("targetType", "TRACK")
                             .param("page", "0")
                             .param("size", "20"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.content[0].targetType").value("TRACK"));
         }
     }
 
     @Nested
-    @DisplayName("좋아요 취소")
+    @WithMockUser
+    @DisplayName("좋아요 취소 API")
     class DeleteLike {
 
         @Test
         @DisplayName("좋아요 취소 성공 시 200 반환")
         void deleteLike_success() throws Exception {
-            // given
             doNothing().when(likeService).deleteLike(any(), eq(LIKE_ID));
 
-            // when & then
-            mockMvc.perform(delete("/api/likes/{likeId}", LIKE_ID))
+            mockMvc.perform(delete("/api/likes/{likeId}", LIKE_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("좋아요 취소 성공"));
+                    .andExpect(jsonPath("$.message").value("좋아요 취소 성공"))
+                    .andDo(document("like-delete",
+                            pathParameters(
+                                    parameterWithName("likeId").description("취소할 좋아요 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
 
         @Test
         @DisplayName("존재하지 않는 좋아요 취소 시 404 반환")
         void deleteLike_notFound() throws Exception {
-            // given
             doThrow(new BusinessException(LikeErrorCode.ERR_LIKE_NOT_FOUND))
                     .when(likeService).deleteLike(any(), eq(LIKE_ID));
 
-            // when & then
-            mockMvc.perform(delete("/api/likes/{likeId}", LIKE_ID))
+            mockMvc.perform(delete("/api/likes/{likeId}", LIKE_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(LikeErrorCode.ERR_LIKE_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            LikeErrorCode.ERR_LIKE_NOT_FOUND.getMessage()))
+                    .andDo(document("like-delete-not-found",
+                            pathParameters(
+                                    parameterWithName("likeId").description("취소할 좋아요 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
+    }
+
+    // ===== RestDocs helper methods =====
+
+    private FieldDescriptor[] baseSuccessResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("응답 메시지")
+        };
+    }
+
+    private FieldDescriptor[] baseErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("에러 메시지")
+        };
+    }
+
+    private FieldDescriptor[] validationErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data").type(ARRAY).description("상세 에러 내역"),
+                fieldWithPath("data[].field").type(STRING).description("에러가 발생한 필드명"),
+                fieldWithPath("data[].message").type(STRING).description("에러 상세 사유")
+        };
+    }
+
+    private FieldDescriptor[] pageResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.page").type(NUMBER).description("현재 페이지"),
+                fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
+                fieldWithPath("data.totalElements").type(NUMBER).description("전체 데이터 수"),
+                fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수")
+        };
+    }
+
+    private FieldDescriptor[] likeCreateRequestFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("targetId").type(NUMBER).description("좋아요 대상 ID"),
+                fieldWithPath("targetType").type(STRING).description("대상 타입 (TRACK / ALBUM)")
+        };
+    }
+
+    private FieldDescriptor[] likeCreateResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.id").type(NUMBER).description("생성된 좋아요 ID"),
+                fieldWithPath("data.targetId").type(NUMBER).description("좋아요 대상 ID"),
+                fieldWithPath("data.targetType").type(STRING).description("대상 타입 (TRACK / ALBUM)"),
+                fieldWithPath("data.createdAt").type(STRING).description("좋아요 생성 시각")
+        };
+    }
+
+    private FieldDescriptor[] likeListContentResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.content").type(ARRAY).description("좋아요 목록"),
+                fieldWithPath("data.content[].id").type(NUMBER).description("좋아요 ID"),
+                fieldWithPath("data.content[].targetId").type(NUMBER).description("좋아요 대상 ID"),
+                fieldWithPath("data.content[].targetType").type(STRING).description("대상 타입"),
+                fieldWithPath("data.content[].targetName").type(STRING).description("대상 이름 (트랙명/앨범명)"),
+                fieldWithPath("data.content[].artistName").type(STRING).description("아티스트 이름"),
+                fieldWithPath("data.content[].createdAt").type(STRING).description("좋아요 생성 시각")
+        };
     }
 }

--- a/src/test/java/com/fivefy/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/fivefy/domain/like/controller/LikeControllerTest.java
@@ -3,7 +3,6 @@ package com.fivefy.domain.like.controller;
 import com.fivefy.common.config.security.JwtUtil;
 import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
-import com.fivefy.common.filter.LastActiveAtFilter;
 import com.fivefy.domain.like.dto.request.LikeCreateRequest;
 import com.fivefy.domain.like.dto.response.LikeCreateResponse;
 import com.fivefy.domain.like.dto.response.LikeGetResponse;

--- a/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
@@ -1,6 +1,7 @@
 package com.fivefy.domain.notification.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
 import com.fivefy.domain.notification.dto.response.NotificationGetResponse;
 import com.fivefy.domain.notification.enums.NotificationChannel;
@@ -11,16 +12,15 @@ import com.fivefy.domain.notification.service.NotificationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
@@ -31,15 +31,20 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+/**
+ * NotificationController 웹 계층 테스트 및 REST Docs 문서화
+ */
 @WebMvcTest(NotificationController.class)
-@AutoConfigureMockMvc(addFilters = false)
-class NotificationControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+class NotificationControllerTest extends RestDocsSupport {
 
     @MockitoBean
     private NotificationService notificationService;
@@ -50,225 +55,339 @@ class NotificationControllerTest {
     @MockitoBean
     private StringRedisTemplate stringRedisTemplate;
 
-    private static final Long USER_ID = 1L;
     private static final Long NOTIFICATION_ID = 10L;
 
     private NotificationGetResponse makeResponse() {
         return new NotificationGetResponse(
                 NOTIFICATION_ID,
                 NotificationType.NEW_FOLLOWER,
-                "테스트 알림",
+                "새 팔로워가 생겼습니다",
                 NotificationStatus.SENT,
                 NotificationChannel.IN_APP,
-                null,
-                LocalDateTime.now()
+                LocalDateTime.of(2026, 5, 13, 9, 0, 0),
+                LocalDateTime.of(2026, 5, 13, 10, 0, 0)
         );
     }
 
     @Nested
-    @DisplayName("SSE 구독")
+    @WithMockUser
+    @DisplayName("SSE 구독 API")
     class Subscribe {
 
         @Test
-        @DisplayName("구독 요청 시 200과 text/event-stream을 반환한다")
-        void subscribe_returns200() throws Exception {
-            // given
+        @DisplayName("구독 요청 시 200 반환")
+        void subscribe_success() throws Exception {
             given(notificationService.subscribe(any(), any())).willReturn(new SseEmitter());
 
-            // when & then
             mockMvc.perform(get("/api/notifications/subscribe")
                             .accept(MediaType.TEXT_EVENT_STREAM))
-                            .andExpect(status().isOk())
-                            .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM));
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM))
+                    .andDo(document("notification-subscribe",
+                            requestHeaders(
+                                    headerWithName("Last-Event-ID")
+                                            .description("재연결 시 마지막 이벤트 ID (선택)").optional()
+                            )
+                    ));
         }
 
         @Test
-        @DisplayName("Last-Event-ID 헤더와 함께 재연결 시 200을 반환한다")
-        void subscribe_withLastEventId_returns200() throws Exception {
+        @DisplayName("Last-Event-ID 헤더 재연결 시 200 반환")
+        void subscribe_withLastEventId() throws Exception {
             given(notificationService.subscribe(any(), eq(5L))).willReturn(new SseEmitter());
 
             mockMvc.perform(get("/api/notifications/subscribe")
-                            .header("Last-Event-ID", "5")
-                            .accept(MediaType.TEXT_EVENT_STREAM))
-                            .andExpect(status().isOk());
+                            .accept(MediaType.TEXT_EVENT_STREAM)
+                            .header("Last-Event-ID", "5"))
+                    .andExpect(status().isOk());
         }
     }
 
     @Nested
-    @DisplayName("알림 목록 조회")
+    @WithMockUser
+    @DisplayName("알림 목록 조회 API")
     class GetAllNotification {
 
         @Test
-        @DisplayName("알림 목록 조회 성공 시 200을 반환한다")
-        void getAllNotification_returns200() throws Exception {
-            // given
+        @DisplayName("알림 목록 조회 성공 시 200 반환")
+        void getAllNotification_success() throws Exception {
             Page<NotificationGetResponse> page = new PageImpl<>(
-                    List.of(makeResponse()), PageRequest.of(0, 20), 1);
+                    List.of(makeResponse()), PageRequest.of(0, 20), 1
+            );
             given(notificationService.getNotifications(any(), any())).willReturn(page);
 
-            // when & then
-            mockMvc.perform(get("/api/notifications"))
+            mockMvc.perform(get("/api/notifications")
+                            .param("page", "0")
+                            .param("size", "20"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("알림 목록 조회 성공"))
                     .andExpect(jsonPath("$.data.content[0].id").value(NOTIFICATION_ID))
-                    .andExpect(jsonPath("$.data.content[0].type").value("NEW_FOLLOWER"))
-                    .andExpect(jsonPath("$.data.totalElements").value(1));
-        }
-
-        @Test
-        @DisplayName("알림이 없으면 빈 목록을 반환한다")
-        void getAllNotification_empty_returnsEmptyList() throws Exception {
-            // given
-            given(notificationService.getNotifications(any(), any())).willReturn(Page.empty());
-
-            // when & then
-            mockMvc.perform(get("/api/notifications"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.content").isEmpty());
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andDo(document("notification-list",
+                            queryParameters(
+                                    parameterWithName("page")
+                                            .description("페이지 번호 (0부터 시작)").optional(),
+                                    parameterWithName("size")
+                                            .description("페이지 크기 (기본 20)").optional(),
+                                    parameterWithName("sort")
+                                            .description("정렬 조건 (기본 createdAt,asc)").optional()
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    pageResponseFields()
+                            ).and(
+                                    notificationListContentResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("읽지 않은 알림 수 조회")
+    @WithMockUser
+    @DisplayName("읽지 않은 알림 수 조회 API")
     class GetUnreadCount {
 
         @Test
-        @DisplayName("읽지 않은 알림 수 조회 성공 시 200을 반환한다")
-        void getUnreadCount_returns200() throws Exception {
-            // given
-            given(notificationService.getUnreadCount(any())).willReturn(5L);
+        @DisplayName("읽지 않은 알림 수 조회 성공 시 200 반환")
+        void getUnreadCount_success() throws Exception {
+            given(notificationService.getUnreadCount(any())).willReturn(7L);
 
-            // when & then
             mockMvc.perform(get("/api/notifications/unread-count"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("읽지 않은 알림 수 조회 성공"))
-                    .andExpect(jsonPath("$.data").value(5));
+                    .andExpect(jsonPath("$.data").value(7))
+                    .andDo(document("notification-unread-count",
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    fieldWithPath("data").type(NUMBER).description("읽지 않은 알림 수")
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("단건 읽음 처리")
+    @WithMockUser
+    @DisplayName("단건 읽음 처리 API")
     class MarkAsRead {
 
         @Test
-        @DisplayName("읽음 처리 성공 시 200을 반환한다")
-        void markAsRead_returns200() throws Exception {
-            // given
+        @DisplayName("단건 읽음 처리 성공 시 200 반환")
+        void markAsRead_success() throws Exception {
             doNothing().when(notificationService).markAsRead(any(), eq(NOTIFICATION_ID));
 
-            // when & then
-            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID))
+            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("알림 읽음 처리 성공"));
+                    .andExpect(jsonPath("$.message").value("알림 읽음 처리 성공"))
+                    .andDo(document("notification-read",
+                            pathParameters(
+                                    parameterWithName("notificationId").description("읽음 처리할 알림 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
 
         @Test
-        @DisplayName("존재하지 않는 알림 읽음 처리 시 404를 반환한다")
-        void markAsRead_notFound_returns404() throws Exception {
-            // given
+        @DisplayName("존재하지 않는 알림 읽음 처리 시 404 반환")
+        void markAsRead_notFound() throws Exception {
             doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND))
                     .when(notificationService).markAsRead(any(), eq(NOTIFICATION_ID));
 
-            // when & then
-            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID))
+            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage()))
+                    .andDo(document("notification-read-not-found",
+                            pathParameters(
+                                    parameterWithName("notificationId").description("읽음 처리할 알림 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
 
         @Test
-        @DisplayName("다른 유저의 알림 읽음 처리 시 403을 반환한다")
-        void markAsRead_unauthorized_returns403() throws Exception {
-            // given
+        @DisplayName("다른 유저의 알림 읽음 처리 시 403 반환")
+        void markAsRead_unauthorized() throws Exception {
             doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED))
                     .when(notificationService).markAsRead(any(), eq(NOTIFICATION_ID));
 
-            // when & then
-            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID))
+            mockMvc.perform(patch("/api/notifications/{notificationId}/read", NOTIFICATION_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage()))
+                    .andDo(document("notification-read-unauthorized",
+                            pathParameters(
+                                    parameterWithName("notificationId").description("읽음 처리할 알림 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("전체 읽음 처리")
+    @WithMockUser
+    @DisplayName("전체 읽음 처리 API")
     class MarkAllAsRead {
 
         @Test
-        @DisplayName("전체 읽음 처리 성공 시 200을 반환한다")
-        void markAllAsRead_returns200() throws Exception {
-            // given
+        @DisplayName("전체 읽음 처리 성공 시 200 반환")
+        void markAllAsRead_success() throws Exception {
             doNothing().when(notificationService).markAllAsRead(any());
 
-            // when & then
-            mockMvc.perform(patch("/api/notifications/read-all"))
+            mockMvc.perform(patch("/api/notifications/read-all")
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("전체 알림 읽음 처리 성공"));
+                    .andExpect(jsonPath("$.message").value("전체 알림 읽음 처리 성공"))
+                    .andDo(document("notification-read-all",
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("단건 알림 삭제")
+    @WithMockUser
+    @DisplayName("단건 알림 삭제 API")
     class DeleteNotification {
 
         @Test
-        @DisplayName("단건 삭제 성공 시 200을 반환한다")
-        void deleteNotification_returns200() throws Exception {
-            // given
+        @DisplayName("단건 삭제 성공 시 200 반환")
+        void deleteNotification_success() throws Exception {
             doNothing().when(notificationService).deleteNotification(any(), eq(NOTIFICATION_ID));
 
-            // when & then
-            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID))
+            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("알림 삭제 성공"));
+                    .andExpect(jsonPath("$.message").value("알림 삭제 성공"))
+                    .andDo(document("notification-delete",
+                            pathParameters(
+                                    parameterWithName("notificationId").description("삭제할 알림 ID")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
 
         @Test
-        @DisplayName("존재하지 않는 알림 삭제 시 404를 반환한다")
-        void deleteNotification_notFound_returns404() throws Exception {
-            // given
+        @DisplayName("존재하지 않는 알림 삭제 시 404 반환")
+        void deleteNotification_notFound() throws Exception {
             doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND))
                     .when(notificationService).deleteNotification(any(), eq(NOTIFICATION_ID));
 
-            // when & then
-            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID))
+            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage()))
+                    .andDo(document("notification-delete-not-found",
+                            pathParameters(
+                                    parameterWithName("notificationId").description("삭제할 알림 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
 
         @Test
-        @DisplayName("다른 유저의 알림 삭제 시 403을 반환한다")
-        void deleteNotification_unauthorized_returns403() throws Exception {
-            // given
+        @DisplayName("다른 유저의 알림 삭제 시 403 반환")
+        void deleteNotification_unauthorized() throws Exception {
             doThrow(new BusinessException(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED))
                     .when(notificationService).deleteNotification(any(), eq(NOTIFICATION_ID));
 
-            // when & then
-            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID))
+            mockMvc.perform(delete("/api/notifications/{notificationId}", NOTIFICATION_ID)
+                            .with(csrf().asHeader()))
                     .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.message").value(NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage()))
+                    .andDo(document("notification-delete-unauthorized",
+                            pathParameters(
+                                    parameterWithName("notificationId").description("삭제할 알림 ID")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("전체 알림 삭제")
+    @WithMockUser
+    @DisplayName("전체 알림 삭제 API")
     class DeleteAllNotifications {
 
         @Test
-        @DisplayName("전체 삭제 성공 시 200을 반환한다")
-        void deleteAllNotifications_returns200() throws Exception {
-            // given
+        @DisplayName("전체 삭제 성공 시 200 반환")
+        void deleteAllNotifications_success() throws Exception {
             doNothing().when(notificationService).deleteAllNotifications(any());
 
-            // when & then
-            mockMvc.perform(delete("/api/notifications"))
+            mockMvc.perform(delete("/api/notifications")
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("전체 알림 삭제 성공"));
+                    .andExpect(jsonPath("$.message").value("전체 알림 삭제 성공"))
+                    .andDo(document("notification-delete-all",
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
+    }
+
+    // ===== RestDocs helper methods =====
+
+    private FieldDescriptor[] baseSuccessResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("응답 메시지")
+        };
+    }
+
+    private FieldDescriptor[] baseErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("에러 메시지")
+        };
+    }
+
+    private FieldDescriptor[] pageResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.page").type(NUMBER).description("현재 페이지"),
+                fieldWithPath("data.size").type(NUMBER).description("페이지 크기"),
+                fieldWithPath("data.totalElements").type(NUMBER).description("전체 데이터 수"),
+                fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수")
+        };
+    }
+
+    private FieldDescriptor[] notificationListContentResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data.content").type(ARRAY).description("알림 목록"),
+                fieldWithPath("data.content[].id").type(NUMBER).description("알림 ID"),
+                fieldWithPath("data.content[].type").type(STRING).description("알림 타입"),
+                fieldWithPath("data.content[].content").type(STRING).description("알림 내용"),
+                fieldWithPath("data.content[].status").type(STRING).description("알림 상태 (QUEUED/SENT/FAILED)"),
+                fieldWithPath("data.content[].channel").type(STRING).description("알림 채널 (PUSH/EMAIL/IN_APP)"),
+                fieldWithPath("data.content[].readAt").type(STRING).description("읽은 시각"),
+                fieldWithPath("data.content[].createdAt").type(STRING).description("알림 생성 시각")
+        };
     }
 }

--- a/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/fivefy/domain/notification/controller/NotificationControllerTest.java
@@ -275,6 +275,7 @@ class NotificationControllerTest extends RestDocsSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("알림 삭제 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("notification-delete",
                             pathParameters(
                                     parameterWithName("notificationId").description("삭제할 알림 ID")
@@ -296,6 +297,7 @@ class NotificationControllerTest extends RestDocsSupport {
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message").value(
                             NotificationErrorCode.ERR_NOTIFICATION_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("notification-delete-not-found",
                             pathParameters(
                                     parameterWithName("notificationId").description("삭제할 알림 ID")
@@ -317,6 +319,7 @@ class NotificationControllerTest extends RestDocsSupport {
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.message").value(
                             NotificationErrorCode.ERR_NOTIFICATION_UNAUTHORIZED.getMessage()))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("notification-delete-unauthorized",
                             pathParameters(
                                     parameterWithName("notificationId").description("삭제할 알림 ID")
@@ -343,6 +346,7 @@ class NotificationControllerTest extends RestDocsSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("전체 알림 삭제 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("notification-delete-all",
                             responseFields(
                                     baseSuccessResponseFields()

--- a/src/test/java/com/fivefy/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/fivefy/domain/search/controller/SearchControllerTest.java
@@ -1,40 +1,43 @@
 package com.fivefy.domain.search.controller;
 
 import com.fivefy.common.config.security.JwtUtil;
+import com.fivefy.common.docs.RestDocsSupport;
 import com.fivefy.common.exception.BusinessException;
+import com.fivefy.domain.search.dto.response.SearchAlbumResponse;
 import com.fivefy.domain.search.dto.response.SearchArtistResponse;
 import com.fivefy.domain.search.dto.response.SearchResponse;
+import com.fivefy.domain.search.dto.response.SearchTrackResponse;
 import com.fivefy.domain.search.enums.SearchErrorCode;
 import com.fivefy.domain.search.service.SearchHistoryService;
 import com.fivefy.domain.search.service.SearchService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@AutoConfigureMockMvc(addFilters = false)
 @WebMvcTest(controllers = {SearchController.class, SearchHistoryController.class})
-class SearchControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
+class SearchControllerTest extends RestDocsSupport {
 
     @MockitoBean
     private SearchService searchService;
@@ -46,88 +49,136 @@ class SearchControllerTest {
     private JwtUtil jwtUtil;
 
     @MockitoBean
-    private StringRedisTemplate stringRedisTemplate;;
+    private StringRedisTemplate stringRedisTemplate;
 
     @Nested
-    @DisplayName("검색")
+    @WithMockUser
+    @DisplayName("통합 검색 API")
     class Search {
 
         @Test
-        @DisplayName("정상 검색 시 200을 반환한다")
-        void search_validKeyword_returns200() throws Exception {
-            // given
-            SearchResponse response = new SearchResponse(List.of(), Page.empty(), Page.empty(), 0);
+        @DisplayName("정상 검색 시 200 반환")
+        void search_success() throws Exception {
+            SearchArtistResponse artist = new SearchArtistResponse(
+                    1L, "루나", "https://img.example.com/luna.jpg"
+            );
+            SearchTrackResponse track = new SearchTrackResponse(
+                    10L, "Moonlight", "POP", 210L
+            );
+            SearchAlbumResponse album = new SearchAlbumResponse(
+                    100L, "Phase", "https://img.example.com/phase.jpg"
+            );
+
+            PageImpl<SearchTrackResponse> tracks = new PageImpl<>(
+                    List.of(track), PageRequest.of(0, 20), 1
+            );
+            PageImpl<SearchAlbumResponse> albums = new PageImpl<>(
+                    List.of(album), PageRequest.of(0, 20), 1
+            );
+
+            SearchResponse response = new SearchResponse(
+                    List.of(artist), tracks, albums, 3
+            );
+
             given(searchService.search(anyString(), any(), any())).willReturn(response);
 
-            // when & then
             mockMvc.perform(get("/api/search")
-                            .param("keyword", "루나"))
+                            .param("keyword", "루나")
+                            .param("page", "0")
+                            .param("size", "20"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("검색 성공"));
-        }
-
-        @Test
-        @DisplayName("검색 결과에 artists, tracks, albums, resultCount가 포함된다")
-        void search_returnsResultData() throws Exception {
-            // given
-            SearchArtistResponse artist = new SearchArtistResponse(1L, "루나", "https://img.example.com/luna.jpg");
-            PageImpl<Object> emptyPage = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
-            SearchResponse response = new SearchResponse(List.of(artist), Page.empty(), Page.empty(), 1);
-            given(searchService.search(anyString(), any(), any())).willReturn(response);
-
-            // when & then
-            mockMvc.perform(get("/api/search")
-                            .param("keyword", "루나"))
-                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.message").value("검색 성공"))
                     .andExpect(jsonPath("$.data.artists[0].id").value(1L))
                     .andExpect(jsonPath("$.data.artists[0].name").value("루나"))
-                    .andExpect(jsonPath("$.data.resultCount").value(1));
+                    .andExpect(jsonPath("$.data.resultCount").value(3))
+                    .andDo(document("search",
+                            queryParameters(
+                                    parameterWithName("keyword")
+                                            .description("검색 키워드"),
+                                    parameterWithName("page")
+                                            .description("페이지 번호 (0부터 시작)").optional(),
+                                    parameterWithName("size")
+                                            .description("페이지 크기 (기본 20)").optional(),
+                                    parameterWithName("sort")
+                                            .description("정렬 조건 (기본 relevance,desc)").optional()
+                            ),
+                            relaxedResponseFields(
+                                    fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                                    fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                                    fieldWithPath("message").type(STRING).description("응답 메시지"),
+                                    fieldWithPath("data.artists").type(ARRAY).description("아티스트 결과 (최대 5건)"),
+                                    fieldWithPath("data.artists[].id").type(NUMBER).description("아티스트 ID"),
+                                    fieldWithPath("data.artists[].name").type(STRING).description("아티스트 이름"),
+                                    fieldWithPath("data.artists[].profileImageUrl").type(STRING).description("프로필 이미지 URL"),
+                                    fieldWithPath("data.tracks.content").type(ARRAY).description("트랙 결과 목록"),
+                                    fieldWithPath("data.tracks.content[].id").type(NUMBER).description("트랙 ID"),
+                                    fieldWithPath("data.tracks.content[].title").type(STRING).description("트랙 제목"),
+                                    fieldWithPath("data.tracks.content[].genre").type(STRING).description("장르"),
+                                    fieldWithPath("data.tracks.content[].durationSec").type(NUMBER).description("재생 시간(초)"),
+                                    fieldWithPath("data.albums.content").type(ARRAY).description("앨범 결과 목록"),
+                                    fieldWithPath("data.albums.content[].id").type(NUMBER).description("앨범 ID"),
+                                    fieldWithPath("data.albums.content[].title").type(STRING).description("앨범 제목"),
+                                    fieldWithPath("data.albums.content[].coverImageUrl").type(STRING).description("앨범 커버 이미지 URL"),
+                                    fieldWithPath("data.resultCount").type(NUMBER).description("전체 결과 개수")
+                            )
+                    ));
         }
 
         @Test
-        @DisplayName("공백 keyword로 요청 시 서비스에서 예외가 발생하여 400을 반환한다")
-        void search_blankKeyword_returns400() throws Exception {
-            // given
+        @DisplayName("공백 keyword 시 400 반환")
+        void search_blankKeyword() throws Exception {
             given(searchService.search(anyString(), any(), any()))
                     .willThrow(new BusinessException(SearchErrorCode.ERR_SEARCH_KEYWORD_BLANK));
 
-            // when & then
             mockMvc.perform(get("/api/search")
                             .param("keyword", "   "))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.message").value(SearchErrorCode.ERR_SEARCH_KEYWORD_BLANK.getMessage()));
+                    .andExpect(jsonPath("$.message").value(
+                            SearchErrorCode.ERR_SEARCH_KEYWORD_BLANK.getMessage()))
+                    .andDo(document("search-blank-keyword",
+                            queryParameters(
+                                    parameterWithName("keyword").description("검색 키워드 (공백)")
+                            ),
+                            responseFields(
+                                    baseErrorResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("최근 검색 기록 조회")
+    @WithMockUser
+    @DisplayName("최근 검색 기록 조회 API")
     class GetRecentSearchHistories {
 
         @Test
-        @DisplayName("최근 검색 기록 조회 시 200을 반환한다")
-        void getRecentSearchHistories_returns200() throws Exception {
-            // given
+        @DisplayName("최근 검색 기록 조회 성공 시 200 반환")
+        void getRecentSearchHistories_success() throws Exception {
             given(searchHistoryService.getRecentSearchHistories(any()))
                     .willReturn(List.of("아이유", "루나"));
 
-            // when & then
             mockMvc.perform(get("/api/search-histories"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("최근 검색 기록 조회 성공"))
                     .andExpect(jsonPath("$.data[0]").value("아이유"))
-                    .andExpect(jsonPath("$.data[1]").value("루나"));
+                    .andExpect(jsonPath("$.data[1]").value("루나"))
+                    .andDo(document("search-histories-get",
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            ).and(
+                                    fieldWithPath("data").type(ARRAY).description("최근 검색 키워드 목록")
+                            )
+                    ));
         }
 
         @Test
-        @DisplayName("최근 검색 기록이 없으면 빈 리스트를 반환한다")
-        void getRecentSearchHistories_empty_returnsEmptyList() throws Exception {
-            // given
+        @DisplayName("기록이 없으면 빈 배열 반환")
+        void getRecentSearchHistories_empty() throws Exception {
             given(searchHistoryService.getRecentSearchHistories(any()))
                     .willReturn(List.of());
 
-            // when & then
             mockMvc.perform(get("/api/search-histories"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -136,39 +187,71 @@ class SearchControllerTest {
     }
 
     @Nested
-    @DisplayName("검색 기록 삭제")
+    @WithMockUser
+    @DisplayName("최근 검색 기록 전체 삭제 API")
     class DeleteAllRecentSearchHistories {
 
         @Test
-        @DisplayName("전체 검색 기록 삭제 시 200을 반환한다")
-        void deleteAllRecentSearchHistories_returns200() throws Exception {
-            // given
+        @DisplayName("전체 검색 기록 삭제 성공 시 200 반환")
+        void deleteAll_success() throws Exception {
             doNothing().when(searchHistoryService).deleteAllRecentSearchHistories(any());
 
-            // when & then
-            mockMvc.perform(delete("/api/search-histories"))
+            mockMvc.perform(delete("/api/search-histories")
+                            .with(csrf().asHeader()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("최근 검색 기록 전체 삭제 성공"));
+                    .andExpect(jsonPath("$.message").value("최근 검색 기록 전체 삭제 성공"))
+                    .andDo(document("search-histories-delete-all",
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
     }
 
     @Nested
-    @DisplayName("DELETE /api/search-histories/recent")
+    @WithMockUser
+    @DisplayName("최근 검색 기록 개별 삭제 API")
     class DeleteRecentSearchHistory {
 
         @Test
-        @DisplayName("개별 검색 기록 삭제 시 200을 반환한다")
-        void deleteRecentSearchHistory_returns200() throws Exception {
-            // given
-            doNothing().when(searchHistoryService).deleteRecentSearchHistory(any(), anyString());
+        @DisplayName("개별 검색 기록 삭제 성공 시 200 반환")
+        void deleteOne_success() throws Exception {
+            doNothing().when(searchHistoryService)
+                    .deleteRecentSearchHistory(any(), anyString());
 
-            // when & then
             mockMvc.perform(delete("/api/search-histories/recent")
-                            .param("keyword", "아이유"))
+                            .with(csrf().asHeader())
+                            .queryParam("keyword", "아이유"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.message").value("최근 검색 기록 삭제 성공"));
+                    .andExpect(jsonPath("$.message").value("최근 검색 기록 삭제 성공"))
+                    .andDo(document("search-histories-delete-one",
+                            queryParameters(
+                                    parameterWithName("keyword").description("삭제할 검색 키워드")
+                            ),
+                            responseFields(
+                                    baseSuccessResponseFields()
+                            )
+                    ));
         }
+    }
+
+    // ===== RestDocs helper methods =====
+
+    private FieldDescriptor[] baseSuccessResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("응답 메시지")
+        };
+    }
+
+    private FieldDescriptor[] baseErrorResponseFields() {
+        return new FieldDescriptor[]{
+                fieldWithPath("success").type(BOOLEAN).description("성공 여부"),
+                fieldWithPath("status").type(STRING).description("HTTP 상태 코드"),
+                fieldWithPath("message").type(STRING).description("에러 메시지")
+        };
     }
 }

--- a/src/test/java/com/fivefy/domain/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/fivefy/domain/search/controller/SearchControllerTest.java
@@ -201,6 +201,7 @@ class SearchControllerTest extends RestDocsSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("최근 검색 기록 전체 삭제 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("search-histories-delete-all",
                             responseFields(
                                     baseSuccessResponseFields()
@@ -226,6 +227,7 @@ class SearchControllerTest extends RestDocsSupport {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.message").value("최근 검색 기록 삭제 성공"))
+                    .andExpect(jsonPath("$.data").doesNotExist())
                     .andDo(document("search-histories-delete-one",
                             queryParameters(
                                     parameterWithName("keyword").description("삭제할 검색 키워드")


### PR DESCRIPTION
## 개요

좋아요 / 팔로우 / 검색 / 알림 컨트롤러에 Spring REST Docs 를 적용했습니다. 

## 관련 이슈

closes #

## 변경 사항

like: LikeControllerTest RestDocs 적용 (등록/목록/취소, 총 7개 테스트)
follow: FollowControllerTest 신규 작성 (등록/목록/취소/알림토글, 총 8개 테스트)
search: SearchControllerTest 신규 작성 (검색/검색기록, 총 6개 테스트, SearchController + SearchHistoryController 통합 커버)
notification: NotificationControllerTest 신규 작성 (SSE구독/목록/미읽음수/읽음/삭제, 총 12개 테스트)

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)


## 스크린샷 (선택)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * Like API, Follow API, Search API, Notification API의 새로운 REST API 문서 추가
  * 각 엔드포인트별 요청/응답 예제 및 에러 케이스 포함

* **Tests**
  * API 테스트 자동 문서화 통합으로 API 명세서 자동 생성
  * 모든 엔드포인트의 요청/응답 스키마 검증 및 문서화 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/139)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->