### PR TITLE
fix: 오디오 저장소 타입별 재생 URL 생성 정책 보강

### DIFF
--- a/src/main/java/com/fivefy/common/storage/AudioStorageProperties.java
+++ b/src/main/java/com/fivefy/common/storage/AudioStorageProperties.java
@@ -11,7 +11,8 @@ public record AudioStorageProperties(
         String bucket,
         String region,
         String prefix,
-        String localRoot
+        String localRoot,
+        String publicBaseUrl
 ) {
     public String normalizedPrefix() {
         if (prefix == null || prefix.isBlank()) {
@@ -29,6 +30,15 @@ public record AudioStorageProperties(
 
         String normalized = localRoot.replaceAll("/+$", "");
         return normalized.isBlank() ? "build/audio-storage" : normalized;
+    }
+
+    public String normalizedPublicBaseUrl() {
+        if (publicBaseUrl == null || publicBaseUrl.isBlank()) {
+            return "http://localhost:8080";
+        }
+
+        String normalized = publicBaseUrl.replaceAll("/+$", "");
+        return normalized.isBlank() ? "http://localhost:8080" : normalized;
     }
 
     @AssertTrue(message = "S3 오디오 저장소 bucket 설정은 필수입니다")

--- a/src/main/java/com/fivefy/common/storage/LocalAudioResourceConfig.java
+++ b/src/main/java/com/fivefy/common/storage/LocalAudioResourceConfig.java
@@ -1,0 +1,31 @@
+package com.fivefy.common.storage;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+
+@Configuration
+@ConditionalOnProperty(name = "storage.audio.type", havingValue = "local")
+public class LocalAudioResourceConfig implements WebMvcConfigurer {
+
+    private final AudioStorageProperties properties;
+
+    public LocalAudioResourceConfig(AudioStorageProperties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        Path storageRoot = Path.of(properties.normalizedLocalRoot())
+                .resolve(properties.normalizedPrefix())
+                .toAbsolutePath()
+                .normalize();
+        String location = storageRoot.toUri().toString();
+
+        registry.addResourceHandler("/" + properties.normalizedPrefix() + "/**")
+                .addResourceLocations(location);
+    }
+}

--- a/src/main/java/com/fivefy/common/storage/LocalAudioResourceConfig.java
+++ b/src/main/java/com/fivefy/common/storage/LocalAudioResourceConfig.java
@@ -1,13 +1,18 @@
 package com.fivefy.common.storage;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.nio.file.Path;
 
+/**
+ * 로컬 오디오 파일 정적 리소스 설정
+ */
 @Configuration
+@EnableConfigurationProperties(AudioStorageProperties.class)
 @ConditionalOnProperty(name = "storage.audio.type", havingValue = "local")
 public class LocalAudioResourceConfig implements WebMvcConfigurer {
 
@@ -23,7 +28,7 @@ public class LocalAudioResourceConfig implements WebMvcConfigurer {
                 .resolve(properties.normalizedPrefix())
                 .toAbsolutePath()
                 .normalize();
-        String location = storageRoot.toUri().toString();
+        String location = storageRoot.toUri().toString() + "/";
 
         registry.addResourceHandler("/" + properties.normalizedPrefix() + "/**")
                 .addResourceLocations(location);

--- a/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
+++ b/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
@@ -1,13 +1,18 @@
 package com.fivefy.common.storage;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
+/**
+ * S3 오디오 저장소 설정
+ */
 @Configuration
+@EnableConfigurationProperties(AudioStorageProperties.class)
 @ConditionalOnProperty(name = "storage.audio.type", havingValue = "s3")
 public class S3AudioStorageConfig {
 

--- a/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
+++ b/src/main/java/com/fivefy/common/storage/S3AudioStorageConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @ConditionalOnProperty(name = "storage.audio.type", havingValue = "s3")
@@ -13,6 +14,13 @@ public class S3AudioStorageConfig {
     @Bean
     public S3Client s3Client(AudioStorageProperties properties) {
         return S3Client.builder()
+                .region(Region.of(properties.region()))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(AudioStorageProperties properties) {
+        return S3Presigner.builder()
                 .region(Region.of(properties.region()))
                 .build();
     }

--- a/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
+++ b/src/main/java/com/fivefy/domain/playback/service/AudioUrlService.java
@@ -1,10 +1,16 @@
 package com.fivefy.domain.playback.service;
 
+import com.fivefy.common.storage.AudioStorageProperties;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriUtils;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 
 /**
  * 저장된 audioKey를 실제 재생 가능한 audioUrl로 변환하는 서비스
@@ -12,13 +18,19 @@ import java.nio.charset.StandardCharsets;
 @Service
 public class AudioUrlService {
 
-    // CloudFront 또는 S3 접근 도메인
+    private static final Duration S3_PLAY_URL_TTL = Duration.ofMinutes(10);
+
+    private final AudioStorageProperties audioStorageProperties;
+    private final ObjectProvider<S3Presigner> s3PresignerProvider;
     private final String cloudFrontDomain;
 
     public AudioUrlService(
-            @Value("${cloudfront.audio-domain}") String cloudFrontDomain
+            AudioStorageProperties audioStorageProperties,
+            ObjectProvider<S3Presigner> s3PresignerProvider,
+            @Value("${cloudfront.audio-domain:}") String cloudFrontDomain
     ) {
-        // URL 중복 방지를 위해 마지막 "/" 제거
+        this.audioStorageProperties = audioStorageProperties;
+        this.s3PresignerProvider = s3PresignerProvider;
         this.cloudFrontDomain = normalizeDomain(cloudFrontDomain);
     }
 
@@ -26,21 +38,55 @@ public class AudioUrlService {
      * audioKey를 기반으로 실제 접근 가능한 audioUrl 생성
      */
     public String createAudioUrl(String audioKey) {
-        // audioKey가 없으면 URL 생성 불가
         if (audioKey == null || audioKey.isBlank()) {
             return null;
         }
 
-        // 공백, 한글 등의 특수문자 인코딩 처리
-        String encodedKey =
-                UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
+        if ("s3".equalsIgnoreCase(audioStorageProperties.type())) {
+            return createS3PresignedUrl(audioKey);
+        }
 
-        // 도메인 + audioKey 조합
+        if ("local".equalsIgnoreCase(audioStorageProperties.type())) {
+            return createLocalAudioUrl(audioKey);
+        }
+
+        if (cloudFrontDomain.isBlank()) {
+            return null;
+        }
+
+        String encodedKey = UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
         return cloudFrontDomain + "/" + encodedKey;
     }
 
-    // URL 중복 방지를 위해 마지막 "/" 제거
+    private String createLocalAudioUrl(String audioKey) {
+        String encodedKey = UriUtils.encodePath(audioKey, StandardCharsets.UTF_8);
+        return audioStorageProperties.normalizedPublicBaseUrl() + "/" + encodedKey;
+    }
+
+    private String createS3PresignedUrl(String audioKey) {
+        S3Presigner s3Presigner = s3PresignerProvider.getIfAvailable();
+        if (s3Presigner == null) {
+            return null;
+        }
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(audioStorageProperties.bucket())
+                .key(audioKey)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(S3_PLAY_URL_TTL)
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return s3Presigner.presignGetObject(presignRequest).url().toString();
+    }
+
     private String normalizeDomain(String domain) {
+        if (domain == null || domain.isBlank()) {
+            return "";
+        }
+
         if (domain.endsWith("/")) {
             return domain.substring(0, domain.length() - 1);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,8 @@ spring:
 
 storage:
   audio:
-    # 로컬 기본 실행도 실제 S3 업로드 사용
-    # AWS 없이 로컬 디스크 저장으로 테스트하려면 개인 application-local.yml에서 type/local-root 재정의
+    # local 기본 실행은 로컬 디스크 저장소 사용
+    # 실제 S3 업로드를 테스트하려면 개인 application-local.yml에서 type=s3 및 bucket을 재정의
     type: s3
     # storage.audio.type=s3인 경우 bucket 미설정 시 시작 단계에서 실패
     bucket: ${AUDIO_S3_BUCKET:}
@@ -31,3 +31,5 @@ storage:
     prefix: tracks/audio
     # type=local 재정의 시 audioKey를 이 디렉터리 하위 경로로 저장
     local-root: build/audio-storage
+    # type=local일 때 응답 audioUrl의 base URL
+    public-base-url: ${AUDIO_PUBLIC_BASE_URL:http://localhost:8080}

--- a/src/test/java/com/fivefy/common/storage/AudioStoragePropertiesTest.java
+++ b/src/test/java/com/fivefy/common/storage/AudioStoragePropertiesTest.java
@@ -16,6 +16,7 @@ class AudioStoragePropertiesTest {
                 "bucket",
                 "ap-northeast-2",
                 "/",
+                null,
                 null
         );
 
@@ -30,7 +31,8 @@ class AudioStoragePropertiesTest {
                 null,
                 null,
                 "tracks/audio",
-                "/"
+                "/",
+                "http://localhost:8080"
         );
 
         assertThat(properties.normalizedLocalRoot()).isEqualTo("build/audio-storage");

--- a/src/test/java/com/fivefy/common/storage/LocalAudioStorageServiceTest.java
+++ b/src/test/java/com/fivefy/common/storage/LocalAudioStorageServiceTest.java
@@ -122,7 +122,8 @@ class LocalAudioStorageServiceTest {
                 null,
                 null,
                 prefix,
-                tempDir.toString()
+                tempDir.toString(),
+                "http://localhost:8080"
         );
     }
 

--- a/src/test/java/com/fivefy/common/storage/S3AudioStorageServiceTest.java
+++ b/src/test/java/com/fivefy/common/storage/S3AudioStorageServiceTest.java
@@ -97,6 +97,7 @@ class S3AudioStorageServiceTest {
                 "fivefy-audio",
                 "ap-northeast-2",
                 "tracks/audio",
+                null,
                 null
         );
     }

--- a/src/test/java/com/fivefy/domain/playback/service/AudioUrlServiceTest.java
+++ b/src/test/java/com/fivefy/domain/playback/service/AudioUrlServiceTest.java
@@ -1,34 +1,91 @@
 package com.fivefy.domain.playback.service;
 
+import com.fivefy.common.storage.AudioStorageProperties;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AudioUrlServiceTest {
 
     private static final String CLOUD_FRONT_DOMAIN = "https://cdn.fivefy.com";
 
-    private final AudioUrlService audioUrlService =
-            new AudioUrlService(CLOUD_FRONT_DOMAIN);
-
     @Test
-    @DisplayName("audioKey가 정상 값이면 CloudFront 기반 audioUrl을 생성한다")
-    void createAudioUrlSuccess() {
+    @DisplayName("s3 저장소이면 presigned GET URL을 생성한다")
+    void createAudioUrlSuccess_s3() {
         // given
-        String audioKey = "tracks/test.mp3";
+        S3Presigner s3Presigner = S3Presigner.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create("test-access-key", "test-secret-key")
+                        )
+                )
+                .build();
+
+        AudioUrlService audioUrlService = createService(
+                new AudioStorageProperties(
+                        "s3",
+                        "fivefy-audio",
+                        "ap-northeast-2",
+                        "tracks/audio",
+                        null,
+                        null
+                ),
+                s3Presigner,
+                CLOUD_FRONT_DOMAIN
+        );
+
+        String audioKey = "tracks/audio/test.mp3";
 
         // when
         String result = audioUrlService.createAudioUrl(audioKey);
 
         // then
-        assertThat(result)
-                .isEqualTo("https://cdn.fivefy.com/tracks/test.mp3");
+        assertThat(result).startsWith("https://fivefy-audio.s3.ap-northeast-2.amazonaws.com/tracks/audio/test.mp3?");
+        assertThat(result).contains("X-Amz-Algorithm=AWS4-HMAC-SHA256");
+        assertThat(result).contains("X-Amz-SignedHeaders=host");
+    }
+
+    @Test
+    @DisplayName("local 저장소이면 publicBaseUrl 기반 audioUrl을 생성한다")
+    void createAudioUrlSuccess_local() {
+        // given
+        AudioUrlService audioUrlService = createService(
+                new AudioStorageProperties(
+                        "local",
+                        null,
+                        null,
+                        "tracks/audio",
+                        "build/audio-storage",
+                        "http://localhost:8080"
+                ),
+                null,
+                CLOUD_FRONT_DOMAIN
+        );
+
+        String audioKey = "tracks/audio/test.mp3";
+
+        // when
+        String result = audioUrlService.createAudioUrl(audioKey);
+
+        // then
+        assertThat(result).isEqualTo("http://localhost:8080/tracks/audio/test.mp3");
     }
 
     @Test
     @DisplayName("audioKey가 null이면 null을 반환한다")
     void createAudioUrlNull() {
+        // given
+        AudioUrlService audioUrlService = createLocalService();
+
         // when
         String result = audioUrlService.createAudioUrl(null);
 
@@ -39,6 +96,9 @@ class AudioUrlServiceTest {
     @Test
     @DisplayName("audioKey가 공백이면 null을 반환한다")
     void createAudioUrlBlank() {
+        // given
+        AudioUrlService audioUrlService = createLocalService();
+
         // when
         String result = audioUrlService.createAudioUrl("   ");
 
@@ -49,6 +109,9 @@ class AudioUrlServiceTest {
     @Test
     @DisplayName("audioKey가 빈 문자열이면 null을 반환한다")
     void createAudioUrlEmpty() {
+        // given
+        AudioUrlService audioUrlService = createLocalService();
+
         // when
         String result = audioUrlService.createAudioUrl("");
 
@@ -60,47 +123,126 @@ class AudioUrlServiceTest {
     @DisplayName("audioKey 앞뒤에 공백이 있으면 인코딩된 URL을 생성한다")
     void createAudioUrlWithSpaceInKey() {
         // given
-        String audioKey = " tracks/test.mp3 ";
+        AudioUrlService audioUrlService = createLocalService();
+
+        String audioKey = " tracks/audio/test.mp3 ";
 
         // when
         String result = audioUrlService.createAudioUrl(audioKey);
 
         // then
         assertThat(result)
-                .isEqualTo("https://cdn.fivefy.com/%20tracks/test.mp3%20");
+                .isEqualTo("http://localhost:8080/%20tracks/audio/test.mp3%20");
     }
 
     @Test
-    @DisplayName("CloudFront 도메인 끝에 슬래시가 없어도 정상적으로 audioUrl을 생성한다")
-    void createAudioUrlWithoutTrailingSlash() {
+    @DisplayName("local 저장소 publicBaseUrl 끝에 슬래시가 있으면 제거 후 audioUrl을 생성한다")
+    void createAudioUrlWithTrailingSlashPublicBaseUrl() {
         // given
-        AudioUrlService service =
-                new AudioUrlService("https://cdn.fivefy.com");
+        AudioUrlService audioUrlService = createService(
+                new AudioStorageProperties(
+                        "local",
+                        null,
+                        null,
+                        "tracks/audio",
+                        "build/audio-storage",
+                        "http://localhost:8080/"
+                ),
+                null,
+                CLOUD_FRONT_DOMAIN
+        );
 
-        String audioKey = "tracks/test.mp3";
+        String audioKey = "tracks/audio/test.mp3";
 
         // when
-        String result = service.createAudioUrl(audioKey);
+        String result = audioUrlService.createAudioUrl(audioKey);
 
         // then
         assertThat(result)
-                .isEqualTo("https://cdn.fivefy.com/tracks/test.mp3");
+                .isEqualTo("http://localhost:8080/tracks/audio/test.mp3");
+    }
+
+    @Test
+    @DisplayName("알 수 없는 저장소 타입이면 CloudFront 기반 audioUrl을 생성한다")
+    void createAudioUrlFallbackCloudFront() {
+        // given
+        AudioUrlService audioUrlService = createService(
+                new AudioStorageProperties(
+                        "cloudfront",
+                        null,
+                        null,
+                        "tracks/audio",
+                        "build/audio-storage",
+                        null
+                ),
+                null,
+                CLOUD_FRONT_DOMAIN
+        );
+
+        String audioKey = "tracks/audio/test.mp3";
+
+        // when
+        String result = audioUrlService.createAudioUrl(audioKey);
+
+        // then
+        assertThat(result)
+                .isEqualTo("https://cdn.fivefy.com/tracks/audio/test.mp3");
     }
 
     @Test
     @DisplayName("CloudFront 도메인 끝에 슬래시가 있으면 제거 후 audioUrl을 생성한다")
     void createAudioUrlWithTrailingSlashDomain() {
         // given
-        AudioUrlService service =
-                new AudioUrlService("https://cdn.fivefy.com/");
+        AudioUrlService audioUrlService = createService(
+                new AudioStorageProperties(
+                        "cloudfront",
+                        null,
+                        null,
+                        "tracks/audio",
+                        "build/audio-storage",
+                        null
+                ),
+                null,
+                "https://cdn.fivefy.com/"
+        );
 
-        String audioKey = "tracks/test.mp3";
+        String audioKey = "tracks/audio/test.mp3";
 
         // when
-        String result = service.createAudioUrl(audioKey);
+        String result = audioUrlService.createAudioUrl(audioKey);
 
         // then
         assertThat(result)
-                .isEqualTo("https://cdn.fivefy.com/tracks/test.mp3");
+                .isEqualTo("https://cdn.fivefy.com/tracks/audio/test.mp3");
+    }
+
+    private AudioUrlService createLocalService() {
+        return createService(
+                new AudioStorageProperties(
+                        "local",
+                        null,
+                        null,
+                        "tracks/audio",
+                        "build/audio-storage",
+                        "http://localhost:8080"
+                ),
+                null,
+                CLOUD_FRONT_DOMAIN
+        );
+    }
+
+    private AudioUrlService createService(
+            AudioStorageProperties properties,
+            S3Presigner s3Presigner,
+            String cloudFrontDomain
+    ) {
+        ObjectProvider<S3Presigner> s3PresignerProvider = mock(ObjectProvider.class);
+        when(s3PresignerProvider.getIfAvailable()).thenReturn(s3Presigner);
+
+        return new AudioUrlService(
+                properties,
+                s3PresignerProvider,
+                cloudFrontDomain
+        );
     }
 }


### PR DESCRIPTION
## 개요
- 오디오 저장소 타입별 재생 URL 생성 정책 분리
- local 오디오 정적 리소스 접근 설정 추가
- 오디오 URL 생성 테스트 구조 재구성

## 변경 사항

### 오디오 URL 생성 정책 분리
- `AudioUrlService`를 저장소 타입 기반 구조로 재구성
- `s3` 저장소이면 `S3Presigner` 기반 presigned GET URL 생성
- `local` 저장소이면 `publicBaseUrl + audioKey` 기반 URL 생성
- 알 수 없는 저장소 타입이면 CloudFront URL fallback 처리
- audioKey null/blank 처리 유지

### S3 Presigned URL 지원 추가
- `S3AudioStorageConfig`에 `S3Presigner` Bean 추가
- presigned GET URL 만료 시간 10분 적용
- playback 재생 시 직접 S3 접근 가능한 URL 생성 구조 추가

### Local 오디오 정적 리소스 설정 추가
- `LocalAudioResourceConfig` 추가
- `storage.audio.type=local` 환경에서만 ResourceHandler 활성화
- `/tracks/audio/**` 경로를 local 저장소 디렉터리와 매핑
- local 저장소 기반 재생 가능 구조 추가

### 오디오 저장소 설정 보강
- `AudioStorageProperties`에 `publicBaseUrl` 추가
- `normalizedPublicBaseUrl()` 추가
- trailing slash 제거 및 기본값 정규화 처리 추가
- `application.yml`에 `storage.audio.public-base-url` 설정 추가
- 기본 저장소 타입을 `s3` 기준으로 유지

### 테스트 구조 재구성
- `AudioUrlServiceTest`를 저장소 타입별 구조로 재작성
  - S3 presigned URL 생성 검증
  - local publicBaseUrl 생성 검증
  - CloudFront fallback 검증
  - trailing slash 정규화 검증
- `AudioStorageProperties` 생성자 변경에 맞춰 테스트 fixture 수정
- local/S3 storage 테스트 객체 생성 보강

## 변경 유형
- [x] 오류 수정
- [x] 설정 변경
- [x] 테스트 코드 수정

## 테스트 방법
```bash
./gradlew test --tests "com.fivefy.domain.playback.service.AudioUrlServiceTest"
./gradlew test --tests "com.fivefy.common.storage.AudioStoragePropertiesTest"
./gradlew test --tests "com.fivefy.common.storage.LocalAudioStorageServiceTest"
./gradlew test --tests "com.fivefy.common.storage.S3AudioStorageServiceTest"
```

주요 확인 시나리오
- s3 저장소 환경에서 presigned GET URL 생성 여부 확인
- local 저장소 환경에서 publicBaseUrl 기반 URL 생성 여부 확인
- `/tracks/audio/**` local 정적 리소스 접근 여부 확인
- CloudFront fallback URL 생성 여부 확인
- trailing slash 제거 정규화 동작 확인

## 체크리스트
- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 로컬 파일 시스템을 이용한 오디오 저장소 지원 추가
  * 저장소 유형(로컬, S3, CloudFront)에 따른 동적 오디오 URL 생성

* **설정**
  * 로컬 오디오 서빙을 위한 공개 기본 URL 설정 옵션 추가 (기본값: `http://localhost:8080`)

* **테스트**
  * 새로운 저장소 유형과 URL 생성 로직 검증을 위한 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/142)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->