### PR TITLE
test: PlaylistTrack reorder K6 성능 테스트 추가

### DIFF
--- a/k6/reorder-test.js
+++ b/k6/reorder-test.js
@@ -1,0 +1,41 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE_URL = 'http://localhost:8080';
+
+// cmd에서 ACCESS_TOKEN으로 넘겨받기
+const ACCESS_TOKEN = __ENV.ACCESS_TOKEN;
+
+export const options = {
+    vus: 100,
+    iterations: 10000,
+};
+
+export default function () {
+    const payload = JSON.stringify({
+        trackId: 50,
+        position: 1
+    });
+
+    const params = {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${ACCESS_TOKEN}`,
+        },
+    };
+
+    const response = http.patch(
+        `${BASE_URL}/api/playlists/1/tracks/index`,
+        payload,
+        params
+    );
+
+    console.log(response.status);
+    console.log(response.body);
+
+    check(response, {
+        'status is 200': (r) => r.status === 200,
+    });
+
+    sleep(1);
+}

--- a/k6/reorder-test.js
+++ b/k6/reorder-test.js
@@ -34,8 +34,10 @@ export default function () {
         params
     );
 
-    console.log(response.status);
-    console.log(response.body);
+    if (response.status !== 200) {
+        console.log(`status: ${response.status}`);
+        console.log(response.body);
+    }
 
     check(response, {
         'status is 200': (r) => r.status === 200,

--- a/k6/reorder-test.js
+++ b/k6/reorder-test.js
@@ -6,6 +6,10 @@ const BASE_URL = 'http://localhost:8080';
 // cmd에서 ACCESS_TOKEN으로 넘겨받기
 const ACCESS_TOKEN = __ENV.ACCESS_TOKEN;
 
+if (!ACCESS_TOKEN) {
+    throw new Error('ACCESS_TOKEN is required');
+}
+
 export const options = {
     vus: 100,
     iterations: 10000,


### PR DESCRIPTION
## 개요

> K6를 활용하여 PlaylistTrack reorder API에 대한 부하 테스트를 추가했습니다.  

기존에는 JUnit 기반 테스트를 통해 reorder 정합성과 동시 요청 상황을 검증했지만,
실제 HTTP 요청 환경에서의 응답 시간 및 안정성을 직접 확인해보고자 K6 기반 성능 테스트를 진행했습니다.

특히 부분 재정렬 구조 적용 이후 아래 항목들을 중점적으로 검증했습니다.

- 요청 수 증가에 따른 p95 응답 시간 변화
- HTTP 실패율 발생 여부
- DB 충돌 및 deadlock 발생 여부
- reorder 정합성 유지 여부

100건 / 1,000건 / 10,000건 환경으로 나누어 부하 테스트를 진행했습니다.

## 변경 사항

- K6 reorder 성능 테스트 스크립트 추가
- JWT 인증 기반 테스트 환경 구성
- 100 / 1,000 / 10,000건 부하 테스트 진행
- p95 응답 시간 및 실패율 측정
- reorder 정합성 및 DB 충돌 여부 검증

## 변경 유형

- [ ] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [x] 테스트 (test)
- [ ] 문서 (docs)
- [ ] 기타 (chore)

## 테스트 방법

```bash
ACCESS_TOKEN=발급받은JWT토큰 \
k6 run k6/reorder-test.js
```
## 테스트 환경  
### 1차 테스트
```
vus: 10,
iterations: 100
```
### 2차 테스트
```
vus: 50,
iterations: 1000
```
### 3차 테스트
```
vus: 100,
iterations: 10000
```

## 스크린샷
- 100건 부하 테스트 결과 첨부
<img width="1587" height="847" alt="image" src="https://github.com/user-attachments/assets/13384bb7-88be-471e-ba09-e7e270e99ba6" />

- 1,000건 부하 테스트 결과 첨부
<img width="1603" height="847" alt="image" src="https://github.com/user-attachments/assets/3cbcf74c-5c15-4a29-8fbd-82f25179da74" />

- 10,000건 부하 테스트 결과 첨부
<img width="1564" height="850" alt="image" src="https://github.com/user-attachments/assets/b7c62c87-b182-482d-9623-5cbcef18c5c2" />

## 체크리스트

- [x] 코드 자체 리뷰 완료
- [x] 테스트 코드 작성 / 확인
- [ ] 관련 문서 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * 플레이리스트 트랙 순서 변경 기능에 대한 로드 테스트 스크립트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fivefy/fivefy/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->