### PR TITLE
feat: followService 등록시 artist deletedAt 검증 코드 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,6 @@ com.fivefy
 - Hibernate 7 QueryDSL 의 `MATCH AGAINST` 미지원 우회 — EntityManager 네이티브 쿼리
 - Elasticsearch 는 MVP 이후로 보류
 
-### 👍 좋아요 · 팔로우
-
-- **다형성 좋아요** : Track / Album 공통 처리 (`targetId + targetType`)
-- **고아 객체 정리** : `TrackDeletedEvent` / `AlbumDeletedEvent` 이벤트 기반 + `@TransactionalEventListener` 롤백 보장
-
 ### 🤖 AI 추천
 
 - **재생 이력 기반 트랙 추천** (Spring AI)
@@ -408,7 +403,6 @@ feat: 트랙 재생 권한 체크 Redis 캐싱 적용
 | Application 동시 승인 시 엔티티 중복 생성 위험 | **`PESSIMISTIC_WRITE`** 승인/거절 경로에만 `findByIdForUpdate` |
 | Application 생성 시 TOCTOU (CodeRabbit 지적) | **Generated Column + UNIQUE** + `saveAndFlush` 로 즉시 unique 충돌 감지 |
 | 승인 결과 엔티티 중복 생성 가능성 | **`application_id` UNIQUE** 최종 방어선 |
-| Like 다형성 구조로 FK CASCADE 적용 불가 | **이벤트 기반 처리** (`TrackDeletedEvent` / `AlbumDeletedEvent`) + `@TransactionalEventListener` 롤백 보장 |
 
 **검증** : 동시 10건 요청 → 1건 201 / 9건 409 / DB row 1건 / 500 응답 0건
 

--- a/src/main/java/com/fivefy/domain/follow/service/FollowService.java
+++ b/src/main/java/com/fivefy/domain/follow/service/FollowService.java
@@ -35,7 +35,7 @@ public class FollowService {
     @Transactional
     public FollowCreateResponse createFollow(Long userId, Long artistId) {
         User user = getUser(userId);
-        Artist artist = getArtist(artistId);
+        Artist artist = findNotDeletedArtist(artistId);
         // 중복 검증
         if (followRepository.existsByUserIdAndArtistId(userId, artistId)) {
             throw new BusinessException(FollowErrorCode.ERR_FOLLOW_ALREADY_EXISTS);
@@ -90,9 +90,15 @@ public class FollowService {
                 .orElseThrow(() -> new BusinessException(UserErrorCode.ERR_USER_NOT_FOUND));
     }
 
-    private Artist getArtist(Long artistId) {
-        return artistRepository.findById(artistId)
+    private Artist findNotDeletedArtist(Long artistId) {
+        Artist artist = artistRepository.findById(artistId)
                 .orElseThrow(() -> new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND));
+
+        if (artist.isDeleted()) {
+            throw new BusinessException(ArtistErrorCode.ERR_ARTIST_NOT_FOUND);
+        }
+
+        return artist;
     }
 
     // 권한 체크

--- a/src/main/java/com/fivefy/domain/like/service/LikeService.java
+++ b/src/main/java/com/fivefy/domain/like/service/LikeService.java
@@ -28,8 +28,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// TODO: Track/Album 삭제 시 연관 Like 삭제 처리 필요 / 방안: 이벤트 방식
-
 @Service
 @RequiredArgsConstructor
 public class LikeService {


### PR DESCRIPTION
## 개요
softdelete 상태인 아티스트에게 팔로우가 가능한 문제 발견 팔로우시 검증 코드 추가
트랙/앨범에 삭제되는 코드 미존재로 README 좋아요 고아객체 내용 제거

## 변경 사항

- findNotDeletedArtist() - artistId를 찾고 softdelete 상태 확인하는 메서드 추가
- README 트랙/앨범 삭제 코드 부재로 고아객체 관련 내용 제거

## 변경 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [ ] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 아티스트 팔로우 시 삭제된 아티스트가 거부되도록 개선했습니다.

* **Documentation**
  * README의 주요 기능 섹션 배치를 정렬했습니다.
  * 트러블슈팅 및 기술 의사결정 섹션을 최적화했습니다.

* **Chores**
  * 코드 주석을 정리했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/145)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->