### PR TITLE
feat: 트랙 단건 재생 URL API 추가

### DIFF
--- a/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/fivefy/common/config/security/SecurityConfig.java
@@ -47,15 +47,19 @@ public class SecurityConfig {
                                 "/api/users/login",
                                 "/api/users/reissue",
                                 "/api/popular-charts/**",
+                                "/api/tracks/{trackId}/play",
                                 "/test/**",
                                 "/api/portone/config",
                                 "/api/webhook/portone",
+                                "/tracks/audio/**",
                                 "/actuator/health" // 서버 연결 확인
                         ).permitAll()
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/api/albums/{albumId}",
                                 "/api/artists/{artistId}/albums",
+                                "/api/artists/{artistId}",
+                                "/api/search",
                                 "/api/tracks/{trackId}",
                                 "/api/tracks",
                                 "/api/tracks/{trackId}/comments"

--- a/src/main/java/com/fivefy/common/storage/AudioStorageProperties.java
+++ b/src/main/java/com/fivefy/common/storage/AudioStorageProperties.java
@@ -11,7 +11,8 @@ public record AudioStorageProperties(
         String bucket,
         String region,
         String prefix,
-        String localRoot
+        String localRoot,
+        String publicBaseUrl
 ) {
     public String normalizedPrefix() {
         if (prefix == null || prefix.isBlank()) {
@@ -29,6 +30,15 @@ public record AudioStorageProperties(
 
         String normalized = localRoot.replaceAll("/+$", "");
         return normalized.isBlank() ? "build/audio-storage" : normalized;
+    }
+
+    public String normalizedPublicBaseUrl() {
+        if (publicBaseUrl == null || publicBaseUrl.isBlank()) {
+            return "http://localhost:8080";
+        }
+
+        String normalized = publicBaseUrl.replaceAll("/+$", "");
+        return normalized.isBlank() ? "http://localhost:8080" : normalized;
     }
 
     @AssertTrue(message = "S3 오디오 저장소 bucket 설정은 필수입니다")

--- a/src/main/java/com/fivefy/common/storage/LocalAudioResourceConfig.java
+++ b/src/main/java/com/fivefy/common/storage/LocalAudioResourceConfig.java
@@ -1,0 +1,31 @@
+package com.fivefy.common.storage;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+
+@Configuration
+@ConditionalOnProperty(name = "storage.audio.type", havingValue = "local")
+public class LocalAudioResourceConfig implements WebMvcConfigurer {
+
+    private final AudioStorageProperties properties;
+
+    public LocalAudioResourceConfig(AudioStorageProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        Path storageRoot = Path.of(properties.normalizedLocalRoot())
+                .resolve(properties.normalizedPrefix())
+                .toAbsolutePath()
+                .normalize();
+        String location = storageRoot.toUri().toString();
+
+        registry.addResourceHandler("/" + properties.normalizedPrefix() + "/**")
+                .addResourceLocations(location);
+    }
+}

--- a/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
+++ b/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @ConditionalOnProperty(name = "storage.audio.type", havingValue = "s3")
@@ -13,6 +14,13 @@ public class S3AudioStorageConfig {
     @Bean
     public S3Client s3Client(AudioStorageProperties properties) {
         return S3Client.builder()
+                .region(Region.of(properties.region()))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(AudioStorageProperties properties) {
+        return S3Presigner.builder()
                 .region(Region.of(properties.region()))
                 .build();
     }

--- a/src/main/java/com/fivefy/domain/playback/controller/PlaybackController.java
+++ b/src/main/java/com/fivefy/domain/playback/controller/PlaybackController.java
@@ -6,6 +6,7 @@ import com.fivefy.domain.playback.dto.request.PlaybackPlayRequest;
 import com.fivefy.domain.playback.dto.request.PlaybackSkipRequest;
 import com.fivefy.domain.playback.dto.request.PlaybackStopRequest;
 import com.fivefy.domain.playback.dto.response.PlaybackResponse;
+import com.fivefy.domain.playback.dto.response.TrackPlayResponse;
 import com.fivefy.domain.playback.service.PlaybackService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,17 @@ import java.util.List;
 public class PlaybackController {
 
     private final PlaybackService playbackService;
+
+    @PostMapping("/tracks/{trackId}/play")
+    public ResponseEntity<BaseResponse<TrackPlayResponse>> playTrack(
+            @PathVariable Long trackId
+    ) {
+        TrackPlayResponse response = playbackService.playTrack(trackId);
+
+        return ResponseEntity.ok(
+                BaseResponse.success(HttpStatus.OK, "트랙 재생 URL 발급 성공", response)
+        );
+    }
 
     @PostMapping("/playbacks/play")
     public ResponseEntity<BaseResponse<PlaybackResponse>> play(

--- a/src/main/java/com/fivefy/domain/playback/dto/response/TrackPlayResponse.java
+++ b/src/main/java/com/fivefy/domain/playback/dto/response/TrackPlayResponse.java
@@ -1,0 +1,8 @@
+package com.fivefy.domain.playback.dto.response;
+
+public record TrackPlayResponse(
+        Long trackId,
+        String audioUrl,
+        Long playCount
+) {
+}

--- a/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
@@ -1,10 +1,16 @@
 package com.fivefy.domain.playback.service;
 
+import com.fivefy.common.storage.AudioStorageProperties;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriUtils;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 /**
  * 저장된 audioKey를 실제 재생 가능한 audioUrl로 변환하는 서비스
@@ -12,13 +18,19 @@ import java.nio.charset.StandardCharsets;
 @Service
 public class AudioUrlService {
 
-    // CloudFront 또는 S3 접근 도메인
+    private static final Duration S3_PLAY_URL_TTL = Duration.ofMinutes(10);
+
+    private final AudioStorageProperties audioStorageProperties;
+    private final ObjectProvider<S3Presigner> s3PresignerProvider;
     private final String cloudFrontDomain;
 
     public AudioUrlService(
-            @Value("${cloudfront.audio-domain}") String cloudFrontDomain
+            AudioStorageProperties audioStorageProperties,
+            ObjectProvider<S3Presigner> s3PresignerProvider,
+            @Value("${cloudfront.audio-domain:}") String cloudFrontDomain
     ) {
-        // URL 중복 방지를 위해 마지막 "/" 제거
+        this.audioStorageProperties = audioStorageProperties;
+        this.s3PresignerProvider = s3PresignerProvider;
         this.cloudFrontDomain = normalizeDomain(cloudFrontDomain);
     }
 
@@ -26,21 +38,55 @@ public class AudioUrlService {
      * audioKey를 기반으로 실제 접근 가능한 audioUrl 생성
      */
     public String createAudioUrl(String audioKey) {
-        // audioKey가 없으면 URL 생성 불가
         if (audioKey == null || audioKey.isBlank()) {
             return null;
         }
 
-        // 공백, 한글 등의 특수문자 인코딩 처리
-        String encodedKey =
-                UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
+        if ("s3".equalsIgnoreCase(audioStorageProperties.type())) {
+            return createS3PresignedUrl(audioKey);
+        }
 
-        // 도메인 + audioKey 조합
+        if ("local".equalsIgnoreCase(audioStorageProperties.type())) {
+            return createLocalAudioUrl(audioKey);
+        }
+
+        if (cloudFrontDomain.isBlank()) {
+            return null;
+        }
+
+        String encodedKey = UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
         return cloudFrontDomain + "/" + encodedKey;
     }
 
-    // URL 중복 방지를 위해 마지막 "/" 제거
+    private String createLocalAudioUrl(String audioKey) {
+        String encodedKey = UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
+        return audioStorageProperties.normalizedPublicBaseUrl() + "/" + encodedKey;
+    }
+
+    private String createS3PresignedUrl(String audioKey) {
+        S3Presigner s3Presigner = s3PresignerProvider.getIfAvailable();
+        if (s3Presigner == null) {
+            return null;
+        }
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(audioStorageProperties.bucket())
+                .key(audioKey)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(S3_PLAY_URL_TTL)
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
     private String normalizeDomain(String domain) {
+        if (domain == null || domain.isBlank()) {
+            return "";
+        }
+
         if (domain.endsWith("/")) {
             return domain.substring(0, domain.length() - 1);
         }

--- a/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/PlaybackService.java
@@ -6,6 +6,7 @@ import com.fivefy.domain.playback.dto.request.PlaybackPlayRequest;
 import com.fivefy.domain.playback.dto.request.PlaybackSkipRequest;
 import com.fivefy.domain.playback.dto.request.PlaybackStopRequest;
 import com.fivefy.domain.playback.dto.response.PlaybackResponse;
+import com.fivefy.domain.playback.dto.response.TrackPlayResponse;
 import com.fivefy.domain.playback.entity.Playback;
 import com.fivefy.domain.playback.enums.PlaybackErrorCode;
 import com.fivefy.domain.playback.enums.PlaybackStatus;
@@ -13,6 +14,7 @@ import com.fivefy.domain.playback.repository.PlaybackRepository;
 import com.fivefy.domain.playlisttrack.entity.PlaylistTrack;
 import com.fivefy.domain.playlisttrack.repository.PlaylistTrackRepository;
 import com.fivefy.domain.track.entity.Track;
+import com.fivefy.domain.track.enums.TrackErrorCode;
 import com.fivefy.domain.track.repository.TrackRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,6 +31,17 @@ public class PlaybackService {
     private final PlaylistTrackRepository playlistTrackRepository;
     private final AudioUrlService audioUrlService;
     private final TrackRepository trackRepository;
+
+    @Transactional
+    public TrackPlayResponse playTrack(Long trackId) {
+        Track track = trackRepository.findById(trackId)
+                .orElseThrow(() -> new BusinessException(TrackErrorCode.ERR_TRACK_NOT_FOUND));
+
+        track.increasePlayCount();
+        String audioUrl = audioUrlService.createAudioUrl(track.getAudioKey());
+
+        return new TrackPlayResponse(track.getId(), audioUrl, track.getPlayCount());
+    }
 
     @Transactional
     public PlaybackResponse play(Long userId, PlaybackPlayRequest request) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,12 +22,14 @@ spring:
 
 storage:
   audio:
-    # 로컬 기본 실행도 실제 S3 업로드 사용
-    # AWS 없이 로컬 디스크 저장으로 테스트하려면 개인 application-local.yml에서 type/local-root 재정의
-    type: s3
+    # local 기본 실행은 로컬 디스크 저장소 사용
+    # 실제 S3 업로드를 테스트하려면 개인 application-local.yml에서 type=s3 및 bucket을 재정의
+    type: local
     # storage.audio.type=s3인 경우 bucket 미설정 시 시작 단계에서 실패
     bucket: ${AUDIO_S3_BUCKET:}
     region: ${AWS_REGION:ap-northeast-2}
     prefix: tracks/audio
     # type=local 재정의 시 audioKey를 이 디렉터리 하위 경로로 저장
     local-root: build/audio-storage
+    # type=local일 때 응답 audioUrl의 base URL
+    public-base-url: ${AUDIO_PUBLIC_BASE_URL:http://localhost:8080}


### PR DESCRIPTION
## 개요

- 공개 트랙 단건 재생 API 추가
- S3/local 저장소 타입별 오디오 재생 URL 생성 방식 정리
- local 오디오 파일 정적 리소스 접근 경로 및 보안 허용 설정 추가

## 관련 이슈

closes #

## 변경 사항

- `POST /api/tracks/{trackId}/play` API 추가
- 재생 요청 시 `playCount` 증가 및 `audioUrl` 응답 처리
- 트랙 재생 응답 DTO `TrackPlayResponse` 추가
- S3 저장소 재생 URL을 presigned GET URL로 생성
- local 저장소 재생 URL을 `/tracks/audio/**` 정적 리소스 경로로 생성
- local 오디오 리소스 경로 인증 제외 처리
- local 기본 저장소 설정 및 `public-base-url` 설정 추가

## 변경 유형

- [x] 기능 추가 (feat)
- [x] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

```bash
./gradlew compileJava
```

- 공개 트랙 재생 API 호출 시 `audioUrl` 응답 확인
- 재생 API 호출 시 `playCount` 증가 확인
- S3 설정에서 presigned GET URL 생성 확인
- local 설정에서 `/tracks/audio/{uuid}.mp3` URL 생성 확인
- local 오디오 파일 요청 인증 제외 확인

## 스크린샷 (선택)

- 해당 없음

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 트랙 재생 엔드포인트 추가 - 음원 URL 발급 기능 구현
  * 다양한 스토리지 지원 - 로컬 디스크 및 S3 기반 음원 접근 지원

* **Chores**
  * 오디오 스토리지 설정 업데이트 및 보안 설정 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->